### PR TITLE
feat: add more fonts 

### DIFF
--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -204,13 +204,42 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-ap
     wget \
     xdg-utils \
     libvulkan1 \
-    fonts-liberation \
-    fonts-noto-cjk \
-    fonts-noto-color-emoji \
-    fonts-nanum \
     fontconfig \
     unzip && \
-    fc-cache -f
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install fonts to match a realistic Ubuntu 22.04 desktop fingerprint.
+# A minimal container has only 3 fonts, which is a strong fingerprinting signal
+# used by reCAPTCHA Enterprise and other bot detection vendors.
+RUN apt-get update && \
+    apt-get --no-install-recommends -y install \
+    fonts-liberation \
+    fonts-liberation2 \
+    fonts-noto-cjk \
+    fonts-noto-color-emoji \
+    fonts-noto-core \
+    fonts-nanum \
+    fonts-dejavu-core \
+    fonts-dejavu-extra \
+    fonts-freefont-ttf \
+    fonts-ubuntu \
+    fonts-opensymbol \
+    fonts-roboto \
+    fonts-croscore \
+    fonts-smc-chilanka \
+    fonts-hosny-amiri \
+    fonts-indic \
+    fonts-kacst \
+    fonts-khmeros-core \
+    fonts-lao \
+    fonts-lklug-sinhala \
+    fonts-sil-abyssinica \
+    fonts-sil-padauk \
+    fonts-thai-tlwg \
+    fonts-tibetan-machine \
+    fonts-droid-fallback && \
+    fc-cache -f && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install ffmpeg manually since the version available in apt is from the 4.x branch due to #drama.
 COPY --from=ffmpeg-downloader /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg


### PR DESCRIPTION
When visiting creepJS, i noticed that we have only 3 fonts, among other signals. As such, 

1. Install Ubuntu 22.04 default font set (25+ packages) to match a real desktop fingerprint. The container previously had only 3 fonts (DejaVu Sans, Liberation Mono, Noto Color Emoji). With this, we have 13/51 now.
<img width="337" height="286" alt="Screenshot 2026-02-25 at 1 25 16 PM" src="https://github.com/user-attachments/assets/3b062bdf-f58b-4676-afda-b8e5a196bfb5" />


# Checklist

- [ ] A link to a related issue in our repository
- [ ] A description of the changes proposed in the pull request.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects container build dependencies by adding font packages and reorganizing apt steps; primary risk is increased image size/build time or missing packages on apt mirrors.
> 
> **Overview**
> Updates the `chromium-headful` image build to install a much broader set of Ubuntu 22.04 font packages and rebuild the font cache, aiming to reduce bot/fingerprint signals from an unnaturally small font list.
> 
> Also reorganizes the Dockerfile so `fontconfig`/`unzip` are installed in the earlier “userland apps” step, while the font install step now includes additional font families and cleans apt lists afterward to keep layers small.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f1ee62454a4073501ffa79c6c30c368b023a0a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->