### PR TITLE
Sync upstream - v24/v28 (2026-02-04)

### DIFF
--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -53,7 +53,7 @@ RUN set -eux; \
     make -j$(nproc); \
     make install;
 
-FROM ghcr.io/onkernel/neko/base:3.0.8-v1.1.0 AS neko
+FROM ghcr.io/onkernel/neko/base:3.0.8-v1.3.0 AS neko
 # ^--- now has event.SYSTEM_PONG with legacy support to keepalive
 FROM docker.io/ubuntu:22.04
 


### PR DESCRIPTION
## Summary

- **Date of sync**: 2026-02-04
- **New image versions**: headless v24, headful v28

## Changes

### Private repo sync
Merged new commits from `origin/main` into the sync branch:
- `83c0fee` Merge pull request #86 from kernel/ulziibay-kernel/reCAPTCHA_v3_Enterprise
- `a202704` Use Click mode for reCAPTCHA Enterprise instead of Token mode

Files changed:
- `shared/extensions/capmonster/defaultSettings.json`
- `shared/extensions/capmonster/defaultSettings.json.template`

### kernel-browser
kernel-browser is up to date at `v144.0.7559.96-r6`.

### Upstream sync
Upstream (`kernel/kernel-images`) is already fully synced.

## Merge Conflicts
No merge conflicts - merge was clean.