### PR TITLE
clipboard fix (v2)

### DIFF
--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -32,7 +32,9 @@ RUN set -eux; \
     make -j$(nproc); \
     make install;
 
-FROM ghcr.io/m1k1o/neko/chromium:3.0.6 AS neko
+#FROM ghcr.io/m1k1o/neko/chromium:3.0.6 AS neko
+FROM ghcr.io/raiden-staging/neko/chromium:3.0.6-kernel-editv1 AS neko
+# ^--------- edited + rebuilt neko:chromium to disable host only on clipboard events
 FROM docker.io/ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/images/chromium-headful/client/src/components/connect.vue
+++ b/images/chromium-headful/client/src/components/connect.vue
@@ -169,7 +169,7 @@
       }
 
       // KERNEL: auto-login
-      this.$accessor.login({ displayname: 'dummy', password: 'dummy' })
+      this.$accessor.login({ displayname: 'kernel', password: 'admin' })
       this.autoPassword = null
     }
 

--- a/images/chromium-headful/neko.yaml
+++ b/images/chromium-headful/neko.yaml
@@ -5,7 +5,32 @@ desktop:
   screen: "1024x768@60"
 
 member:
-  provider: "noauth"
+  provider: multiuser
+  multiuser:
+    admin_password: "admin"
+    admin_profile:
+      name: "" # if empty, the login username is used
+      is_admin: true
+      can_login: true
+      can_connect: true
+      can_watch: true
+      can_host: true
+      can_share_media: true
+      can_access_clipboard: true
+      sends_inactive_cursor: true
+      can_see_inactive_cursors: true
+    user_password: "neko"
+    user_profile:
+      name: "" # if empty, the login username is used
+      is_admin: false
+      can_login: true
+      can_connect: true
+      can_watch: true
+      can_host: true
+      can_share_media: true
+      can_access_clipboard: true
+      sends_inactive_cursor: true
+      can_see_inactive_cursors: false
 
 session:
   merciful_reconnect: true


### PR DESCRIPTION
(Issue #31 , cont. from [PR #36](https://github.com/onkernel/kernel-images/pull/36) )

Fix :

- added admin neko profile with enabled clipboard , was not enough to operate as host
- as found in PR#36 , `m1k1o/neko/chromium:3.0.6` only enables clipboard controls for hosts
- fix required making new `neko:base` & `neko:chromium` builds
  - source in [`raiden-staging/neko`](https://github.com/raiden-staging/neko/)
  - where host-only controls scoping is disabled
- updated the chromium-headful `Dockerfile` 
  - `FROM ghcr.io/raiden-staging/neko/chromium:3.0.6-kernel-editv1 AS neko`
  - package [released here](https://github.com/users/raiden-staging/packages/container/package/neko%2Fchromium)

Clipboard now works 👍

---

Notes
- Takes a long time for the neko images to build from gh actions (40+ mins)
- External APIs for computer controls outside of the neko image seems to be the right approach for faster iterations in near future ; but we can periodically merge into `neko:chromium` if we are to expose the neko websockets and events directly as part of the computer controls apis too

---

<span data-mesa-description="start"></span>
## TL;DR
Fixed clipboard functionality in the `chromium-headful` image by using a custom `neko` base image that disables host-only clipboard restrictions and configuring an admin user.

## Why we made these changes
The previous `neko` image (`m1k1o/neko/chromium:3.0.6`) only enabled clipboard controls for hosts, which was insufficient for the intended operation. This change addresses that limitation by integrating a custom `neko` build where host-only controls are disabled, ensuring clipboard access for all users, specifically the 'admin' profile.

## What changed?
- **images/chromium-headful/Dockerfile**: Updated to use `ghcr.io/raiden-staging/neko/chromium:3.0.6-kernel-editv1` as the base image, a custom build that disables host-only clipboard events.
- **images/chromium-headful/client/src/components/connect.vue**: Modified auto-login to use 'kernel' as the display name and 'admin' as the password.
- **images/chromium-headful/neko.yaml**: Switched the authentication provider from `noauth` to `multiuser`, adding detailed password settings and permission profiles for admin and regular users.

## Validation
- Clipboard functionality verified to be working.
<span data-mesa-description="end"></span>