### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Sign up [here](https://www.onkernel.com/)!
 - Sandboxed Chrome browser that Chrome DevTools-based browser frameworks (Playwright, Puppeteer) can connect to
 - Remote GUI access (live view streaming) for visual monitoring and remote control
 - Configurable live view settings (read-only view, browser window dimensions)
-- [Coming soon] Video replays of the browser's session [[1]](#notes)
+- Controllable video replays of the browser's session
 
 ## What You Can Do With It
 
@@ -138,7 +138,6 @@ You can use the embedded live view to monitor and control the browser. The live 
 ### Notes
 - Audio streaming in the WebRTC implementation is currently non-functional and needs to be fixed.
 - The live view is read/write by default. You can set it to read-only by adding `-e ENABLE_READONLY_VIEW=true \` in `docker run`.
-- Replays are currently a work in progress. There is some source code for it throughout the repo.
 
 ## Replay Capture
 


### PR DESCRIPTION
Replays are live

---

<span data-mesa-description="start"></span>
## TL;DR
Updated the README to reflect that browser session video replays are now live and controllable.

## Why we made these changes
Session replay functionality is now fully launched and available, so the documentation needed to be updated to reflect its current status.

## What changed?
- `README.md`: Updated the description for video replays from 'Coming soon' to 'Controllable video replays of the browser's session' and removed a 'work in progress' note.

## Validation
- [ ] Verified the README accurately reflects the current state of the session replay feature.
<span data-mesa-description="end"></span>