### PR TITLE
add network stats

### DIFF
--- a/shared/uk-check-stats.sh
+++ b/shared/uk-check-stats.sh
@@ -23,12 +23,16 @@ fi
 # get instance stats in a loop until ctrl-c
 trap 'echo "Stopping stats collection..."; exit 0' INT
 
-echo -e "RSS\tCPU Time\tTX Bytes"
+echo -e "RSS\tCPU Time\tTX Bytes\tNConns\tNReqs\tNQueued\tNTotal"
 while true; do
     metrics=$(curl -s -H "Authorization: Bearer $UKC_TOKEN" "$UKC_METRO/instances/$instance_id/metrics")
     rss=$(echo "$metrics" | grep 'instance_rss_bytes{instance_uuid=' | cut -d' ' -f2)
     cpu_time=$(echo "$metrics" | grep 'instance_cpu_time_s{instance_uuid=' | cut -d' ' -f2)
     tx_bytes=$(echo "$metrics" | grep 'instance_tx_bytes{instance_uuid=' | cut -d' ' -f2)
-    echo -e "$rss\t$cpu_time\t$tx_bytes"
+    nconns=$(echo "$metrics" | grep 'instance_nconns{instance_uuid=' | cut -d' ' -f2)
+    nreqs=$(echo "$metrics" | grep 'instance_nreqs{instance_uuid=' | cut -d' ' -f2)
+    nqueued=$(echo "$metrics" | grep 'instance_nqueued{instance_uuid=' | cut -d' ' -f2)
+    ntotal=$(echo "$metrics" | grep 'instance_ntotal{instance_uuid=' | cut -d' ' -f2)
+    echo -e "$rss\t$cpu_time\t$tx_bytes\t$nconns\t$nreqs\t$nqueued\t$ntotal"
     sleep 1
 done


### PR DESCRIPTION
<img width="716" height="179" alt="image" src="https://github.com/user-attachments/assets/29eddbd2-b52d-4f2f-8508-c50f64cbdb07" />


[link](https://unikraft.cloud/docs/api/v1/instances/#retrieving-instance-metrics)

---

<span data-mesa-description="start"></span>
## TL;DR
Enhanced `uk-check-stats.sh` to display new network-related instance metrics.

## Why we made these changes
To provide more comprehensive insights into instance performance, specifically network connection and request statistics, which are crucial for monitoring and debugging.

## What changed?
- `shared/uk-check-stats.sh`: Updated to collect and display `instance_nconns`, `instance_nreqs`, `instance_nqueued`, and `instance_ntotal` metrics. The script's output header and data display were adjusted to incorporate these new columns.

## Validation
- Verified script output includes the new network statistics as shown in the PR body image.
<span data-mesa-description="end"></span>