### PR TITLE
[kernel:781] update loading logo animation to pulse

### DIFF
--- a/images/chromium-headful/client/src/components/about.vue
+++ b/images/chromium-headful/client/src/components/about.vue
@@ -98,12 +98,12 @@
   @keyframes kernel-logo-pulse {
     0%,
     100% {
-      transform: scale(1);
-      opacity: 1;
+      transform: scale(0.85);
+      opacity: 0.7;
     }
     50% {
-      transform: scale(1.2;
-      opacity: 0.8;
+      transform: scale(1);
+      opacity: 1;
     }
   }
 </style>

--- a/images/chromium-headful/client/src/components/connect.vue
+++ b/images/chromium-headful/client/src/components/connect.vue
@@ -115,12 +115,12 @@
   @keyframes kernel-logo-pulse {
     0%,
     100% {
-      transform: scale(1);
-      opacity: 1;
+      transform: scale(0.85);
+      opacity: 0.7;
     }
     50% {
-      transform: scale(1.2);
-      opacity: 0.8;
+      transform: scale(1);
+      opacity: 1;
     }
   }
 </style>


### PR DESCRIPTION

https://github.com/user-attachments/assets/96870841-35bc-4a91-9a04-9d1546af41a7


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the loading experience across the about and connect screens.
> 
> - Switches loader animation from `kernel-logo-spin` to `kernel-logo-pulse` with new keyframes and applies it to `.kernel-logo` in both `about.vue` and `connect.vue`
> - Removes the previous reduced-motion spin override and related spin keyframes
> - Simplifies `.window` container styling by dropping width/background/padding/max size/overflow rules (retains scrollbar styling)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d074578773b581723ea60f8884bda6c1ea71950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->