### PR TITLE
Raise recording framerate limit from 20 to 60 fps

### DIFF
--- a/server/cmd/config/config.go
+++ b/server/cmd/config/config.go
@@ -56,8 +56,8 @@ func validate(config *Config) error {
 	if config.DisplayNum < 0 {
 		return fmt.Errorf("DISPLAY_NUM must be greater than 0")
 	}
-	if config.FrameRate < 0 || config.FrameRate > 20 {
-		return fmt.Errorf("FRAME_RATE must be greater than 0 and less than or equal to 20")
+	if config.FrameRate < 0 || config.FrameRate > 60 {
+		return fmt.Errorf("FRAME_RATE must be greater than 0 and less than or equal to 60")
 	}
 	if config.MaxSizeInMB < 0 || config.MaxSizeInMB > 1000 {
 		return fmt.Errorf("MAX_SIZE_MB must be greater than 0 and less than or equal to 1000")

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -1208,7 +1208,7 @@ components:
           type: integer
           description: Recording framerate in fps (overrides server default)
           minimum: 1
-          maximum: 20
+          maximum: 60
         maxDurationInSeconds:
           type: integer
           description: Maximum recording duration in seconds (overrides server default)


### PR DESCRIPTION
## Summary

- Raises the maximum allowed recording framerate from 20 to 60 fps to support GPU browsers
- Updates `server/openapi.yaml` (`maximum: 20` -> `maximum: 60`) and `server/cmd/config/config.go` default config validation
- Companion to kernel/kernel#1708 which raises the same limit in the API server

## Test plan

- [ ] Verify GPU browser can record at 60fps
- [ ] Verify framerate > 60 is still rejected by config validation
- [ ] Verify non-GPU browsers still work with default framerates