### PR TITLE
Run neko in the background

### DIFF
--- a/images/chromium-headful/wrapper.sh
+++ b/images/chromium-headful/wrapper.sh
@@ -52,7 +52,7 @@ ncat \
 if [[ "${ENABLE_WEBRTC:-}" == "true" ]]; then
   # use webrtc
   echo "✨ Starting neko (webrtc server)."
-  /usr/bin/neko serve --server.static /var/www --server.bind 0.0.0.0:8080 >&2
+  /usr/bin/neko serve --server.static /var/www --server.bind 0.0.0.0:8080 >&2 &
 else
   # use novnc
   ./novnc_startup.sh


### PR DESCRIPTION
With `ENABLE_WEBRTC=true` neko ends up blocking the rest of our `wrapper.sh`. This isn't intentional since there's a few other things we want to do!

Tested with the local docker flow