### PR TITLE
upgrade neko

### DIFF
--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -47,7 +47,7 @@ RUN set -eux; \
     make -j$(nproc); \
     make install;
 
-FROM ghcr.io/onkernel/neko/base:3.0.6-v1.0.1 AS neko
+FROM ghcr.io/onkernel/neko/base:3.0.8-v1.1.0 AS neko
 # ^--- now has event.SYSTEM_PONG with legacy support to keepalive
 FROM docker.io/ubuntu:22.04
 

--- a/images/chromium-headful/neko.yaml
+++ b/images/chromium-headful/neko.yaml
@@ -47,3 +47,6 @@ chat:
 
 filetransfer:
   enabled: false
+
+scaletozero:
+  enabled: true


### PR DESCRIPTION
Pull in https://github.com/onkernel/neko/pull/4 + https://github.com/onkernel/neko/pull/5


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 42d0fc6d86487856f38e475165c20d3ce8cce8f5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

<!-- mesa-description-start -->
## TL;DR

Upgrades the `neko` dependency to incorporate recent upstream changes, including new keepalive support.

## Why we made these changes

This update pulls in the changes from two pull requests in the `onkernel/neko` repository, which introduce `event.SYSTEM_PONG` and legacy keepalive support.
- https://github.com/onkernel/neko/pull/4
- https://github.com/onkernel/neko/pull/5

## What changed?

- **images/chromium-headful/Dockerfile**: The base `neko` image was updated from version `3.0.6-v1.0.1` to `3.0.8-v1.1.0`.

## Validation

- [ ] Verify that the application builds and runs correctly with the new dependency.
- [ ] Test the functionality related to the changes in the upstream PRs to ensure they are integrated properly.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->