### PR TITLE
feat: add interactive live view to headless Chromium image (approach 1 not truly headless)

### DIFF
--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -102,6 +102,8 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG CACHEIDPREFIX=${TARGETOS:-linux}-${TARGETARCH:-amd64}-ubuntu2204
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-apt-cache \
     --mount=type=cache,target=/var/lib/apt,sharing=locked,id=$CACHEIDPREFIX-apt-lib \
     set -xe; \
@@ -143,7 +145,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-ap
     fonts-noto-color-emoji \
     fonts-nanum \
     software-properties-common \
-    supervisor; \
+    supervisor \
+    x11vnc \
+    novnc \
+    websockify; \
     fc-cache -f
 
 # install chromium and sqlite3 for debugging the cookies file
@@ -223,6 +228,7 @@ COPY images/chromium-headless/image/wrapper.sh /usr/bin/wrapper.sh
 # Supervisord configuration
 COPY images/chromium-headless/image/supervisord.conf /etc/supervisor/supervisord.conf
 COPY images/chromium-headless/image/supervisor/services/ /etc/supervisor/conf.d/services/
+COPY images/chromium-headless/image/novnc-view.html /usr/share/novnc/index.html
 COPY shared/envoy/supervisor-envoy.conf /etc/supervisor/conf.d/services/envoy.conf
 
 # Install Envoy proxy

