### PR TITLE
Delete recordings endpoint

### DIFF
--- a/server/cmd/api/api/api.go
+++ b/server/cmd/api/api/api.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/onkernel/kernel-images/server/lib/logger"
@@ -92,7 +94,7 @@ func (s *ApiService) StopRecording(ctx context.Context, req oapi.StopRecordingRe
 
 	rec, exists := s.recordManager.GetRecorder(recorderID)
 	if !exists {
-		log.Warn("attempted to stop recording when none is active", "recorder_id", recorderID)
+		log.Error("attempted to stop recording when none is active", "recorder_id", recorderID)
 		return oapi.StopRecording400JSONResponse{BadRequestErrorJSONResponse: oapi.BadRequestErrorJSONResponse{Message: "no active recording to stop"}}, nil
 	} else if !rec.IsRecording(ctx) {
 		log.Warn("recording already stopped", "recorder_id", recorderID)
@@ -140,6 +142,10 @@ func (s *ApiService) DownloadRecording(ctx context.Context, req oapi.DownloadRec
 		log.Error("attempted to download non-existent recording", "recorder_id", recorderID)
 		return oapi.DownloadRecording404JSONResponse{NotFoundErrorJSONResponse: oapi.NotFoundErrorJSONResponse{Message: "no recording found"}}, nil
 	}
+	if rec.IsDeleted(ctx) {
+		log.Error("attempted to download deleted recording", "recorder_id", recorderID)
+		return oapi.DownloadRecording400JSONResponse{BadRequestErrorJSONResponse: oapi.BadRequestErrorJSONResponse{Message: "requested recording has been deleted"}}, nil
+	}
 
 	out, meta, err := rec.Recording(ctx)
 	if err != nil {
@@ -165,6 +171,35 @@ func (s *ApiService) DownloadRecording(ctx context.Context, req oapi.DownloadRec
 		},
 		ContentLength: meta.Size,
 	}, nil
+}
+
+func (s *ApiService) DeleteRecording(ctx context.Context, req oapi.DeleteRecordingRequestObject) (oapi.DeleteRecordingResponseObject, error) {
+	log := logger.FromContext(ctx)
+
+	recorderID := s.defaultRecorderID
+	if req.Body != nil && req.Body.Id != nil && *req.Body.Id != "" {
+		recorderID = *req.Body.Id
+	}
+	rec, exists := s.recordManager.GetRecorder(recorderID)
+	if !exists {
+		log.Error("attempted to delete non-existent recording", "recorder_id", recorderID)
+		return oapi.DeleteRecording404JSONResponse{NotFoundErrorJSONResponse: oapi.NotFoundErrorJSONResponse{Message: "no recording found"}}, nil
+	}
+
+	if rec.IsRecording(ctx) {
+		log.Error("attempted to delete recording while still in progress", "recorder_id", recorderID)
+		return oapi.DeleteRecording400JSONResponse{BadRequestErrorJSONResponse: oapi.BadRequestErrorJSONResponse{Message: "recording must be stopped first"}}, nil
+	}
+
+	// fine to do this async
+	go func() {
+		if err := rec.Delete(ctx); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Error("failed to delete recording", "err", err, "recorder_id", recorderID)
+		}
+		log.Info("recording deleted", "recorder_id", recorderID)
+	}()
+
+	return oapi.DeleteRecording200Response{}, nil
 }
 
 // ListRecorders returns a list of all registered recorders and whether each one is currently recording.

--- a/server/lib/recorder/recorder.go
+++ b/server/lib/recorder/recorder.go
@@ -14,7 +14,9 @@ type Recorder interface {
 	ForceStop(ctx context.Context) error
 	IsRecording(ctx context.Context) bool
 	Metadata() *RecordingMetadata
-	Recording(ctx context.Context) (io.ReadCloser, *RecordingMetadata, error) // Returns the recording file as a ReadCloser
+	Recording(ctx context.Context) (io.ReadCloser, *RecordingMetadata, error)
+	Delete(ctx context.Context) error
+	IsDeleted(ctx context.Context) bool
 }
 
 type RecordingMetadata struct {

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -101,6 +101,25 @@ paths:
                   $ref: "#/components/schemas/RecorderInfo"
         "500":
           $ref: "#/components/responses/InternalError"
+  /recording/delete:
+    post:
+      summary: Delete a previously recorded video file
+      operationId: deleteRecording
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteRecordingRequest"
+      responses:
+        "200":
+          description: Recording deleted
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /computer/click_mouse:
     post:
       summary: Simulate a mouse click action on the host computer
@@ -242,6 +261,14 @@ components:
           description: Modifier keys to hold during the move
           items:
             type: string
+      additionalProperties: false
+    DeleteRecordingRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Identifier of the recording to delete. Alphanumeric or hyphen.
+          pattern: "^[a-zA-Z0-9-]+$"
       additionalProperties: false
   responses:
     BadRequestError:


### PR DESCRIPTION
### Description

Allow folks to delete recordings. A concern for long running containers is the space used by recordings grows unbounded. We have ~some safeguards in place (e.g. total amount of space for a single recording, total amount of time for a single recording) but no way of actually marking recordings for clean up. I chose what felt like a simple path of "whoever is telling me to record can also tell me when to clean up". To be clear: this isn't meant to prevent all failure modes wrt storage but in typical workflows this should keep run times well within bounds

### Testing

Units + end to end with our API