### PR TITLE
fix computer controls hang

### DIFF
--- a/server/cmd/api/api/computer.go
+++ b/server/cmd/api/api/computer.go
@@ -62,7 +62,7 @@ func (s *ApiService) MoveMouse(ctx context.Context, request oapi.MoveMouseReques
 	}
 
 	// Move the cursor to the desired coordinates
-	args = append(args, "mousemove", "--sync", strconv.Itoa(body.X), strconv.Itoa(body.Y))
+	args = append(args, "mousemove", strconv.Itoa(body.X), strconv.Itoa(body.Y))
 
 	// Release modifier keys (keyup)
 	if body.HoldKeys != nil {
@@ -156,7 +156,7 @@ func (s *ApiService) ClickMouse(ctx context.Context, request oapi.ClickMouseRequ
 	}
 
 	// Move the cursor
-	args = append(args, "mousemove", "--sync", strconv.Itoa(body.X), strconv.Itoa(body.Y))
+	args = append(args, "mousemove", strconv.Itoa(body.X), strconv.Itoa(body.Y))
 
 	// click type defaults to click
 	clickType := oapi.Click
@@ -515,7 +515,7 @@ func (s *ApiService) Scroll(ctx context.Context, request oapi.ScrollRequestObjec
 			args = append(args, "keydown", key)
 		}
 	}
-	args = append(args, "mousemove", "--sync", strconv.Itoa(body.X), strconv.Itoa(body.Y))
+	args = append(args, "mousemove", strconv.Itoa(body.X), strconv.Itoa(body.Y))
 
 	// Apply vertical ticks first (sequential as specified)
 	if body.DeltaY != nil && *body.DeltaY != 0 {
@@ -626,7 +626,7 @@ func (s *ApiService) DragMouse(ctx context.Context, request oapi.DragMouseReques
 		}
 	}
 	start := body.Path[0]
-	args1 = append(args1, "mousemove", "--sync", strconv.Itoa(start[0]), strconv.Itoa(start[1]))
+	args1 = append(args1, "mousemove", strconv.Itoa(start[0]), strconv.Itoa(start[1]))
 	args1 = append(args1, "mousedown", btn)
 	log.Info("executing xdotool (drag start)", "args", args1)
 	if output, err := defaultXdoTool.Run(ctx, args1...); err != nil {


### PR DESCRIPTION
using --sync was ill-advised, it doesn't seem to detect when no mouse movements are necessary to achieve a mousemove, so getting rid of it for now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `--sync` flag from all `xdotool mousemove` calls to prevent hanging during mouse operations.
> 
> - **Backend (computer controls)** in `server/cmd/api/api/computer.go`:
>   - Remove `--sync` from `xdotool mousemove` in:
>     - `MoveMouse`
>     - `ClickMouse`
>     - `Scroll`
>     - `DragMouse` (initial move to start point)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 429cec9da90306d05baa35e8dad24b6c1be4ff67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->