### PR TITLE
Install and configure Envoy

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ curl http://localhost:10001/recording/download --output recording.mp4
 
 Note: the recording file is encoded into a H.264/MPEG-4 AVC video file. [QuickTime has known issues with playback](https://discussions.apple.com/thread/254851789?sortBy=rank) so please make sure to use a compatible media player!
 
+## Proxy configuration
+
+[Envoy](https://www.envoyproxy.io/) is installed with the browser images, which allows for configuration of a forward proxy chain for egress browser traffic. This proxy is part of the Kernel platform, configured by the following environment variables:
+
+**INST_NAME**: Instance name in the platform of this browser, used to identify this browser with the platform
+**METRO_NAME**: Dataplane server name in the platform of this browser, used to identify this browser with the platform
+**XDS_SERVER**: The xDS server hostname, where envoy can discover configuration
+**XDS_JWT**: A token used to authenticate this browser to the xDS server
+
+Envoy is running alongside of the browser. The browser may be configured to proxy through envoy using the [--proxy-server flag](https://www.chromium.org/developers/design-documents/network-settings/). The default configuration directly egresses traffic to the internet. When configured to receive dynamic configuration, the xDS server can control the egress traffic flows of the browser, for example through a forward proxy chain.
+
 ## Documentation
 
 This repo powers our managed [browser infrastructure](https://onkernel.com/docs).

--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ Note: the recording file is encoded into a H.264/MPEG-4 AVC video file. [QuickTi
 
 [Envoy](https://www.envoyproxy.io/) is installed with the browser images, which allows for configuration of a forward proxy chain for egress browser traffic. This proxy is part of the Kernel platform, configured by the following environment variables:
 
-**INST_NAME**: Instance name in the platform of this browser, used to identify this browser with the platform
-**METRO_NAME**: Dataplane server name in the platform of this browser, used to identify this browser with the platform
-**XDS_SERVER**: The xDS server hostname, where envoy can discover configuration
-**XDS_JWT**: A token used to authenticate this browser to the xDS server
+- **INST_NAME**: Instance name in the platform of this browser, used to identify this browser with the platform
+- **METRO_NAME**: Dataplane server name in the platform of this browser, used to identify this browser with the platform
+- **XDS_SERVER**: The xDS server hostname, where envoy can discover configuration
+- **XDS_JWT**: A token used to authenticate this browser to the xDS server
 
 Envoy is running alongside of the browser. The browser may be configured to proxy through envoy using the [--proxy-server flag](https://www.chromium.org/developers/design-documents/network-settings/). The default configuration directly egresses traffic to the internet. When configured to receive dynamic configuration, the xDS server can control the egress traffic flows of the browser, for example through a forward proxy chain.
 

--- a/images/chromium-headful/.gitignore
+++ b/images/chromium-headful/.gitignore
@@ -3,3 +3,4 @@ recording/
 .tmp/
 .rootfs/
 initrd
+temp.sh

--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -181,7 +181,8 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/
 RUN mkdir -p /etc/envoy/templates
 COPY shared/envoy/bootstrap.yaml /etc/envoy/templates/bootstrap.yaml
-COPY shared/envoy/default.yaml /etc/envoy/default.yaml
+# Copy default config to bootstrap.yaml so supervisor can start envoy immediately
+COPY shared/envoy/default.yaml /etc/envoy/bootstrap.yaml
 COPY shared/envoy/init-envoy.sh /usr/local/bin/init-envoy.sh
 RUN chmod +x /usr/local/bin/init-envoy.sh
 

--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -116,7 +116,7 @@ RUN set -eux; \
     install -m755 /tmp/ffmpeg-*/ffprobe /usr/local/bin/ffprobe; \
     rm -rf /tmp/ffmpeg*
 
-    # runtime
+# runtime
 ENV USERNAME=root
 RUN set -eux; \
     apt-get update; \

--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -169,31 +169,16 @@ COPY --from=client /src/dist/ /var/www
 COPY --from=xorg-deps /usr/local/lib/xorg/modules/drivers/dummy_drv.so /usr/lib/xorg/modules/drivers/dummy_drv.so
 COPY --from=xorg-deps /usr/local/lib/xorg/modules/input/neko_drv.so /usr/lib/xorg/modules/input/neko_drv.so
 
-# Install Envoy proxy (official apt.envoyproxy.io) and add bootstrap configuration
-ENV ENVOY_PACKAGE=envoy-1.32
-RUN set -eux; \
-    mkdir -p /etc/apt/keyrings; \
-    curl -fsSL https://apt.envoyproxy.io/signing.key | gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg; \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io jammy main" > /etc/apt/sources.list.d/envoy.list; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends "${ENVOY_PACKAGE}" || (apt-cache policy "${ENVOY_PACKAGE}" envoy && exit 1); \
-    apt-mark hold "${ENVOY_PACKAGE}"; \
-    apt-get clean -y; \
-    rm -rf /var/lib/apt/lists/* /var/cache/apt/
-RUN mkdir -p /etc/envoy/templates
+# Install Envoy proxy and BrightData certificates
+COPY shared/envoy/install-proxy.sh /usr/local/bin/install-proxy.sh
+RUN chmod +x /usr/local/bin/install-proxy.sh && /usr/local/bin/install-proxy.sh && rm /usr/local/bin/install-proxy.sh
+
+# Copy Envoy configuration files
 COPY shared/envoy/bootstrap.yaml /etc/envoy/templates/bootstrap.yaml
 # Copy default config to bootstrap.yaml so supervisor can start envoy immediately
 COPY shared/envoy/default.yaml /etc/envoy/bootstrap.yaml
 COPY shared/envoy/init-envoy.sh /usr/local/bin/init-envoy.sh
 RUN chmod +x /usr/local/bin/init-envoy.sh
-
-# Download and extract BrightData proxy certificate
-RUN set -eux; \
-    mkdir -p /etc/envoy/brightdata; \
-    curl -fsSL https://brightdata.com/static/brightdata_proxy_ca.zip -o /tmp/brightdata_proxy_ca.zip; \
-    unzip -j /tmp/brightdata_proxy_ca.zip '*/*.crt' -d /etc/envoy/brightdata/ || true; \
-    rm /tmp/brightdata_proxy_ca.zip; \
-    echo "BrightData certificates extracted to /etc/envoy/brightdata/"
 
 COPY images/chromium-headful/image-chromium/ /
 COPY images/chromium-headful/start-chromium.sh /images/chromium-headful/start-chromium.sh

--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -168,12 +168,30 @@ COPY --from=client /src/dist/ /var/www
 COPY --from=xorg-deps /usr/local/lib/xorg/modules/drivers/dummy_drv.so /usr/lib/xorg/modules/drivers/dummy_drv.so
 COPY --from=xorg-deps /usr/local/lib/xorg/modules/input/neko_drv.so /usr/lib/xorg/modules/input/neko_drv.so
 
+# Install Envoy proxy (official apt.envoyproxy.io) and add bootstrap configuration
+ENV ENVOY_PACKAGE=envoy-1.32
+RUN set -eux; \
+    mkdir -p /etc/apt/keyrings; \
+    curl -fsSL https://apt.envoyproxy.io/signing.key | gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io jammy main" > /etc/apt/sources.list.d/envoy.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends "${ENVOY_PACKAGE}" || (apt-cache policy "${ENVOY_PACKAGE}" envoy && exit 1); \
+    apt-mark hold "${ENVOY_PACKAGE}"; \
+    apt-get clean -y; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/
+RUN mkdir -p /etc/envoy/templates
+COPY shared/envoy/bootstrap.yaml /etc/envoy/templates/bootstrap.yaml
+COPY shared/envoy/default.yaml /etc/envoy/default.yaml
+COPY shared/envoy/init-envoy.sh /usr/local/bin/init-envoy.sh
+RUN chmod +x /usr/local/bin/init-envoy.sh
+
 COPY images/chromium-headful/image-chromium/ /
 COPY images/chromium-headful/start-chromium.sh /images/chromium-headful/start-chromium.sh
 RUN chmod +x /images/chromium-headful/start-chromium.sh
 COPY images/chromium-headful/wrapper.sh /wrapper.sh
 COPY images/chromium-headful/supervisord.conf /etc/supervisor/supervisord.conf
 COPY images/chromium-headful/supervisor/services/ /etc/supervisor/conf.d/services/
+COPY shared/envoy/supervisor-envoy.conf /etc/supervisor/conf.d/services/envoy.conf
 
 # copy the kernel-images API binary built in the builder stage
 COPY --from=server-builder /out/kernel-images-api /usr/local/bin/kernel-images-api

--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -116,7 +116,7 @@ RUN set -eux; \
     install -m755 /tmp/ffmpeg-*/ffprobe /usr/local/bin/ffprobe; \
     rm -rf /tmp/ffmpeg*
 
-# runtime
+    # runtime
 ENV USERNAME=root
 RUN set -eux; \
     apt-get update; \
@@ -126,7 +126,8 @@ RUN set -eux; \
     libcairo2 libxcb1 libxrandr2 libxv1 libopus0 libvpx7 \
     gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
-    gstreamer1.0-pulseaudio gstreamer1.0-omx; \
+    gstreamer1.0-pulseaudio gstreamer1.0-omx \
+    libnss3-tools; \
     #
     # install libxcvt0 (not available in debian:bullseye)
     ARCH=$(dpkg --print-architecture); \
@@ -185,6 +186,14 @@ COPY shared/envoy/bootstrap.yaml /etc/envoy/templates/bootstrap.yaml
 COPY shared/envoy/default.yaml /etc/envoy/bootstrap.yaml
 COPY shared/envoy/init-envoy.sh /usr/local/bin/init-envoy.sh
 RUN chmod +x /usr/local/bin/init-envoy.sh
+
+# Download and extract BrightData proxy certificate
+RUN set -eux; \
+    mkdir -p /etc/envoy/brightdata; \
+    curl -fsSL https://brightdata.com/static/brightdata_proxy_ca.zip -o /tmp/brightdata_proxy_ca.zip; \
+    unzip -j /tmp/brightdata_proxy_ca.zip '*/*.crt' -d /etc/envoy/brightdata/ || true; \
+    rm /tmp/brightdata_proxy_ca.zip; \
+    echo "BrightData certificates extracted to /etc/envoy/brightdata/"
 
 COPY images/chromium-headful/image-chromium/ /
 COPY images/chromium-headful/start-chromium.sh /images/chromium-headful/start-chromium.sh

--- a/images/chromium-headful/run-docker.sh
+++ b/images/chromium-headful/run-docker.sh
@@ -60,8 +60,6 @@ if [[ -n "${XDS_JWT:-}" ]]; then
   RUN_ARGS+=( -e "XDS_JWT=$XDS_JWT" )
   RUN_ARGS+=( -p 9901:9901 )
   RUN_ARGS+=( -p 3128:3128 )
-  # TODO: import bright data and self-signed client proxy cert to chrome instead of ignore
-  CHROMIUM_FLAGS_DEFAULT="$CHROMIUM_FLAGS_DEFAULT --proxy-server=https://127.0.0.1:3128 --ignore-certificate-errors"
 fi
 
 # WebRTC port mapping

--- a/images/chromium-headful/run-docker.sh
+++ b/images/chromium-headful/run-docker.sh
@@ -19,7 +19,7 @@ if [[ "$RUN_AS_ROOT" == "true" ]]; then
   CHROMIUM_FLAGS_DEFAULT="$CHROMIUM_FLAGS_DEFAULT --no-sandbox --no-zygote"
 fi
 if [[ -n "${XDS_JWT:-}" ]]; then
-  CHROMIUM_FLAGS_DEFAULT="$CHROMIUM_FLAGS_DEFAULT --proxy-server=https://127.0.0.1:3128 --ignore-certificate-errors"
+  CHROMIUM_FLAGS_DEFAULT="$CHROMIUM_FLAGS_DEFAULT --proxy-server=https://127.0.0.1:3128"
 fi
 CHROMIUM_FLAGS="${CHROMIUM_FLAGS:-$CHROMIUM_FLAGS_DEFAULT}"
 rm -rf .tmp/chromium

--- a/images/chromium-headful/run-docker.sh
+++ b/images/chromium-headful/run-docker.sh
@@ -18,6 +18,9 @@ CHROMIUM_FLAGS_DEFAULT="--user-data-dir=/home/kernel/user-data --disable-dev-shm
 if [[ "$RUN_AS_ROOT" == "true" ]]; then
   CHROMIUM_FLAGS_DEFAULT="$CHROMIUM_FLAGS_DEFAULT --no-sandbox --no-zygote"
 fi
+if [[ -n "${XDS_JWT:-}" ]]; then
+  CHROMIUM_FLAGS_DEFAULT="$CHROMIUM_FLAGS_DEFAULT --proxy-server=https://127.0.0.1:3128 --ignore-certificate-errors"
+fi
 CHROMIUM_FLAGS="${CHROMIUM_FLAGS:-$CHROMIUM_FLAGS_DEFAULT}"
 rm -rf .tmp/chromium
 mkdir -p .tmp/chromium
@@ -42,6 +45,24 @@ RUN_ARGS=(
   -e RUN_AS_ROOT="$RUN_AS_ROOT"
   --mount type=bind,src="$FLAGS_FILE",dst=/chromium/flags,ro
 )
+
+# Add XDS environment variables if provided
+if [[ -n "${INST_NAME:-}" ]]; then
+  RUN_ARGS+=( -e "INST_NAME=$INST_NAME" )
+fi
+if [[ -n "${METRO_NAME:-}" ]]; then
+  RUN_ARGS+=( -e "METRO_NAME=$METRO_NAME" )
+fi
+if [[ -n "${XDS_SERVER:-}" ]]; then
+  RUN_ARGS+=( -e "XDS_SERVER=$XDS_SERVER" )
+fi
+if [[ -n "${XDS_JWT:-}" ]]; then
+  RUN_ARGS+=( -e "XDS_JWT=$XDS_JWT" )
+  RUN_ARGS+=( -p 9901:9901 )
+  RUN_ARGS+=( -p 3128:3128 )
+  # TODO: import bright data and self-signed client proxy cert to chrome instead of ignore
+  CHROMIUM_FLAGS_DEFAULT="$CHROMIUM_FLAGS_DEFAULT --proxy-server=https://127.0.0.1:3128 --ignore-certificate-errors"
+fi
 
 # WebRTC port mapping
 if [[ "${ENABLE_WEBRTC:-}" == "true" ]]; then

--- a/images/chromium-headful/run-unikernel.sh
+++ b/images/chromium-headful/run-unikernel.sh
@@ -54,6 +54,20 @@ deploy_args=(
   -n "$NAME"
 )
 
+# Add XDS environment variables if provided
+if [[ -n "${INST_NAME:-}" ]]; then
+  deploy_args+=(-e "INST_NAME=$INST_NAME")
+fi
+if [[ -n "${METRO_NAME:-}" ]]; then
+  deploy_args+=(-e "METRO_NAME=$METRO_NAME")
+fi
+if [[ -n "${XDS_SERVER:-}" ]]; then
+  deploy_args+=(-e "XDS_SERVER=$XDS_SERVER")
+fi
+if [[ -n "${XDS_JWT:-}" ]]; then
+  deploy_args+=(-e "XDS_JWT=$XDS_JWT")
+fi
+
 if [[ "${ENABLE_WEBRTC:-}" == "true" ]]; then
   echo "Deploying with WebRTC enabled"
   kraft cloud inst create --start \

--- a/images/chromium-headful/wrapper.sh
+++ b/images/chromium-headful/wrapper.sh
@@ -195,6 +195,7 @@ supervisorctl -c /etc/supervisor/supervisord.conf start chromium
 echo "[wrapper] Waiting for Chromium remote debugging on 127.0.0.1:$INTERNAL_PORT..."
 for i in {1..100}; do
   if nc -z 127.0.0.1 "$INTERNAL_PORT" 2>/dev/null; then
+    echo "connected to chrome debugging port."
     break
   fi
   sleep 0.2

--- a/images/chromium-headful/wrapper.sh
+++ b/images/chromium-headful/wrapper.sh
@@ -148,6 +148,8 @@ fi
 sleep 0.2
 done
 
+init-envoy.sh
+
 echo "[wrapper] Starting Xorg via supervisord"
 supervisorctl -c /etc/supervisor/supervisord.conf start xorg
 echo "[wrapper] Waiting for Xorg to open display $DISPLAY..."

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -63,7 +63,8 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/
 RUN mkdir -p /etc/envoy/templates
 COPY shared/envoy/bootstrap.yaml /etc/envoy/templates/bootstrap.yaml
-COPY shared/envoy/default.yaml /etc/envoy/default.yaml
+# Copy default config to bootstrap.yaml so supervisor can start envoy immediately
+COPY shared/envoy/default.yaml /etc/envoy/bootstrap.yaml
 COPY shared/envoy/init-envoy.sh /usr/local/bin/init-envoy.sh
 RUN chmod +x /usr/local/bin/init-envoy.sh
 

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -48,20 +48,15 @@ RUN set -xe; \
     xvfb \
     x11-utils \
     software-properties-common \
-    supervisor;
+    supervisor \
+    libnss3-tools \
+    unzip;
 
-# Install Envoy proxy (official apt.envoyproxy.io) and add bootstrap configuration
-ENV ENVOY_PACKAGE=envoy-1.32
-RUN set -eux; \
-    mkdir -p /etc/apt/keyrings; \
-    curl -fsSL https://apt.envoyproxy.io/signing.key | gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg; \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io jammy main" > /etc/apt/sources.list.d/envoy.list; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends "${ENVOY_PACKAGE}" || (apt-cache policy "${ENVOY_PACKAGE}" envoy && exit 1); \
-    apt-mark hold "${ENVOY_PACKAGE}"; \
-    apt-get clean -y; \
-    rm -rf /var/lib/apt/lists/* /var/cache/apt/
-RUN mkdir -p /etc/envoy/templates
+# Install Envoy proxy and BrightData certificates
+COPY shared/envoy/install-proxy.sh /usr/local/bin/install-proxy.sh
+RUN chmod +x /usr/local/bin/install-proxy.sh && /usr/local/bin/install-proxy.sh && rm /usr/local/bin/install-proxy.sh
+
+# Copy Envoy configuration files
 COPY shared/envoy/bootstrap.yaml /etc/envoy/templates/bootstrap.yaml
 # Copy default config to bootstrap.yaml so supervisor can start envoy immediately
 COPY shared/envoy/default.yaml /etc/envoy/bootstrap.yaml

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -50,6 +50,23 @@ RUN set -xe; \
     software-properties-common \
     supervisor;
 
+# Install Envoy proxy (official apt.envoyproxy.io) and add bootstrap configuration
+ENV ENVOY_PACKAGE=envoy-1.32
+RUN set -eux; \
+    mkdir -p /etc/apt/keyrings; \
+    curl -fsSL https://apt.envoyproxy.io/signing.key | gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io jammy main" > /etc/apt/sources.list.d/envoy.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends "${ENVOY_PACKAGE}" || (apt-cache policy "${ENVOY_PACKAGE}" envoy && exit 1); \
+    apt-mark hold "${ENVOY_PACKAGE}"; \
+    apt-get clean -y; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/
+RUN mkdir -p /etc/envoy/templates
+COPY shared/envoy/bootstrap.yaml /etc/envoy/templates/bootstrap.yaml
+COPY shared/envoy/default.yaml /etc/envoy/default.yaml
+COPY shared/envoy/init-envoy.sh /usr/local/bin/init-envoy.sh
+RUN chmod +x /usr/local/bin/init-envoy.sh
+
 # install chromium and sqlite3 for debugging the cookies file
 RUN add-apt-repository -y ppa:xtradeb/apps
 RUN apt update -y && apt install -y chromium sqlite3
@@ -83,6 +100,7 @@ COPY images/chromium-headless/image/wrapper.sh /usr/bin/wrapper.sh
 # Supervisord configuration
 COPY images/chromium-headless/image/supervisord.conf /etc/supervisor/supervisord.conf
 COPY images/chromium-headless/image/supervisor/services/ /etc/supervisor/conf.d/services/
+COPY shared/envoy/supervisor-envoy.conf /etc/supervisor/conf.d/services/envoy.conf
 
 # Copy the kernel-images API binary built in the builder stage
 COPY --from=server-builder /out/kernel-images-api /usr/local/bin/kernel-images-api

--- a/images/chromium-headless/image/wrapper.sh
+++ b/images/chromium-headless/image/wrapper.sh
@@ -194,6 +194,8 @@ for i in {1..30}; do
   sleep 0.2
 done
 
+init-envoy.sh
+
 echo "[wrapper] Starting system D-Bus daemon via supervisord"
 supervisorctl -c /etc/supervisor/supervisord.conf start dbus
 for i in {1..50}; do

--- a/server/e2e/e2e_chromium_test.go
+++ b/server/e2e/e2e_chromium_test.go
@@ -132,9 +132,6 @@ func runChromiumUserDataSavingFlow(t *testing.T, image, containerName string) {
 	if strings.Contains(image, "headful") {
 		// headless image sets its own flags, so only do this for headful
 		env["CHROMIUM_FLAGS"] = "--no-sandbox --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=* --no-zygote --password-store=basic --no-first-run --proxy-server=http://127.0.0.1:3128"
-	} else {
-		// headless image respects CHROMIUM_FLAGS env var
-		env["CHROMIUM_FLAGS"] = "--proxy-server=http://127.0.0.1:3128"
 	}
 	logger.Info("[setup]", "action", "starting container", "image", image, "name", containerName)
 	_, exitCh, err := runContainer(baseCtx, image, containerName, env)

--- a/server/e2e/e2e_chromium_test.go
+++ b/server/e2e/e2e_chromium_test.go
@@ -131,7 +131,7 @@ func runChromiumUserDataSavingFlow(t *testing.T, image, containerName string) {
 	}
 	if strings.Contains(image, "headful") {
 		// headless image sets its own flags, so only do this for headful
-		env["CHROMIUM_FLAGS"] = "--no-sandbox --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=* --no-zygote --password-store=basic --no-first-run --proxy-server=http://127.0.0.1:3128"
+		env["CHROMIUM_FLAGS"] = "--no-sandbox --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=* --no-zygote --password-store=basic --no-first-run"
 	}
 	logger.Info("[setup]", "action", "starting container", "image", image, "name", containerName)
 	_, exitCh, err := runContainer(baseCtx, image, containerName, env)

--- a/server/e2e/e2e_chromium_test.go
+++ b/server/e2e/e2e_chromium_test.go
@@ -131,7 +131,10 @@ func runChromiumUserDataSavingFlow(t *testing.T, image, containerName string) {
 	}
 	if strings.Contains(image, "headful") {
 		// headless image sets its own flags, so only do this for headful
-		env["CHROMIUM_FLAGS"] = "--no-sandbox --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=* --no-zygote --password-store=basic --no-first-run"
+		env["CHROMIUM_FLAGS"] = "--no-sandbox --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=* --no-zygote --password-store=basic --no-first-run --proxy-server=http://127.0.0.1:3128"
+	} else {
+		// headless image respects CHROMIUM_FLAGS env var
+		env["CHROMIUM_FLAGS"] = "--proxy-server=http://127.0.0.1:3128"
 	}
 	logger.Info("[setup]", "action", "starting container", "image", image, "name", containerName)
 	_, exitCh, err := runContainer(baseCtx, image, containerName, env)

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -1,16 +1,27 @@
+# Envoy bootstrap configuration for xDS-managed proxy
+# This config connects to a control plane for dynamic configuration management
+# Requires: INST_NAME, METRO_NAME, XDS_SERVER, XDS_JWT environment variables
+
+# Node identity sent to xDS server for configuration targeting, authenticated by JWT
 node:
   id: "{INSTANCE_NAME}-{METRO_NAME}"
 
+# Dynamic configuration via xDS protocol
 dynamic_resources:
+  # Aggregated Discovery Service - single gRPC stream for all config types
   ads_config:
     api_type: GRPC
     transport_api_version: V3
     grpc_services:
     - envoy_grpc:
+        # Reference to xDS server cluster below
         cluster_name: xds_server
+    # Send JWT authentication for all xDS requests
     initial_metadata:
     - key: "authorization"
       value: "Bearer {XDS_JWT}"
+  
+  # Listener Discovery Service and Cluster Discovery Service use ADS
   lds_config:
     ads: {}
     resource_api_version: V3
@@ -18,15 +29,20 @@ dynamic_resources:
     ads: {}
     resource_api_version: V3
 
+# Static configuration (always present)
 static_resources:
   clusters:
+  # xDS server: control plane for configuration
   - name: xds_server
+    # Resolve hostname via DNS, for DNS lookup
     type: STRICT_DNS
     connect_timeout: 2s
     http2_protocol_options: {}
+    # TLS configuration for secure xDS connection
     transport_socket:
       name: envoy.transport_sockets.tls
       typed_config:
+        # Uses TLS to verify xDS server, and SNI hostname for TLS handshake
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: {XDS_SERVER}
     load_assignment:
@@ -39,10 +55,9 @@ static_resources:
                 address: {XDS_SERVER}
                 port_value: 443
 
+# Envoy admin interface for debugging
 admin:
   address:
     socket_address:
       address: 127.0.0.1
       port_value: 9901
-
-

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -1,0 +1,40 @@
+node:
+  id: "{INSTANCE_NAME}-{METRO_NAME}"
+
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    transport_api_version: V3
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_server
+  lds_config:
+    ads: {}
+    resource_api_version: V3
+  cds_config:
+    ads: {}
+    resource_api_version: V3
+
+static_resources:
+  clusters:
+  - name: xds_server
+    type: STRICT_DNS
+    connect_timeout: 2s
+    http2_protocol_options: {}
+    load_assignment:
+      cluster_name: xds_server
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: control-plane
+                port_value: 18000
+
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9901
+
+

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -5,7 +5,7 @@
 # Node identity sent to xDS server for configuration targeting, authenticated by JWT
 node:
   id: "{INST_NAME}-{METRO_NAME}"
-  cluster: "{INST_NAME}-{METRO_NAME}"
+  cluster: "kernel"
 
 # Dynamic configuration via xDS protocol
 dynamic_resources:

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -16,10 +16,10 @@ dynamic_resources:
     - envoy_grpc:
         # Reference to xDS server cluster below
         cluster_name: xds_server
-    # Send JWT authentication for all xDS requests
-    initial_metadata:
-    - key: "authorization"
-      value: "Bearer {XDS_JWT}"
+      # Send JWT authentication for all xDS requests
+      initial_metadata:
+      - key: "authorization"
+        value: "Bearer {XDS_JWT}"
   
   # Listener Discovery Service and Cluster Discovery Service use ADS
   lds_config:

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -17,6 +17,7 @@ dynamic_resources:
     - envoy_grpc:
         # Reference to xDS server cluster below
         cluster_name: xds_server
+      authority: "{XDS_SERVER}"
       # Send JWT authentication for all xDS requests
       initial_metadata:
       - key: "authorization"

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -17,7 +17,7 @@ dynamic_resources:
     - envoy_grpc:
         # Reference to xDS server cluster below
         cluster_name: xds_server
-      authority: "{XDS_SERVER}"
+        authority: "{XDS_SERVER}"
       # Send JWT authentication for all xDS requests
       initial_metadata:
       - key: "authorization"

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -5,6 +5,7 @@
 # Node identity sent to xDS server for configuration targeting, authenticated by JWT
 node:
   id: "{INST_NAME}-{METRO_NAME}"
+  cluster: "{INST_NAME}-{METRO_NAME}"
 
 # Dynamic configuration via xDS protocol
 dynamic_resources:
@@ -37,7 +38,6 @@ static_resources:
     # Resolve hostname via DNS, for DNS lookup
     type: STRICT_DNS
     connect_timeout: 2s
-    http2_protocol_options: {}
     # TLS configuration for secure xDS connection
     transport_socket:
       name: envoy.transport_sockets.tls

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -37,7 +37,7 @@ static_resources:
             address:
               socket_address:
                 address: {XDS_SERVER}
-                port_value: 18000
+                port_value: 443
 
 admin:
   address:

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -8,6 +8,9 @@ dynamic_resources:
     grpc_services:
     - envoy_grpc:
         cluster_name: xds_server
+    initial_metadata:
+    - key: "authorization"
+      value: "Bearer {XDS_JWT}"
   lds_config:
     ads: {}
     resource_api_version: V3
@@ -21,6 +24,11 @@ static_resources:
     type: STRICT_DNS
     connect_timeout: 2s
     http2_protocol_options: {}
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        sni: {XDS_SERVER}
     load_assignment:
       cluster_name: xds_server
       endpoints:
@@ -28,7 +36,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: control-plane
+                address: {XDS_SERVER}
                 port_value: 18000
 
 admin:

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -39,6 +39,8 @@ static_resources:
     # Resolve hostname via DNS, for DNS lookup
     type: STRICT_DNS
     connect_timeout: 2s
+    http2_protocol_options: {}
+    dns_lookup_family: V4_ONLY
     # TLS configuration for secure xDS connection
     transport_socket:
       name: envoy.transport_sockets.tls
@@ -60,5 +62,5 @@ static_resources:
 admin:
   address:
     socket_address:
-      address: 127.0.0.1
+      address: 0.0.0.0
       port_value: 9901

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -4,7 +4,7 @@
 
 # Node identity sent to xDS server for configuration targeting, authenticated by JWT
 node:
-  id: "{INSTANCE_NAME}-{METRO_NAME}"
+  id: "{INST_NAME}-{METRO_NAME}"
 
 # Dynamic configuration via xDS protocol
 dynamic_resources:

--- a/shared/envoy/bootstrap.yaml
+++ b/shared/envoy/bootstrap.yaml
@@ -58,9 +58,9 @@ static_resources:
                 address: {XDS_SERVER}
                 port_value: 443
 
-# Envoy admin interface for debugging
-admin:
-  address:
-    socket_address:
-      address: 0.0.0.0
-      port_value: 9901
+# Enable Envoy admin interface for debugging locally
+# admin:
+#   address:
+#     socket_address:
+#       address: 0.0.0.0
+#       port_value: 9901

--- a/shared/envoy/default.yaml
+++ b/shared/envoy/default.yaml
@@ -1,0 +1,71 @@
+static_resources:
+  listeners:
+    - name: http_explicit_forward_proxy
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 3128
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: hcm
+                normalize_path: true
+                http_filters:
+                  - name: envoy.filters.http.dynamic_forward_proxy
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
+                      dns_cache_config:
+                        name: local_dns_cache
+                        dns_lookup_family: V4_ONLY
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: forward_proxy
+                      domains: ["*"]
+                      routes:
+                        - match: { connect_matcher: {} }
+                          route:
+                            cluster: dynamic_forward_proxy_cluster
+                            upgrade_configs:
+                              - upgrade_type: CONNECT
+                                connect_config: {}
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: dynamic_forward_proxy_cluster
+                access_log:
+                  - name: envoy.access_loggers.stdout
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+                      log_format:
+                        text_format: "[%START_TIME%] %DOWNSTREAM_REMOTE_ADDRESS% %REQ(:method)% %REQ(:authority)% %REQ(:path)% -> %RESPONSE_CODE% (%BYTES_SENT%b) %DURATION%ms %RESPONSE_FLAGS% %UPSTREAM_TRANSPORT_FAILURE_REASON%\n"
+
+  clusters:
+    - name: dynamic_forward_proxy_cluster
+      connect_timeout: 5s
+      lb_policy: CLUSTER_PROVIDED
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http_protocol_options: {}
+          upstream_http_protocol_options:
+            auto_sni: true
+            auto_san_validation: true
+      cluster_type:
+        name: envoy.clusters.dynamic_forward_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+          dns_cache_config:
+            name: local_dns_cache
+            dns_lookup_family: V4_ONLY
+
+admin:
+  address:
+    socket_address: { address: 127.0.0.1, port_value: 9901 }
+
+

--- a/shared/envoy/default.yaml
+++ b/shared/envoy/default.yaml
@@ -1,24 +1,38 @@
+# HTTP forward proxy, direct egress to internet
 static_resources:
   listeners:
     - name: http_explicit_forward_proxy
       address:
+        # e.g. on chromium, set --proxy-server=http://127.0.0.1:3128
         socket_address:
           address: 0.0.0.0
           port_value: 3128
       filter_chains:
+        # One filter chain for HTTP/1.1 proxy traffic
         - filters:
+            # HTTP Connection Manager filter:
+            # this is handling the connection between the client and the proxy,
+            # which is an HTTP connection.
             - name: envoy.filters.network.http_connection_manager
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                 stat_prefix: hcm
                 normalize_path: true
+                # Enable forward proxy behavior
                 http_filters:
+                  # Dynamic Forward Proxy filter: resolves upstreams on-the-fly and caches DNS
+                  # Browsers send CONNECT to this proxy to tunnel HTTPS upstreams
+                  # e.g. CONNECT target.example.com
+                  # Envoy establishes a TCP tunnel to the target.
                   - name: envoy.filters.http.dynamic_forward_proxy
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
                       dns_cache_config:
                         name: local_dns_cache
                         dns_lookup_family: V4_ONLY
+                  # Router filter: actually routes/tunnels the request once target is known
+                  # See what happens here down in route_config, slightly different
+                  # for HTTPS vs HTTP upstream requests.
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -28,22 +42,35 @@ static_resources:
                     - name: forward_proxy
                       domains: ["*"]
                       routes:
+                        # === HTTPS upstream traffic (CONNECT tunnel) ===
+                        # Handle CONNECT method for HTTPS tunneling (creates TCP tunnel)
+                        # 'connect_matcher' is a special matcher that matches CONNECT requests
+                        # "Note that CONNECT support is currently considered alpha in Envoy."
+                        # https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routematch-connect-matcher
                         - match: { connect_matcher: {} }
                           route:
+                            # Use single DFP cluster; CONNECT handled via connect_config
                             cluster: dynamic_forward_proxy_cluster
+                            # This tells Envoy to upgrade the connection to a TCP tunnel
+                            # which we only do after getting the CONNECT request.
                             upgrade_configs:
                               - upgrade_type: CONNECT
                                 connect_config: {}
+                        # === HTTP upstream traffic (absolute-form proxy) ===
+                        # The client didn't send CONNECT, because it's an HTTP request.
                         - match: { prefix: "/" }
                           route:
+                            # Same cluster for HTTP proxying
                             cluster: dynamic_forward_proxy_cluster
                 access_log:
+                  # Access log sink: print one line per request to stdout
                   - name: envoy.access_loggers.stdout
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
                       log_format:
                         text_format: "[%START_TIME%] %DOWNSTREAM_REMOTE_ADDRESS% %REQ(:method)% %REQ(:authority)% %REQ(:path)% -> %RESPONSE_CODE% (%BYTES_SENT%b) %DURATION%ms %RESPONSE_FLAGS% %UPSTREAM_TRANSPORT_FAILURE_REASON%\n"
 
+  # Connection pooling / load balancing to target(s)
   clusters:
     - name: dynamic_forward_proxy_cluster
       connect_timeout: 5s
@@ -64,8 +91,8 @@ static_resources:
             name: local_dns_cache
             dns_lookup_family: V4_ONLY
 
+# Admin interface for debugging and monitoring
 admin:
   address:
+    # Admin interface (metrics, config dump, clusters, listeners). Not exposed publicly.
     socket_address: { address: 127.0.0.1, port_value: 9901 }
-
-

--- a/shared/envoy/init-envoy.sh
+++ b/shared/envoy/init-envoy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -o pipefail -o errexit -o nounset
+
+echo "[envoy-init] Preparing Envoy bootstrap configuration"
+mkdir -p /etc/envoy
+
+render_from_template=false
+if [[ -f /etc/envoy/templates/bootstrap.yaml && -n "${INST_NAME:-}" && -n "${METRO_NAME:-}" ]]; then
+  render_from_template=true
+fi
+
+if $render_from_template; then
+  inst_esc=$(printf '%s' "$INST_NAME" | sed -e 's/[\/&]/\\&/g')
+  metro_esc=$(printf '%s' "$METRO_NAME" | sed -e 's/[\/&]/\\&/g')
+  sed -e "s|{INSTANCE_NAME}|$inst_esc|g" \
+      -e "s|{METRO_NAME}|$metro_esc|g" \
+      /etc/envoy/templates/bootstrap.yaml > /etc/envoy/bootstrap.yaml
+else
+  cp -f /etc/envoy/default.yaml /etc/envoy/bootstrap.yaml
+fi
+
+echo "[envoy-init] Starting Envoy via supervisord"
+supervisorctl -c /etc/supervisor/supervisord.conf start envoy
+echo "[envoy-init] Waiting for Envoy admin on 127.0.0.1:9901..."
+for i in {1..50}; do
+  if (echo >/dev/tcp/127.0.0.1/9901) >/dev/null 2>&1; then
+    echo "[envoy-init] Envoy is started"
+    break
+  fi
+  sleep 0.1
+  if [[ $i -eq 50 ]]; then
+    echo "[envoy-init] Failed to start Envoy - admin interface not responding after 5 seconds"
+  fi
+done

--- a/shared/envoy/init-envoy.sh
+++ b/shared/envoy/init-envoy.sh
@@ -55,8 +55,10 @@ if [[ -d /etc/envoy/brightdata ]] && [[ -n "$(ls -A /etc/envoy/brightdata/*.crt 
     # Add to NSS database
     if [[ $RUN_AS_ROOT == "true" ]]; then
       certutil -d /root/.pki/nssdb -A -t "C,," -n "BrightData $cert_name" -i "$cert" 2>&1 | sed 's/^/[envoy-init] /'
+      echo "[envoy-init] Certificate added to nssdb as root"
     else
       certutil -d /home/kernel/.pki/nssdb -A -t "C,," -n "BrightData $cert_name" -i "$cert" 2>&1 | sed 's/^/[envoy-init] /'
+      echo "[envoy-init] Certificate added to nssdb as kernel"
     fi
   done
   

--- a/shared/envoy/init-envoy.sh
+++ b/shared/envoy/init-envoy.sh
@@ -11,12 +11,14 @@ if [[ -f /etc/envoy/templates/bootstrap.yaml && -n "${INST_NAME:-}" && -n "${MET
 fi
 
 if $render_from_template; then
+  echo "[envoy-init] Rendering template with INST_NAME=${INST_NAME} and METRO_NAME=${METRO_NAME}"
   inst_esc=$(printf '%s' "$INST_NAME" | sed -e 's/[\/&]/\\&/g')
   metro_esc=$(printf '%s' "$METRO_NAME" | sed -e 's/[\/&]/\\&/g')
   sed -e "s|{INSTANCE_NAME}|$inst_esc|g" \
       -e "s|{METRO_NAME}|$metro_esc|g" \
       /etc/envoy/templates/bootstrap.yaml > /etc/envoy/bootstrap.yaml
 else
+  echo "[envoy-init] Using default configuration (template vars not provided)"
   cp -f /etc/envoy/default.yaml /etc/envoy/bootstrap.yaml
 fi
 

--- a/shared/envoy/init-envoy.sh
+++ b/shared/envoy/init-envoy.sh
@@ -25,7 +25,7 @@ if [[ ! -f /etc/envoy/certs/proxy.crt || ! -f /etc/envoy/certs/proxy.key ]]; the
  cp /etc/envoy/certs/proxy.crt /kernel-envoy-proxy.crt
  update-ca-certificates 2>&1 | sed 's/^/[envoy-init] /'
  echo "[envoy-init] Certificate added to system trust store"
- if [[ $RUN_AS_ROOT == "true" ]]; then
+if [[ "${RUN_AS_ROOT:-}" == "true" ]]; then
     mkdir -p /root/.pki/nssdb
     certutil -d /root/.pki/nssdb -N --empty-password 2>/dev/null || true
     certutil -d /root/.pki/nssdb -A -t "C,," -n "Kernel Envoy Proxy" -i /etc/envoy/certs/proxy.crt
@@ -53,7 +53,7 @@ if [[ -d /etc/envoy/brightdata ]] && [[ -n "$(ls -A /etc/envoy/brightdata/*.crt 
     cp "$cert" "/usr/local/share/ca-certificates/brightdata-${cert_name}.crt"
     
     # Add to NSS database
-    if [[ $RUN_AS_ROOT == "true" ]]; then
+    if [[ "${RUN_AS_ROOT:-}" == "true" ]]; then
       certutil -d /root/.pki/nssdb -A -t "C,," -n "BrightData $cert_name" -i "$cert" 2>&1 | sed 's/^/[envoy-init] /'
       echo "[envoy-init] Certificate added to nssdb as root"
     else

--- a/shared/envoy/init-envoy.sh
+++ b/shared/envoy/init-envoy.sh
@@ -16,13 +16,13 @@ if $render_from_template; then
   metro_esc=$(printf '%s' "$METRO_NAME" | sed -e 's/[\/&]/\\&/g')
   xds_esc=$(printf '%s' "$XDS_SERVER" | sed -e 's/[\/&]/\\&/g')
   jwt_esc=$(printf '%s' "$XDS_JWT" | sed -e 's/[\/&]/\\&/g')
-  sed -e "s|{INSTANCE_NAME}|$inst_esc|g" \
+  sed -e "s|{INST_NAME}|$inst_esc|g" \
       -e "s|{METRO_NAME}|$metro_esc|g" \
       -e "s|{XDS_SERVER}|$xds_esc|g" \
       -e "s|{XDS_JWT}|$jwt_esc|g" \
       /etc/envoy/templates/bootstrap.yaml > /etc/envoy/bootstrap.yaml
 else
-  echo "[envoy-init] Using default configuration (template vars not provided: INST_NAME=${INST_NAME:-unset}, METRO_NAME=${METRO_NAME:-unset}, XDS_SERVER=${XDS_SERVER:-unset}, XDS_JWT=${XDS_JWT:+set}${XDS_JWT:-unset})"
+  echo "[envoy-init] Using default configuration (template vars not provided: INST_NAME=${INST_NAME:-unset}, METRO_NAME=${METRO_NAME:-unset}, XDS_SERVER=${XDS_SERVER:-unset}, XDS_JWT)"
 fi
 
 echo "[envoy-init] Starting Envoy via supervisord"

--- a/shared/envoy/init-envoy.sh
+++ b/shared/envoy/init-envoy.sh
@@ -6,19 +6,23 @@ echo "[envoy-init] Preparing Envoy bootstrap configuration"
 mkdir -p /etc/envoy
 
 render_from_template=false
-if [[ -f /etc/envoy/templates/bootstrap.yaml && -n "${INST_NAME:-}" && -n "${METRO_NAME:-}" ]]; then
+if [[ -f /etc/envoy/templates/bootstrap.yaml && -n "${INST_NAME:-}" && -n "${METRO_NAME:-}" && -n "${XDS_SERVER:-}" && -n "${XDS_JWT:-}" ]]; then
   render_from_template=true
 fi
 
 if $render_from_template; then
-  echo "[envoy-init] Rendering template with INST_NAME=${INST_NAME} and METRO_NAME=${METRO_NAME}"
+  echo "[envoy-init] Rendering template with INST_NAME=${INST_NAME}, METRO_NAME=${METRO_NAME}, XDS_SERVER=${XDS_SERVER}, XDS_JWT=***"
   inst_esc=$(printf '%s' "$INST_NAME" | sed -e 's/[\/&]/\\&/g')
   metro_esc=$(printf '%s' "$METRO_NAME" | sed -e 's/[\/&]/\\&/g')
+  xds_esc=$(printf '%s' "$XDS_SERVER" | sed -e 's/[\/&]/\\&/g')
+  jwt_esc=$(printf '%s' "$XDS_JWT" | sed -e 's/[\/&]/\\&/g')
   sed -e "s|{INSTANCE_NAME}|$inst_esc|g" \
       -e "s|{METRO_NAME}|$metro_esc|g" \
+      -e "s|{XDS_SERVER}|$xds_esc|g" \
+      -e "s|{XDS_JWT}|$jwt_esc|g" \
       /etc/envoy/templates/bootstrap.yaml > /etc/envoy/bootstrap.yaml
 else
-  echo "[envoy-init] Using default configuration (template vars INST_NAME and METRO_NAME not provided)"
+  echo "[envoy-init] Using default configuration (template vars not provided: INST_NAME=${INST_NAME:-unset}, METRO_NAME=${METRO_NAME:-unset}, XDS_SERVER=${XDS_SERVER:-unset}, XDS_JWT=${XDS_JWT:+***}${XDS_JWT:-unset})"
 fi
 
 echo "[envoy-init] Starting Envoy via supervisord"

--- a/shared/envoy/init-envoy.sh
+++ b/shared/envoy/init-envoy.sh
@@ -18,8 +18,7 @@ if $render_from_template; then
       -e "s|{METRO_NAME}|$metro_esc|g" \
       /etc/envoy/templates/bootstrap.yaml > /etc/envoy/bootstrap.yaml
 else
-  echo "[envoy-init] Using default configuration (template vars not provided)"
-  cp -f /etc/envoy/default.yaml /etc/envoy/bootstrap.yaml
+  echo "[envoy-init] Using default configuration (template vars INST_NAME and METRO_NAME not provided)"
 fi
 
 echo "[envoy-init] Starting Envoy via supervisord"

--- a/shared/envoy/init-envoy.sh
+++ b/shared/envoy/init-envoy.sh
@@ -95,14 +95,3 @@ sed -e "s|{INST_NAME}|$inst_esc|g" \
 
 echo "[envoy-init] Starting Envoy via supervisord"
 supervisorctl -c /etc/supervisor/supervisord.conf start envoy
-echo "[envoy-init] Waiting for Envoy admin on 127.0.0.1:9901..."
-for i in {1..50}; do
-  if (echo >/dev/tcp/127.0.0.1/9901) >/dev/null 2>&1; then
-    echo "[envoy-init] Envoy is started"
-    break
-  fi
-  sleep 0.1
-  if [[ $i -eq 50 ]]; then
-    echo "[envoy-init] Failed to start Envoy - admin interface not responding after 5 seconds"
-  fi
-done

--- a/shared/envoy/init-envoy.sh
+++ b/shared/envoy/init-envoy.sh
@@ -5,8 +5,6 @@ set -o pipefail -o errexit -o nounset
 # Check for required environment variables, to see if envoy is enabled
 if [[ -z "${INST_NAME:-}" || -z "${METRO_NAME:-}" || -z "${XDS_SERVER:-}" || -z "${XDS_JWT:-}" ]]; then
   echo "[envoy-init] Required environment variables not set. Skipping Envoy initialization."
-  echo "[envoy-init] Required: INST_NAME, METRO_NAME, XDS_SERVER, XDS_JWT"
-  echo "[envoy-init] Current values: INST_NAME=${INST_NAME:-unset}, METRO_NAME=${METRO_NAME:-unset}, XDS_SERVER=${XDS_SERVER:-unset}, XDS_JWT=***"
   exit 0
 fi
 

--- a/shared/envoy/init-envoy.sh
+++ b/shared/envoy/init-envoy.sh
@@ -22,7 +22,7 @@ if $render_from_template; then
       -e "s|{XDS_JWT}|$jwt_esc|g" \
       /etc/envoy/templates/bootstrap.yaml > /etc/envoy/bootstrap.yaml
 else
-  echo "[envoy-init] Using default configuration (template vars not provided: INST_NAME=${INST_NAME:-unset}, METRO_NAME=${METRO_NAME:-unset}, XDS_SERVER=${XDS_SERVER:-unset}, XDS_JWT=${XDS_JWT:+***}${XDS_JWT:-unset})"
+  echo "[envoy-init] Using default configuration (template vars not provided: INST_NAME=${INST_NAME:-unset}, METRO_NAME=${METRO_NAME:-unset}, XDS_SERVER=${XDS_SERVER:-unset}, XDS_JWT=${XDS_JWT:+set}${XDS_JWT:-unset})"
 fi
 
 echo "[envoy-init] Starting Envoy via supervisord"

--- a/shared/envoy/install-proxy.sh
+++ b/shared/envoy/install-proxy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -eux
+
+# Install Envoy proxy (official apt.envoyproxy.io)
+ENVOY_PACKAGE="${ENVOY_PACKAGE:-envoy-1.32}"
+
+echo "Installing Envoy proxy package: ${ENVOY_PACKAGE}"
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://apt.envoyproxy.io/signing.key | gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io jammy main" > /etc/apt/sources.list.d/envoy.list
+apt-get update
+apt-get install -y --no-install-recommends "${ENVOY_PACKAGE}" || (apt-cache policy "${ENVOY_PACKAGE}" envoy && exit 1)
+apt-mark hold "${ENVOY_PACKAGE}"
+apt-get clean -y
+rm -rf /var/lib/apt/lists/* /var/cache/apt/
+
+# Create directory structure for Envoy configuration
+mkdir -p /etc/envoy/templates
+
+# Download and extract BrightData proxy certificate
+echo "Downloading and extracting BrightData certificates"
+mkdir -p /etc/envoy/brightdata
+curl -fsSL https://brightdata.com/static/brightdata_proxy_ca.zip -o /tmp/brightdata_proxy_ca.zip
+unzip -j /tmp/brightdata_proxy_ca.zip '*/*.crt' -d /etc/envoy/brightdata/ || true
+rm /tmp/brightdata_proxy_ca.zip
+echo "BrightData certificates extracted to /etc/envoy/brightdata/"
+
+# List extracted certificates for verification
+ls -la /etc/envoy/brightdata/

--- a/shared/envoy/supervisor-envoy.conf
+++ b/shared/envoy/supervisor-envoy.conf
@@ -1,5 +1,5 @@
 [program:envoy]
-command=/bin/bash -lc 'set -e; args="-c /etc/envoy/bootstrap.yaml --log-level ${ENVOY_LOG_LEVEL:-info}"; [ -n "${ENVOY_NODE_ID:-}" ] && args="$args --service-node=${ENVOY_NODE_ID}"; [ -n "${ENVOY_CLUSTER:-}" ] && args="$args --service-cluster=${ENVOY_CLUSTER}"; exec envoy $args'
+command=/bin/bash -lc 'set -e; args="-c /etc/envoy/bootstrap.yaml --log-level ${ENVOY_LOG_LEVEL:-warning}"; [ -n "${ENVOY_NODE_ID:-}" ] && args="$args --service-node=${ENVOY_NODE_ID}"; [ -n "${ENVOY_CLUSTER:-}" ] && args="$args --service-cluster=${ENVOY_CLUSTER}"; exec envoy $args'
 autostart=false
 autorestart=true
 startsecs=2

--- a/shared/envoy/supervisor-envoy.conf
+++ b/shared/envoy/supervisor-envoy.conf
@@ -1,5 +1,5 @@
 [program:envoy]
-command=/bin/bash -lc 'set -e; args="-c /etc/envoy/bootstrap.yaml --log-level ${ENVOY_LOG_LEVEL:-warning}"; [ -n "${ENVOY_NODE_ID:-}" ] && args="$args --service-node=${ENVOY_NODE_ID}"; [ -n "${ENVOY_CLUSTER:-}" ] && args="$args --service-cluster=${ENVOY_CLUSTER}"; exec envoy $args'
+command=envoy -c /etc/envoy/bootstrap.yaml --log-level ${ENVOY_LOG_LEVEL:-warning}
 autostart=false
 autorestart=true
 startsecs=2

--- a/shared/envoy/supervisor-envoy.conf
+++ b/shared/envoy/supervisor-envoy.conf
@@ -1,5 +1,5 @@
 [program:envoy]
-command=envoy -c /etc/envoy/bootstrap.yaml --log-level info
+command=envoy -c /etc/envoy/bootstrap.yaml --log-level warn
 autostart=false
 autorestart=true
 startsecs=2

--- a/shared/envoy/supervisor-envoy.conf
+++ b/shared/envoy/supervisor-envoy.conf
@@ -1,5 +1,5 @@
 [program:envoy]
-command=envoy -c /etc/envoy/bootstrap.yaml --log-level ${ENVOY_LOG_LEVEL:-warning}
+command=envoy -c /etc/envoy/bootstrap.yaml --log-level warning
 autostart=false
 autorestart=true
 startsecs=2

--- a/shared/envoy/supervisor-envoy.conf
+++ b/shared/envoy/supervisor-envoy.conf
@@ -1,5 +1,5 @@
 [program:envoy]
-command=/bin/bash -lc 'set -e; args="-c /etc/envoy/bootstrap.yaml --log-level ${ENVOY_LOG_LEVEL:-info}"; [ -n "${ENVOY_NODE_ID:-}" ] && args="$args --service-node=${ENVOY_NODE_ID}"; [ -n "${ENVOY_CLUSTER:-}" ] && args="$args --service-cluster=${ENVOY_CLUSTER}"; exec envoy-1.32 $args'
+command=/bin/bash -lc 'set -e; args="-c /etc/envoy/bootstrap.yaml --log-level ${ENVOY_LOG_LEVEL:-info}"; [ -n "${ENVOY_NODE_ID:-}" ] && args="$args --service-node=${ENVOY_NODE_ID}"; [ -n "${ENVOY_CLUSTER:-}" ] && args="$args --service-cluster=${ENVOY_CLUSTER}"; exec envoy $args'
 autostart=false
 autorestart=true
 startsecs=2

--- a/shared/envoy/supervisor-envoy.conf
+++ b/shared/envoy/supervisor-envoy.conf
@@ -1,0 +1,9 @@
+[program:envoy]
+command=/bin/bash -lc 'set -e; args="-c /etc/envoy/bootstrap.yaml --log-level ${ENVOY_LOG_LEVEL:-info}"; [ -n "${ENVOY_NODE_ID:-}" ] && args="$args --service-node=${ENVOY_NODE_ID}"; [ -n "${ENVOY_CLUSTER:-}" ] && args="$args --service-cluster=${ENVOY_CLUSTER}"; exec envoy-1.32 $args'
+autostart=false
+autorestart=true
+startsecs=2
+stdout_logfile=/var/log/supervisord/envoy
+redirect_stderr=true
+
+

--- a/shared/envoy/supervisor-envoy.conf
+++ b/shared/envoy/supervisor-envoy.conf
@@ -1,5 +1,5 @@
 [program:envoy]
-command=envoy -c /etc/envoy/bootstrap.yaml --log-level warning
+command=envoy -c /etc/envoy/bootstrap.yaml --log-level info
 autostart=false
 autorestart=true
 startsecs=2


### PR DESCRIPTION
Install Envoy in the Kernel browser image.

- Default and template configuration
- Default is direct-mode proxy, static configuration
- Template configuration applied when `INST_NAME` and `METRO_NAME` provided
- e2e tests adjusted to use the local proxy, default configuration

---

<!-- mesa-description-start -->
## TL;DR

Installs and configures Envoy in the browser images to act as a local proxy for dynamic traffic routing.

## Why we made these changes

To create a flexible networking layer for browser instances. By routing all egress traffic through a local Envoy proxy, we can dynamically configure traffic routing based on the deployment environment (e.g., connecting to different backend services using `INST_NAME` and `METRO_NAME`). This avoids hardcoding network paths in the browser image itself.

## What changed?

- **Envoy Installation & Process Management:**
  - Added a shared `install-proxy.sh` script to install Envoy via APT.
  - Added `supervisor-envoy.conf` to manage the Envoy process with `supervisord`.
  - Updated `chromium-headful` and `chromium-headless` Dockerfiles to run the installation.
- **Dynamic Configuration:**
  - A new `init-envoy.sh` script runs on container startup to configure Envoy.
  - If `INST_NAME` and `METRO_NAME` environment variables are present, it uses a dynamic `bootstrap.yaml` template for xDS.
  - Otherwise, it falls back to a static `default.yaml` config that sets up a direct-mode forward proxy.
- **Browser & Test Integration:**
  - Startup scripts (`run-docker.sh`, `wrapper.sh`) were updated to initialize Envoy.
  - Chromium is now launched with the `--proxy-server=http://127.0.0.1:3128` flag to route all traffic through the local Envoy instance.
  - E2E tests were updated to work with the new default proxy configuration.
- **Documentation:**
  - The `README.md` was updated with a "Proxy configuration" section explaining the new setup.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->