### PR TITLE
Disable IPv6 in browser VMs at boot

### DIFF
--- a/images/chromium-headful/wrapper.sh
+++ b/images/chromium-headful/wrapper.sh
@@ -82,6 +82,17 @@ fi
 export HOSTNAME="${HOSTNAME:-kernel-vm}"
 
 # -----------------------------------------------------------------------------
+# Disable IPv6 -----------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# The VM environment has no IPv6 route, so any IPv6 connection attempt will fail
+# immediately with ENETUNREACH. Chromium's built-in DNS client may attempt
+# DNS-over-HTTPS to IPv6 endpoints (e.g. [2001:4860:4860::8888]:443), and each
+# failed attempt wastes a connection slot from the MaxConnectionsPerProxy pool.
+# Disabling IPv6 at the kernel level prevents these wasted attempts.
+echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6 2>/dev/null || true
+echo 1 > /proc/sys/net/ipv6/conf/default/disable_ipv6 2>/dev/null || true
+
+# -----------------------------------------------------------------------------
 # House-keeping for the unprivileged "kernel" user --------------------------------
 # Some Chromium subsystems want to create files under $HOME (NSS cert DB, dconf
 # cache).  If those directories are missing or owned by root Chromium emits

--- a/images/chromium-headless/image/wrapper.sh
+++ b/images/chromium-headless/image/wrapper.sh
@@ -75,6 +75,17 @@ if h=$(cat /proc/sys/kernel/hostname 2>/dev/null); then
 fi
 export HOSTNAME="${HOSTNAME:-kernel-vm}"
 
+# -----------------------------------------------------------------------------
+# Disable IPv6 -----------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# The VM environment has no IPv6 route, so any IPv6 connection attempt will fail
+# immediately with ENETUNREACH. Chromium's built-in DNS client may attempt
+# DNS-over-HTTPS to IPv6 endpoints (e.g. [2001:4860:4860::8888]:443), and each
+# failed attempt wastes a connection slot from the MaxConnectionsPerProxy pool.
+# Disabling IPv6 at the kernel level prevents these wasted attempts.
+echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6 2>/dev/null || true
+echo 1 > /proc/sys/net/ipv6/conf/default/disable_ipv6 2>/dev/null || true
+
 # if CHROMIUM_FLAGS is not set, default to the flags used in playwright_stealth
 # NOTE: --disable-background-networking was intentionally removed because it prevents
 # Chrome from fetching extensions via ExtensionInstallForcelist enterprise policy.


### PR DESCRIPTION
## Summary

Disables IPv6 at the kernel level during VM boot in both headful and headless wrapper scripts.

Browser VMs have no IPv6 route, so any IPv6 connection attempt fails immediately with `ENETUNREACH`. Chromium's built-in DNS client may attempt DNS-over-HTTPS to IPv6 endpoints (e.g. `[2001:4860:4860::8888]:443`), and each failed attempt wastes a connection slot from the `MaxConnectionsPerProxy` pool. Under certain conditions — particularly when combined with intermittent DNS failures — this can exhaust all available connection slots and lead to `ERR_INSUFFICIENT_RESOURCES` tab crashes.

### Changes

- **`images/chromium-headful/wrapper.sh`** — write `1` to `/proc/sys/net/ipv6/conf/{all,default}/disable_ipv6` after hostname setup, before service startup
- **`images/chromium-headless/image/wrapper.sh`** — same change

Uses the same `/proc/sys` write pattern already used for hostname configuration. Writes are best-effort (`|| true`) so the script continues if the sysctl paths are unavailable.

### Testing

Verified on a live stealth browser VM (`gb732pp14lssq510l2lq4q53`):
- Before: `net.ipv6.conf.all.disable_ipv6 = 0`, link-local IPv6 addr on eth0, IPv6 ping fails with "Network is unreachable"
- Observed `8.8.4.4:443` in TIME_WAIT at startup — Chrome's DoH probe to Google DNS over IPv4 (IPv6 attempt would have also fired)
- After manually applying the sysctl: IPv6 addresses removed from interfaces, no more IPv6 connection attempts possible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code complexity, but it changes VM networking behavior at the kernel level and could impact workloads that rely on IPv6 connectivity.
> 
> **Overview**
> Disables IPv6 at boot in both headful and headless Chromium VM wrapper scripts by writing `1` to `/proc/sys/net/ipv6/conf/{all,default}/disable_ipv6` (best-effort), to prevent Chromium making futile IPv6 DoH/proxy connection attempts that can exhaust connection slots and trigger `ERR_INSUFFICIENT_RESOURCES` crashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b99ba4688312dcfeaebb3d79f710ac2403110418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->