### PR TITLE
Add noVNC window size configs

### DIFF
--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -33,9 +33,11 @@ DISPLAY=:1 chromium \
   --no-sandbox \
   --disable-dev-shm-usage \
   --disable-gpu \
+  --start-maximized \
   --disable-software-rasterizer \
   --remote-allow-origins=* \
   --no-zygote >&2 &
+  
 echo "Setting up ncat proxy on port $CHROME_PORT"
 ncat \
   --sh-exec "ncat localhost $INTERNAL_PORT" \

--- a/containers/docker/README.md
+++ b/containers/docker/README.md
@@ -23,6 +23,13 @@ This exposes three ports:
 - `9222`: Chrome DevTools Protocol for browser automation via Playwright and Puppeteer
 - `8501`: Streamlit interfaced used by Computer Use
 
+## Live View Configuration
+You can set the browser width and height with the environment variables `WIDTH` and `HEIGHT` in the `docker run` command:
+
+```bash
+docker run -e WIDTH=1920 -e HEIGHT=1080 -p 8501:8501 -p 8080:8080 -p 6080:6080 -p 9222:9222 kernel-chromium
+```
+
 ## 👾 Connect via Chrome DevTools Protocol
 
 We expose port `9222` via ncat, allowing you to connect Chrome DevTools Protocol-based browser frameworks like Playwright and Puppeteer (and CDP-based SDKs like Browser Use). You can use these frameworks to drive the browser in the cloud.

--- a/unikernels/unikraft-cu/wrapper.sh
+++ b/unikernels/unikraft-cu/wrapper.sh
@@ -27,6 +27,7 @@ DISPLAY=:1 chromium \
   --no-sandbox \
   --disable-dev-shm-usage \
   --disable-gpu \
+  --start-maximized \
   --disable-software-rasterizer \
   --remote-allow-origins=* \
   --no-zygote >&2 &


### PR DESCRIPTION

# Checklist

- [x] [Related issue](https://github.com/onkernel/kernel-images/issues/6)
- [x] Adds support for setting the noVNC window size and maximizes the browser to it.

<img width="844" alt="Screenshot 2025-04-24 at 7 46 41 PM" src="https://github.com/user-attachments/assets/d7f2baf4-9e6a-4240-9327-73a99bdaa19d" />
<img width="1920" alt="Screenshot 2025-04-24 at 7 46 30 PM" src="https://github.com/user-attachments/assets/0d9885cc-c2be-44bb-b60e-a49621be66e4" />
