### PR TITLE
Keepalive fix cleanup [kernel-images]

### DIFF
--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -32,7 +32,9 @@ RUN set -eux; \
     make -j$(nproc); \
     make install;
 
-FROM ghcr.io/onkernel/neko/base:3.0.6-v1.0 AS neko
+# FROM ghcr.io/onkernel/neko/base:3.0.6-v1.0 AS neko
+FROM ghcr.io/raiden-staging/neko/base:3.0.6-v1.0.1 AS neko
+# ^--- now has event.SYSTEM_PONG with legacy support to keepalive
 FROM docker.io/ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -32,8 +32,7 @@ RUN set -eux; \
     make -j$(nproc); \
     make install;
 
-# FROM ghcr.io/onkernel/neko/base:3.0.6-v1.0 AS neko
-FROM ghcr.io/raiden-staging/neko/base:3.0.6-v1.0.1 AS neko
+FROM ghcr.io/onkernel/neko/base:3.0.6-v1.0.1 AS neko
 # ^--- now has event.SYSTEM_PONG with legacy support to keepalive
 FROM docker.io/ubuntu:22.04
 

--- a/images/chromium-headful/client/src/neko/events.ts
+++ b/images/chromium-headful/client/src/neko/events.ts
@@ -13,6 +13,7 @@ export const EVENT = {
     INIT: 'system/init',
     DISCONNECT: 'system/disconnect',
     ERROR: 'system/error',
+    PONG: 'system/pong',
   },
   CLIENT: {
     HEARTBEAT: 'client/heartbeat',
@@ -90,7 +91,7 @@ export type ControlEvents =
   | typeof EVENT.CONTROL.CLIPBOARD
   | typeof EVENT.CONTROL.KEYBOARD
 
-export type SystemEvents = typeof EVENT.SYSTEM.DISCONNECT
+export type SystemEvents = typeof EVENT.SYSTEM.DISCONNECT | typeof EVENT.SYSTEM.PONG
 export type ClientEvents = typeof EVENT.CLIENT.HEARTBEAT
 export type MemberEvents = typeof EVENT.MEMBER.LIST | typeof EVENT.MEMBER.CONNECTED | typeof EVENT.MEMBER.DISCONNECTED
 

--- a/images/chromium-headful/client/src/neko/index.ts
+++ b/images/chromium-headful/client/src/neko/index.ts
@@ -152,8 +152,6 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
       this._ws_heartbeat = window.setInterval(() => {
         this.emit('debug', `sending client/heartbeat`)
         this.sendMessage(EVENT.CLIENT.HEARTBEAT)
-        this.emit('debug', `sending chat/message`)
-        this.sendMessage(EVENT.CHAT.MESSAGE, { content: `heartbeat/fake [${Date.now()}]` })
       }, heartbeat_interval * 1000)
     }
   }
@@ -181,6 +179,10 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
       icon: 'error',
       confirmButtonText: this.$vue.$t('connection.button_confirm') as string,
     })
+  }
+
+  protected [EVENT.SYSTEM.PONG]({ timestamp }: { timestamp: string }) {
+    // this.emit('debug', `received system/pong with timestamp: ${timestamp}`)
   }
 
   /////////////////////////////

--- a/images/chromium-headful/client/src/neko/messages.ts
+++ b/images/chromium-headful/client/src/neko/messages.ts
@@ -25,6 +25,7 @@ export type WebSocketMessages =
   | ScreenResolutionMessage
   | ScreenConfigurationsMessage
   | ChatMessage
+  | SystemPongMessage
 
 export type WebSocketPayloads =
   | SignalProvidePayload
@@ -45,6 +46,7 @@ export type WebSocketPayloads =
   | AdminLockPayload
   | BroadcastStatusPayload
   | BroadcastCreatePayload
+  | SystemPongPayload
 
 export interface WebSocketMessage {
   event: WebSocketEvents | string
@@ -72,6 +74,14 @@ export interface SystemMessage extends WebSocketMessage, SystemMessagePayload {
 export interface SystemMessagePayload {
   title: string
   message: string
+}
+
+// system/pong
+export interface SystemPongMessage extends WebSocketMessage, SystemPongPayload {
+  event: typeof EVENT.SYSTEM.PONG
+}
+export interface SystemPongPayload {
+  timestamp: string
 }
 
 /*

--- a/images/chromium-headful/neko.yaml
+++ b/images/chromium-headful/neko.yaml
@@ -43,7 +43,7 @@ plugins:
   enabled: false
 
 chat:
-  enabled: true
+  enabled: false
 
 filetransfer:
   enabled: false


### PR DESCRIPTION
- Updated with new neko build so live client websockets receives `system/pong`
- Removed chat temp fix
- `client/heartbeat` → `system/pong` reply with 10s interval works ✅ 

# Next Steps :
- [`onkernel/neko`](https://github.com/onkernel/neko/)
  - Merge PR (`Keepalive fix cleanup [neko]`)
  - Release tag `v3.0.6-v1.0.1`
- [`onkernel/kernel-images`](https://github.com/onkernel/kernel-images/)
  - Merge this PR (`Keepalive fix cleanup [kernel-images]`). Notes :
    - `Dockerfile` already set to _ghcr.io/**onkernel**/neko/base:3.0.6-v1.0.1_
    - after `onkernel/neko:v3.0.6-v1.0.1` tag release and build completion, would work without needing changes in this PR

[ @Sayan- @rgarcia ]