### PR TITLE
Fix docker build failure when buildkit container is absent

### DIFF
--- a/images/chromium-headful/build-docker.sh
+++ b/images/chromium-headful/build-docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex -o pipefail
+set -e -o pipefail
 
 # Move to the script's directory so relative paths work regardless of the caller CWD
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)

--- a/shared/start-buildkit.sh
+++ b/shared/start-buildkit.sh
@@ -6,7 +6,7 @@
 export KRAFTKIT_BUILDKIT_HOST=docker-container://buildkit
 
 # Install container if not already installed.
-if test "$(docker ps --all --no-trunc --quiet --filter 'name=^buildkit$')"; then
+if [ -n "$(docker ps --all --no-trunc --quiet --filter 'name=^buildkit$')" ]; then
     echo "Container 'buildkit' is already installed. Nothing to do."
 else
     echo "Installing 'buildkit' container ... "

--- a/shared/start-buildkit.sh
+++ b/shared/start-buildkit.sh
@@ -6,8 +6,7 @@
 export KRAFTKIT_BUILDKIT_HOST=docker-container://buildkit
 
 # Install container if not already installed.
-docker container inspect buildkit > /dev/null 2>&1
-if test $? -eq 0; then
+if test "$(docker ps --all --no-trunc --quiet --filter 'name=^buildkit$')"; then
     echo "Container 'buildkit' is already installed. Nothing to do."
 else
     echo "Installing 'buildkit' container ... "
@@ -17,7 +16,7 @@ fi
 
 test "$(docker container inspect -f '{{.State.Running}}' buildkit 2> /dev/null)" = "true"
 if test $? -eq 0; then
-    echo "Container 'buidlkitd' is already running. Nothing to do."
+    echo "Container 'buildkit' is already running. Nothing to do."
 else
     echo "Starting 'buildkit' container ... "
     docker start buildkit

--- a/shared/start-buildkit.sh
+++ b/shared/start-buildkit.sh
@@ -14,8 +14,7 @@ else
     return $?
 fi
 
-test "$(docker container inspect -f '{{.State.Running}}' buildkit 2> /dev/null)" = "true"
-if test $? -eq 0; then
+if [ "$(docker container inspect -f '{{.State.Running}}' buildkit 2> /dev/null)" = "true" ]; then
     echo "Container 'buildkit' is already running. Nothing to do."
 else
     echo "Starting 'buildkit' container ... "


### PR DESCRIPTION
# Checklist

- [ ] A link to a related issue in our repository
- [x] A description of the changes proposed in the pull request.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

## Description

Building the docker container fails when the _buildkit_ container does not already exist.

The failure is from a sourced script testing for container presence. The script exits when the test fails while having inherited the `-e` bash option.

The sourced presence test is modified. Additionally a typo is corrected, an EOF newline is added, and the sourcing script has bash tracing output disabled.