### PR TITLE
[kernel:781] add kernel logo loading spinner when browser launches

### DIFF
--- a/images/chromium-headful/client/src/assets/styles/_variables.scss
+++ b/images/chromium-headful/client/src/assets/styles/_variables.scss
@@ -21,7 +21,7 @@ $background-modifier-accent: hsla(0, 0%, 100%, 0.06);
 $elevation-low: 0 1px 0 rgba(4, 4, 5, 0.2), 0 1.5px 0 rgba(6, 6, 7, 0.05), 0 2px 0 rgba(4, 4, 5, 0.05);
 $elevation-high: 0 8px 16px rgba(0, 0, 0, 0.24);
 
-$style-primary: #8B5CF6;
+$style-primary: #8b5cf6;
 $style-error: #d32f2f;
 
 $menu-height: 40px;

--- a/images/chromium-headful/client/src/components/about.vue
+++ b/images/chromium-headful/client/src/components/about.vue
@@ -3,7 +3,7 @@
     <div class="window">
       <div class="loading" v-if="loading">
         <div class="loader">
-          <img src="../assets/images/logo.svg" alt="Kernel" class="kernel-logo" />
+          <img src="../assets/images/logo.svg" alt="loading" aria-hidden="true" class="kernel-logo" />
         </div>
       </div>
 
@@ -91,7 +91,13 @@
           .kernel-logo {
             width: 100%;
             height: 100%;
-            animation: spin 1s linear infinite;
+            animation: kernel-logo-spin 1s linear infinite;
+          }
+
+          @media (prefers-reduced-motion: reduce) {
+            .kernel-logo {
+              animation: none;
+            }
           }
         }
       }
@@ -102,7 +108,7 @@
     }
   }
 
-  @keyframes spin {
+  @keyframes kernel-logo-spin {
     from {
       transform: rotate(0deg);
     }

--- a/images/chromium-headful/client/src/components/connect.vue
+++ b/images/chromium-headful/client/src/components/connect.vue
@@ -11,7 +11,7 @@
         </button>
       </form>
       <div class="loader" v-if="connecting">
-        <img src="../assets/images/logo.svg" alt="Kernel" class="kernel-logo" />
+        <img src="../assets/images/logo.svg" alt="loading" aria-hidden="true" class="kernel-logo" />
       </div>
     </div>
   </div>
@@ -111,18 +111,24 @@
         .kernel-logo {
           width: 100%;
           height: 100%;
-          animation: spin 1s linear infinite;
+          animation: kernel-logo-spin 1s linear infinite;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .kernel-logo {
+            animation: none;
+          }
         }
       }
     }
+  }
 
-    @keyframes spin {
-      from {
-        transform: rotate(0deg);
-      }
-      to {
-        transform: rotate(360deg);
-      }
+  @keyframes kernel-logo-spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
     }
   }
 </style>


### PR DESCRIPTION


https://github.com/user-attachments/assets/da27698d-bd1a-470e-9821-f8657efe2022



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a branded loading experience and updates theme color.
> 
> - Replaces legacy bounce loaders with a spinning `logo.svg` in `about.vue` and `connect.vue` (flex-centered, `kernel-logo-spin` animation, respects `prefers-reduced-motion`)
> - Updates `$style-primary` to `#8b5cf6` in `_variables.scss`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32adaa4a648ca2a30086235a47613a0a5784e382. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->