### PR TITLE
fix negative relative mouse moves

### DIFF
--- a/server/cmd/api/api/computer.go
+++ b/server/cmd/api/api/computer.go
@@ -700,7 +700,13 @@ func (s *ApiService) DragMouse(ctx context.Context, request oapi.DragMouseReques
 		x0, y0 := prev[0], prev[1]
 		x1, y1 := pt[0], pt[1]
 		for _, step := range generateRelativeSteps(x1-x0, y1-y0, stepsPerSegment) {
-			args2 = append(args2, "mousemove_relative", strconv.Itoa(step[0]), strconv.Itoa(step[1]))
+			xStr := strconv.Itoa(step[0])
+			yStr := strconv.Itoa(step[1])
+			if step[0] < 0 || step[1] < 0 {
+				args2 = append(args2, "mousemove_relative", "--", xStr, yStr)
+			} else {
+				args2 = append(args2, "mousemove_relative", xStr, yStr)
+			}
 			// add a tiny delay between moves, but not after the last step
 			if stepIndex < totalSteps-1 && stepDelayMs > 0 {
 				args2 = append(args2, "sleep", stepDelaySeconds)


### PR DESCRIPTION
fixes this error:

```
Internal_error: {"message":"failed during drag movement: mousemove_relative: unrecognized option '-60'\nUsage:
  mousemove_relative [options] \u003cx\u003e \u003cy\u003e\n-c, --clearmodifiers - reset active modifiers (alt, etc)
  while typing\n-p, --polar - Use polar coordinates. X as an angle, Y as distance\n--sync - only exit once the mouse
  has moved\n\nUsing polar coordinate mode makes 'x' the angle (in degrees) and\n'y' the distance.\n\nIf you want to
  use negative numbers for a coordinate, you'll need to\ninvoke it this way (with the '--'):\n mousemove_relative -- -
  20 -15\notherwise, normal usage looks like this:\n mousemove_relative 100 140\n"} .
```

tested manually:  https://screen.studio/share/lM76bBHd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure negative relative mouse moves use the "--" separator when building xdotool drag steps to avoid option parsing errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d5ee8712eb006c76c7aeb173b831ca4394d009f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->