--- a/images/chromium-headless/image/novnc-view.html
+++ b/images/chromium-headless/image/novnc-view.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Live View</title>
+    <meta charset="utf-8">
+    <style>
+        html, body { margin: 0; padding: 0; overflow: hidden; width: 100%; height: 100%; background: #000; }
+    </style>
+    <script src="vendor/promise.js"></script>
+    <script type="module">
+        window._noVNC_has_module_support = true;
+    </script>
+    <script>
+        window.addEventListener("load", function() {
+            if (window._noVNC_has_module_support) return;
+            var loader = document.createElement("script");
+            loader.src = "vendor/browser-es-module-loader/dist/browser-es-module-loader.js";
+            document.head.appendChild(loader);
+        });
+    </script>
+    <script type="module" crossorigin="anonymous">
+        import * as WebUtil from './app/webutil.js';
+        import RFB from './core/rfb.js';
+
+        WebUtil.init_logging(WebUtil.getConfigVar('logging', 'warn'));
+
+        var host = WebUtil.getConfigVar('host', window.location.hostname);
+        var port = WebUtil.getConfigVar('port', window.location.port);
+        if (!port) {
+            port = (window.location.protocol === 'https:') ? 443 : 80;
+        }
+        var path = WebUtil.getConfigVar('path', 'websockify');
+        var scheme = (window.location.protocol === 'https:') ? 'wss' : 'ws';
+        var url = scheme + '://' + host + ':' + port + '/' + path;
+
+        var rfb = new RFB(document.body, url, {
+            shared: true,
+            credentials: { password: WebUtil.getConfigVar('password', '') }
+        });
+        rfb.scaleViewport = true;
+        rfb.focusOnClick = true;
+        rfb.addEventListener("disconnect", function(e) {
+            if (!e.detail.clean) document.title = "Disconnected";
+        });
+    </script>
+</head>
+<body></body>
+</html>

--- a/images/chromium-headless/image/supervisor/services/chromium.conf
+++ b/images/chromium-headless/image/supervisor/services/chromium.conf
@@ -1,5 +1,5 @@
 [program:chromium]
-command=/usr/local/bin/chromium-launcher --headless
+command=/usr/local/bin/chromium-launcher
 autostart=false
 autorestart=true
 startsecs=0

--- a/images/chromium-headless/image/supervisor/services/novnc.conf
+++ b/images/chromium-headless/image/supervisor/services/novnc.conf
@@ -1,0 +1,7 @@
+[program:novnc]
+command=websockify --web /usr/share/novnc 8080 localhost:5900
+autostart=false
+autorestart=true
+startsecs=2
+stdout_logfile=/var/log/supervisord/novnc
+redirect_stderr=true

--- a/images/chromium-headless/image/supervisor/services/x11vnc.conf
+++ b/images/chromium-headless/image/supervisor/services/x11vnc.conf
@@ -1,0 +1,7 @@
+[program:x11vnc]
+command=x11vnc -display :1 -forever -shared -nopw -rfbport 5900 -noxdamage
+autostart=false
+autorestart=true
+startsecs=2
+stdout_logfile=/var/log/supervisord/x11vnc
+redirect_stderr=true

--- a/images/chromium-headless/image/wrapper.sh
+++ b/images/chromium-headless/image/wrapper.sh
@@ -79,6 +79,10 @@ export HOSTNAME="${HOSTNAME:-kernel-vm}"
 # NOTE: --disable-background-networking was intentionally removed because it prevents
 # Chrome from fetching extensions via ExtensionInstallForcelist enterprise policy.
 # Enterprise extensions require Chrome to make HTTP requests to fetch update.xml and .crx files.
+#
+# Chromium renders to Xvfb (DISPLAY=:1) so that screenshots, recordings, xdotool
+# input, and live view all work. Flags like --ozone-platform=headless and
+# --disable-software-rasterizer are intentionally absent.
 if [ -z "${CHROMIUM_FLAGS:-}" ]; then
   CHROMIUM_FLAGS="--accept-lang=en-US,en \
     --allow-pre-commit-input \
@@ -106,24 +110,23 @@ if [ -z "${CHROMIUM_FLAGS:-}" ]; then
     --disable-prompt-on-repost \
     --disable-renderer-backgrounding \
     --disable-search-engine-choice-screen \
-    --disable-software-rasterizer \
     --enable-use-zoom-for-dsf=false \
     --export-tagged-pdf \
     --force-color-profile=srgb \
     --hide-crash-restore-bubble \
-    --hide-scrollbars \
     --metrics-recording-only \
     --mute-audio \
     --no-default-browser-check \
     --no-first-run \
     --no-sandbox \
     --no-service-autorun \
-    --ozone-platform=headless \
     --password-store=basic \
     --unsafely-disable-devtools-self-xss-warnings \
     --use-angle=swiftshader \
     --use-gl=angle \
-    --use-mock-keychain"
+    --use-mock-keychain \
+    --window-size=${WIDTH:-1920},${HEIGHT:-1080} \
+    --window-position=0,0"
 fi
 export CHROMIUM_FLAGS
 
@@ -216,6 +219,8 @@ cleanup () {
   echo "[wrapper] Cleaning up..."
   # Re-enable scale-to-zero if the script terminates early
   enable_scale_to_zero
+  supervisorctl -c /etc/supervisor/supervisord.conf stop novnc || true
+  supervisorctl -c /etc/supervisor/supervisord.conf stop x11vnc || true
   supervisorctl -c /etc/supervisor/supervisord.conf stop chromedriver || true
   supervisorctl -c /etc/supervisor/supervisord.conf stop chromium || true
   supervisorctl -c /etc/supervisor/supervisord.conf stop xvfb || true
@@ -273,6 +278,16 @@ wait_for_tcp_port 127.0.0.1 "${API_PORT}" "kernel-images API"
 echo "[wrapper] Starting ChromeDriver via supervisord"
 supervisorctl -c /etc/supervisor/supervisord.conf start chromedriver
 wait_for_tcp_port 127.0.0.1 9225 "ChromeDriver" 50 0.2 "10s" || true
+
+if [[ "${ENABLE_LIVE_VIEW:-}" == "true" ]]; then
+  echo "[wrapper] Starting x11vnc via supervisord"
+  supervisorctl -c /etc/supervisor/supervisord.conf start x11vnc
+  wait_for_tcp_port 127.0.0.1 5900 "x11vnc" 50 0.2 "10s" || true
+
+  echo "[wrapper] Starting noVNC via supervisord"
+  supervisorctl -c /etc/supervisor/supervisord.conf start novnc
+  wait_for_tcp_port 127.0.0.1 8080 "noVNC" 50 0.2 "10s" || true
+fi
 
 echo "[wrapper] startup complete!"
 # Re-enable scale-to-zero once startup has completed (when not under Docker)

--- a/images/chromium-headless/run-docker.sh
+++ b/images/chromium-headless/run-docker.sh
@@ -17,7 +17,9 @@ RUN_ARGS=(
   -p 9222:9222
   -p 9224:9224
   -p 444:10001
+  -p 8080:8080
   -v "$HOST_RECORDINGS_DIR:/recordings"
+  -e ENABLE_LIVE_VIEW="${ENABLE_LIVE_VIEW:-true}"
 )
 
 if [[ -n "${PLAYWRIGHT_ENGINE:-}" ]]; then


### PR DESCRIPTION
## Summary

- Makes Chromium render to Xvfb instead of using offscreen headless mode (`--ozone-platform=headless`), enabling X11-based tools (screenshots, recordings, xdotool, xclip) to work with actual browser content
- Adds an interactive noVNC-based live view (x11vnc + websockify) on port 8080, gated behind `ENABLE_LIVE_VIEW=true`, matching the headful image's live view port for parity
- Includes a custom minimal noVNC client with auto-connect, scale-to-fit, and no UI chrome


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Chromium launch mode/flags and adds an optionally exposed remote-control surface (x11vnc/noVNC on `8080`), which could impact runtime behavior and security if enabled unintentionally.
> 
> **Overview**
> Switches the headless Chromium image to render via `Xvfb` (removing explicit `--headless`/`--ozone-platform=headless` assumptions) and updates default Chromium flags to set an explicit window size/position for consistent viewport behavior.
> 
> Adds an *optional* interactive live view behind `ENABLE_LIVE_VIEW=true` by installing and supervising `x11vnc` + `novnc`/`websockify`, serving a minimal auto-connecting noVNC client, and updating `run-docker.sh` to publish port `8080` (and default `ENABLE_LIVE_VIEW` on for local runs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 194f427165181f452d035c4ef18aa4c4eaf4862e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->