### PR TITLE
Notify parent frame about kernel status

### DIFF
--- a/images/chromium-headful/client/src/app.vue
+++ b/images/chromium-headful/client/src/app.vue
@@ -233,6 +233,17 @@
       }
     }
 
+    get parentOrigin() {
+      try {
+        if (document.referrer) {
+          return new URL(document.referrer).origin
+        }
+      } catch (e) {
+        // fallback if referrer is not a valid URL
+      }
+      return '*'
+    }
+
     @Watch('hideControls', { immediate: true })
     onHideControls(enabled: boolean) {
       if (enabled) {
@@ -260,15 +271,15 @@
     // Add a watcher so that when we are connected we can set the resolution from query params
     @Watch('connected', { immediate: true })
     onConnected(value: boolean) {
-      try {
-        if (value) {
-          this.applyQueryResolution()
+      if (value) {
+        this.applyQueryResolution()
+        try {
           if (window.parent !== window) {
-            window.parent.postMessage({ type: 'KERNEL_CONNECTED', connected: true }, '*')
+            window.parent.postMessage({ type: 'KERNEL_CONNECTED', connected: true }, this.parentOrigin)
           }
+        } catch (e) {
+          console.error('Failed to post message to parent', e)
         }
-      } catch (e) {
-        console.error('Failed to post message to parent', e)
       }
     }
 
@@ -344,9 +355,9 @@
         if (window.parent === window) return
 
         if (value) {
-          window.parent.postMessage({ type: 'KERNEL_PLAYING', playing: true }, '*')
+          window.parent.postMessage({ type: 'KERNEL_PLAYING', playing: true }, this.parentOrigin)
         } else {
-          window.parent.postMessage({ type: 'KERNEL_PAUSED', playing: false }, '*')
+          window.parent.postMessage({ type: 'KERNEL_PAUSED', playing: false }, this.parentOrigin)
         }
       } catch (e) {
         console.error('Failed to post message to parent', e)


### PR DESCRIPTION
Removes the unused playable watcher and adds guard checks to postMessage calls to prevent loopback messages when running outside of an iframe. Also removes test.html.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds parent-frame notifications and deployment docs.
> 
> - **Client (`app.vue`)**: Introduces `parentOrigin` and iframe guards; posts `KERNEL_CONNECTED`, `KERNEL_PLAYING`, and `KERNEL_PAUSED` via `postMessage` when embedded to signal connection and playback state changes
> - **Docs**: New `DEPLOYMENT.md` detailing core components, networking/ports, env vars, resource requirements, and a deployment checklist
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8d7eb47c2f522a051c5b223e80ebdee2f76e23a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->