### PR TITLE
Use absolute path for ./tmp/chromium/flags

### DIFF
--- a/images/chromium-headful/run-docker.sh
+++ b/images/chromium-headful/run-docker.sh
@@ -23,7 +23,7 @@ fi
 CHROMIUM_FLAGS="${CHROMIUM_FLAGS:-$CHROMIUM_FLAGS_DEFAULT}"
 rm -rf .tmp/chromium
 mkdir -p .tmp/chromium
-FLAGS_FILE=".tmp/chromium/flags"
+FLAGS_FILE="$(pwd)/.tmp/chromium/flags"
 echo "$CHROMIUM_FLAGS" > "$FLAGS_FILE"
 
 echo "flags file: $FLAGS_FILE"


### PR DESCRIPTION
Running Docker locally requires an absolute path for `.tmp/chromium/flags"`

---

---

<span data-mesa-description="start"></span>
## TL;DR
Updated `run-docker.sh` to use an absolute path for Chromium flags, fixing local Docker execution.

## Why we made these changes
Local Docker setup for Chromium failed because the flags file was not found without an absolute path.

## What changed?
- **images/chromium-headful/run-docker.sh**: Modified the `FLAGS_FILE` variable to prepend `$(pwd)/`, ensuring it's always an absolute path relative to the current working directory.

## Validation
- Verified local Docker execution works correctly with the absolute path.
- No testing was performed with unikernels.
<span data-mesa-description="end"></span>