### PR TITLE
Clean up logs

### DIFF
--- a/server/cmd/api/api/computer.go
+++ b/server/cmd/api/api/computer.go
@@ -350,8 +350,6 @@ func (s *ApiService) TypeText(ctx context.Context, request oapi.TypeTextRequestO
 	// Use "--" to terminate options and pass raw text
 	args = append(args, "--", body.Text)
 
-	log.Info("executing xdotool", "args", args)
-
 	output, err := defaultXdoTool.Run(ctx, args...)
 	if err != nil {
 		log.Error("xdotool command failed", "err", err, "output", string(output))
@@ -465,7 +463,6 @@ func (s *ApiService) PressKey(ctx context.Context, request oapi.PressKeyRequestO
 			argsDown = append(argsDown, "keydown", key)
 		}
 
-		log.Info("executing xdotool (keydown phase)", "args", argsDown)
 		if output, err := defaultXdoTool.Run(ctx, argsDown...); err != nil {
 			log.Error("xdotool keydown failed", "err", err, "output", string(output))
 			// Best-effort release any keys that may be down (primary and modifiers)
@@ -497,7 +494,6 @@ func (s *ApiService) PressKey(ctx context.Context, request oapi.PressKeyRequestO
 			}
 		}
 
-		log.Info("executing xdotool (keyup phase)", "args", argsUp)
 		if output, err := defaultXdoTool.Run(ctx, argsUp...); err != nil {
 			log.Error("xdotool keyup failed", "err", err, "output", string(output))
 			return oapi.PressKey500JSONResponse{InternalErrorJSONResponse: oapi.InternalErrorJSONResponse{
@@ -524,7 +520,6 @@ func (s *ApiService) PressKey(ctx context.Context, request oapi.PressKeyRequestO
 		}
 	}
 
-	log.Info("executing xdotool", "args", args)
 	output, err := defaultXdoTool.Run(ctx, args...)
 	if err != nil {
 		log.Error("xdotool command failed", "err", err, "output", string(output))

--- a/server/cmd/api/api/playwright.go
+++ b/server/cmd/api/api/playwright.go
@@ -80,7 +80,7 @@ func (s *ApiService) ExecutePlaywrightCode(ctx context.Context, request oapi.Exe
 			}, nil
 		}
 
-		log.Error("playwright execution failed", "error", err, "output", string(output))
+		log.Error("playwright execution failed", "error", err)
 
 		// Try to parse the error output as JSON
 		var result struct {
@@ -117,7 +117,7 @@ func (s *ApiService) ExecutePlaywrightCode(ctx context.Context, request oapi.Exe
 		Result  interface{} `json:"result,omitempty"`
 	}
 	if err := json.Unmarshal(output, &result); err != nil {
-		log.Error("failed to parse playwright output", "error", err, "output", string(output))
+		log.Error("failed to parse playwright output", "error", err)
 		success := false
 		errorMsg := fmt.Sprintf("failed to parse output: %v", err)
 		stdout := string(output)


### PR DESCRIPTION
## Overview

Removes xdotool and playwright excess logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Logging cleanup**
> 
> - Remove `log.Info` statements that printed xdotool args in `TypeText` and `PressKey` (keydown/keyup/tap phases)
> - Simplify Playwright error logging to exclude raw process output and only log the error; similarly reduce logs on JSON parse failures
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5980e751fc62ed05068c7c8cdfd71b8ce1021fbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->