### PR TITLE
use erofs for headful image

### DIFF
--- a/images/chromium-headful/.gitignore
+++ b/images/chromium-headful/.gitignore
@@ -1,3 +1,5 @@
 bin/
 recording/
 .tmp/
+.rootfs/
+initrd

--- a/images/chromium-headful/Kraftfile
+++ b/images/chromium-headful/Kraftfile
@@ -3,10 +3,10 @@ spec: v0.6
 runtime: index.unikraft.io/official/base-compat:latest
 
 labels:
-  cloud.unikraft.v1.instances/scale_to_zero.policy: "on"
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "idle"
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
-  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 4000
+  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 5000
 
-rootfs: ./Dockerfile
+rootfs: ./initrd
 
 cmd: ["/wrapper.sh"]

--- a/images/chromium-headful/build-unikernel.sh
+++ b/images/chromium-headful/build-unikernel.sh
@@ -22,7 +22,7 @@ docker rm cnt-"$app_name" || true
 docker create --platform linux/amd64 --name cnt-"$app_name" "$IMAGE" /bin/sh
 docker cp cnt-"$app_name":/ ./.rootfs
 rm -f initrd || true
-mkfs.erofs --all-root -d2 -E noinline_data -b 4096 initrd ./.rootfs
+sudo mkfs.erofs --all-root -d2 -E noinline_data -b 4096 initrd ./.rootfs
 
 # Package the unikernel (and the new initrd) to KraftCloud
 kraft pkg \

--- a/images/chromium-headful/build-unikernel.sh
+++ b/images/chromium-headful/build-unikernel.sh
@@ -1,16 +1,34 @@
 #!/usr/bin/env bash
 
 source common.sh
+source ../../shared/erofs-utils.sh
+
+# Ensure the mkfs.erofs tool is available
+if ! check_mkfs_erofs; then
+    echo "mkfs.erofs is not installed. Installing erofs-utils..."
+    install_erofs_utils
+fi
+
 set -euo pipefail  
 
+# Build the root file system
 source ../../shared/start-buildkit.sh
-
+rm -rf ./.rootfs || true
 # Build the API binary
 source ../../shared/build-server.sh "$(pwd)/bin"
+app_name=chromium-headful-build
+docker build --platform linux/amd64 -t "$IMAGE" .
+docker rm cnt-"$app_name" || true
+docker create --platform linux/amd64 --name cnt-"$app_name" "$IMAGE" /bin/sh
+docker cp cnt-"$app_name":/ ./.rootfs
+rm -f initrd || true
+mkfs.erofs --all-root -d2 -E noinline_data -b 4096 initrd ./.rootfs
 
+# Package the unikernel (and the new initrd) to KraftCloud
 kraft pkg \
   --name $UKC_INDEX/$IMAGE \
-  --plat kraftcloud --arch x86_64 \
+  --plat kraftcloud \
+  --arch x86_64 \
   --strategy overwrite \
   --push \
   .

