### PR TITLE
Live view disconnections fix (v1)

### DIFF
--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -32,7 +32,9 @@ RUN set -eux; \
     make -j$(nproc); \
     make install;
 
-FROM ghcr.io/m1k1o/neko/chromium:3.0.6 AS neko
+#FROM ghcr.io/m1k1o/neko/chromium:3.0.6 AS neko
+FROM ghcr.io/raiden-staging/neko/chromium:3.0.6-kernel-v1.1 AS neko
+# ^--------- edited + rebuilt neko:chromium to disable host only on clipboard events
 FROM docker.io/ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/images/chromium-headful/client/src/components/connect.vue
+++ b/images/chromium-headful/client/src/components/connect.vue
@@ -169,7 +169,7 @@
       }
 
       // KERNEL: auto-login
-      this.$accessor.login({ displayname: 'dummy', password: 'dummy' })
+      this.$accessor.login({ displayname: 'kernel', password: 'admin' })
       this.autoPassword = null
     }
 

--- a/images/chromium-headful/client/src/neko/index.ts
+++ b/images/chromium-headful/client/src/neko/index.ts
@@ -149,7 +149,12 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
 
     if (heartbeat_interval > 0) {
       if (this._ws_heartbeat) clearInterval(this._ws_heartbeat)
-      this._ws_heartbeat = window.setInterval(() => this.sendMessage(EVENT.CLIENT.HEARTBEAT), heartbeat_interval * 1000)
+      this._ws_heartbeat = window.setInterval(() => {
+        this.emit('debug', `sending client/heartbeat`)
+        this.sendMessage(EVENT.CLIENT.HEARTBEAT)
+        this.emit('debug', `sending chat/message`)
+        this.sendMessage(EVENT.CHAT.MESSAGE, { content: `heartbeat/fake [${Date.now()}]` })
+      }, heartbeat_interval * 1000)
     }
   }
 

--- a/images/chromium-headful/neko.yaml
+++ b/images/chromium-headful/neko.yaml
@@ -5,7 +5,32 @@ desktop:
   screen: "1024x768@60"
 
 member:
-  provider: "noauth"
+  provider: multiuser
+  multiuser:
+    admin_password: "admin"
+    admin_profile:
+      name: "" # if empty, the login username is used
+      is_admin: true
+      can_login: true
+      can_connect: true
+      can_watch: true
+      can_host: true
+      can_share_media: true
+      can_access_clipboard: true
+      sends_inactive_cursor: true
+      can_see_inactive_cursors: true
+    user_password: "neko"
+    user_profile:
+      name: "" # if empty, the login username is used
+      is_admin: false
+      can_login: true
+      can_connect: true
+      can_watch: true
+      can_host: true
+      can_share_media: true
+      can_access_clipboard: true
+      sends_inactive_cursor: true
+      can_see_inactive_cursors: false
 
 session:
   merciful_reconnect: true
@@ -18,7 +43,7 @@ plugins:
   enabled: false
 
 chat:
-  enabled: false
+  enabled: true
 
 filetransfer:
   enabled: false


### PR DESCRIPTION
[Issue #27]

## Analysis

- neko doesn't reply on [`event.CLIENT_HEARTBEAT` in websockets handler](https://github.com/onkernel/neko/blob/96d9e8a6ea789d855cb134308237e2c5dcae7514/server/internal/websocket/handler/handler.go#L40)
- after handshake, ws events are (live client → neko instance) only - until peer disconnect event
- debugging by having playwright connect/disconnect on same kernel browser session, to have neko emit `event.MEMBER_CONNECT` & `event.MEMBER_DISCONNECT` to the client every few seconds to keepalive. seems to work :)

https://github.com/user-attachments/assets/f28098bd-4f09-48cb-838e-e170c794fa4a

_both sessions have steady input.
left session has peer disconnect error 3x in the recorded interval.
right session, where neko sends new event to client every few secs (member notifications), has no peer disconnect error in the interval._

---

## Fix

- new [raiden-staging/neko](https://github.com/raiden-staging/neko) chromium build (`neko/chromium:3.0.6-kernel-v1.1`) sets a reduced heartbeat interval.
- enabled chat on `neko.yaml` , sending dummy `event.CHAT_MESSAGE` alongside `event.CLIENT_HEARTBEAT` from client, as neko handler replies to the event.
- (also added `event.SYSTEM_HEARTBEAT` in the neko src, will use it instead of the `event.CHAT_MESSAGE` workaround later if the approach works when deployed)

this could fix live view peer disconnections.

---

# Notes

- can't try on deployed unikraft cloud - my `UKC_TOKEN` has <8gb required memory quotas.
- Docker build runs well. if someone can confirm on unikraft deployment would be cool 👍
- other potential alternative would be to have a /ping route on the kernel-images/server and use that for heartbeat