### PR TITLE
fix: block notification permission dialogs via Chrome policy

### DIFF
--- a/shared/chromium-policies/managed/policy.json
+++ b/shared/chromium-policies/managed/policy.json
@@ -1,5 +1,6 @@
 {
   "PasswordManagerEnabled": false,
   "AutofillCreditCardEnabled": false,
-  "TranslateEnabled": false
+  "TranslateEnabled": false,
+  "DefaultNotificationsSetting": 2
 }


### PR DESCRIPTION
## Summary
- Add `DefaultNotificationsSetting: 2` Chrome policy to automatically deny all notification permission requests
- Prevents "site wants to show notifications" dialogs from appearing in the automated browser environment

## Test plan
- [ ] Deploy updated chromium-headful image
- [ ] Navigate to a site that requests notification permissions (e.g., yahoo.com)
- [ ] Verify no notification permission dialog appears

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets Chrome policy `DefaultNotificationsSetting: 2` to automatically deny all notification permission prompts.
> 
> - **Policies**:
>   - Update `shared/chromium-policies/managed/policy.json`:
>     - Add `DefaultNotificationsSetting: 2` to auto-deny site notification permission requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94a7d12732435000e3ebb9ed9e934b7ba00526ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->