### PR TITLE
Containerize server builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ You can build and run the Dockerfile directly as a Docker container.
 
 ```sh
 cd images/chromium-headful
-../../shared/build-server.sh bin
 IMAGE=kernel-docker ./build-docker.sh
 IMAGE=kernel-docker ENABLE_WEBRTC=true ./run-docker.sh
 ```

--- a/shared/build-server.sh
+++ b/shared/build-server.sh
@@ -25,9 +25,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # 1. Build the binary in the server module
-pushd "$REPO_ROOT/server" >/dev/null
-GOOS="$TARGET_OS" GOARCH="$TARGET_ARCH" CGO_ENABLED=0 make build
-popd >/dev/null
+GO_REQUIRED=$(grep -E "^go [0-9]+\.[0-9]+" "$REPO_ROOT/server/go.mod" | head -n1 | awk '{print $2}')
+echo "🔨 Building kernel-images-api binary using go ${GO_REQUIRED}"
+docker run --rm \
+  -e GOOS="$TARGET_OS" \
+  -e GOARCH="$TARGET_ARCH" \
+  -e CGO_ENABLED=0 \
+  -e GOFLAGS="-buildvcs=false" \
+  -v "$REPO_ROOT":/workspace \
+  -w /workspace/server \
+  "golang:${GO_REQUIRED}" \
+  make build
 
 # 2. Copy to destination
 mkdir -p "$DEST_DIR"


### PR DESCRIPTION
`build-server.sh` was assuming a bit too much about a users local env. Instead we'll just run it in docker; we're still preferring this over multi-context builds due to limitations in `kraft pkg`

### Testing

- [x] build + run docker locally
- [x] build unikernel