--- a/images/chromium-headful/run-unikernel.sh
+++ b/images/chromium-headful/run-unikernel.sh
@@ -39,7 +39,6 @@ trap 'rm -rf "$FLAGS_DIR"' EXIT
 deploy_args=(
   -M 8192
   -p 9222:9222/tls
-  -p 8080:8080/tls
   -e DISPLAY_NUM=1
   -e HEIGHT=768
   -e WIDTH=1024

--- a/images/chromium-headless/build-unikernel.sh
+++ b/images/chromium-headless/build-unikernel.sh
@@ -1,46 +1,10 @@
 #!/usr/bin/env bash
 
 source common.sh
+source ../../shared/erofs-utils.sh
 
-# Function to check if mkfs.erofs is available
-check_mkfs_erofs() {
-    if command -v mkfs.erofs &>/dev/null; then
-        echo "mkfs.erofs is already installed."
-        return 0
-    else
-        echo "mkfs.erofs is not installed."
-        return 1
-    fi
-}
-
-# Function to install erofs-utils package
-install_erofs_utils() {
-    if command -v apt-get &>/dev/null; then
-        echo "Detected Ubuntu/Debian-based system. Installing erofs-utils..."
-        sudo apt update
-        sudo apt install -y erofs-utils
-    elif command -v dnf &>/dev/null; then
-        echo "Detected Fedora-based system. Installing erofs-utils..."
-        sudo dnf install -y erofs-utils
-    elif command -v yum &>/dev/null; then
-        echo "Detected CentOS/RHEL-based system. Installing erofs-utils..."
-        sudo yum install -y erofs-utils
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        if command -v brew &>/dev/null; then
-            echo "Detected macOS. Installing erofs-utils..."
-            brew install erofs-utils
-        else
-            echo "Homebrew (brew) not found. Please install Homebrew first."
-            exit 1
-        fi
-    else
-        echo "Unsupported operating system or package manager. Please install erofs-utils manually."
-        exit 1
-    fi
-}
-
-check_mkfs_erofs
-if [ $? -ne 0 ]; then
+# Ensure the mkfs.erofs tool is present
+if ! check_mkfs_erofs; then
     echo "mkfs.erofs is not installed. Installing erofs-utils..."
     install_erofs_utils
 fi
@@ -50,11 +14,9 @@ set -euo pipefail
 cd image/
 
 # Build the root file system
+source ../../shared/start-buildkit.sh
 rm -rf ./.rootfs || true
-
-# Load configuration
-app_name=chromium-headless-test
-
+app_name=chromium-headless-build
 docker build --platform linux/amd64 -t "$IMAGE" .
 docker rm cnt-"$app_name" || true
 docker create --platform linux/amd64 --name cnt-"$app_name" "$IMAGE" /bin/sh

--- a/shared/erofs-utils.sh
+++ b/shared/erofs-utils.sh
@@ -41,3 +41,14 @@ install_erofs_utils() {
         exit 1
     fi
 } 
+
+# on debian 12 you have to grab mkfs.erofs from sid:
+# echo "deb http://deb.debian.org/debian unstable main" \
+#     | sudo tee /etc/apt/sources.list.d/unstable.list
+# cat <<'EOF' | sudo tee /etc/apt/preferences.d/90-unstable
+# Package: *
+# Pin: release a=unstable
+# Pin-Priority: 90
+# EOF
+# sudo apt update
+# sudo apt -t unstable install erofs-utils

--- a/shared/erofs-utils.sh
+++ b/shared/erofs-utils.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# erofs-utils.sh
+# ----------------
+# Shared utility functions for verifying that mkfs.erofs (provided by the
+# erofs-utils package) is available on the host and installing it when it is
+# missing.  This script is meant to be sourced by other build scripts.
+
+set -e -o pipefail
+
+# Returns 0 if mkfs.erofs is on the PATH, 1 otherwise.
+check_mkfs_erofs() {
+    if command -v mkfs.erofs &>/dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Installs the erofs-utils package using the host's package manager.
+install_erofs_utils() {
+    if command -v apt-get &>/dev/null; then
+        echo "Detected Debian/Ubuntu system. Installing erofs-utils …"
+        sudo apt update
+        sudo apt install -y erofs-utils
+    elif command -v dnf &>/dev/null; then
+        echo "Detected Fedora system. Installing erofs-utils …"
+        sudo dnf install -y erofs-utils
+    elif command -v yum &>/dev/null; then
+        echo "Detected CentOS/RHEL system. Installing erofs-utils …"
+        sudo yum install -y erofs-utils
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        if command -v brew &>/dev/null; then
+            echo "Detected macOS system. Installing erofs-utils via Homebrew …"
+            brew install erofs-utils
+        else
+            echo "Homebrew is required but not found. Please install Homebrew first."
+            exit 1
+        fi
+    else
+        echo "Unsupported operating system or package manager; please install erofs-utils manually."
+        exit 1
+    fi
+} 

--- a/shared/uk-check-stats.sh
+++ b/shared/uk-check-stats.sh
@@ -23,13 +23,12 @@ fi
 # get instance stats in a loop until ctrl-c
 trap 'echo "Stopping stats collection..."; exit 0' INT
 
+echo -e "RSS\tCPU Time\tTX Bytes"
 while true; do
     metrics=$(curl -s -H "Authorization: Bearer $UKC_TOKEN" "$UKC_METRO/instances/$instance_id/metrics")
     rss=$(echo "$metrics" | grep 'instance_rss_bytes{instance_uuid=' | cut -d' ' -f2)
     cpu_time=$(echo "$metrics" | grep 'instance_cpu_time_s{instance_uuid=' | cut -d' ' -f2)
     tx_bytes=$(echo "$metrics" | grep 'instance_tx_bytes{instance_uuid=' | cut -d' ' -f2)
-    echo "RSS: $rss"
-    echo "CPU Time: $cpu_time"
-    echo "TX Bytes: $tx_bytes"
+    echo -e "$rss\t$cpu_time\t$tx_bytes"
     sleep 1
 done


### PR DESCRIPTION
syncing up with the approach used in the headless image

this should reduce memory usage

---

<span data-mesa-description="start"></span>
## TL;DR
Switched the Chromium headful unikernel to use EROFS for its root filesystem, aligning it with the headless image and reducing memory usage.

## Why we made these changes
To reduce memory consumption for the Chromium headful image and standardize its root filesystem approach with the existing headless image, improving overall efficiency.

## What changed?
*   **Chromium Headful Image:**
    *   Updated `Kraftfile` to use `idle` scale-to-zero policy, increased cooldown, and pointed rootfs to `./initrd`.
    *   Modified `build-unikernel.sh` to generate the `initrd` using `mkfs.erofs` from Docker-extracted contents.
*   **Shared Utilities:**
    *   Introduced `shared/erofs-utils.sh` with functions to check for and install `mkfs.erofs`.
    *   Refactored `chromium-headless/build-unikernel.sh` to utilize these new shared utility scripts, removing duplicated logic.

## Validation
*   [ ] Chromium headful unikernel builds successfully.
*   [ ] Headful image boots and functions as expected.
*   [ ] Memory usage is reduced compared to the previous build.
*   [ ] Scale-to-zero and cooldown policies in `Kraftfile` behave correctly.
<span data-mesa-description="end"></span>