### PR TITLE
fix: resolve clipboard paste race condition in Safari iframe context

### DIFF
--- a/images/chromium-headful/client/src/components/video.vue
+++ b/images/chromium-headful/client/src/components/video.vue
@@ -261,6 +261,7 @@
     private keyboard = GuacamoleKeyboard()
     private observer = new ResizeObserver(this.onResize.bind(this))
     private focused = false
+    private pastePending = false
     private fullscreen = false
     private mutedOverlay = true
     private isVideoSyncing = false
@@ -544,16 +545,26 @@
           return true
         }
 
-        this.$client.sendData('keydown', { key: this.keyMap(key) })
-
-        // Allow Ctrl/Cmd+V through so the browser fires a paste event,
-        // which triggers onPaste -> syncClipboard (required for Safari
-        // clipboard access since it only permits reads in user-initiated events)
         const { ctrl, meta } = this.keyboard.modifiers
-        return key === 0x0076 && !!(ctrl || meta)
+        const isPaste = key === 0x0076 && !!(ctrl || meta)
+
+        if (isPaste) {
+          // Don't send V keydown yet -- onPaste will sync the clipboard
+          // first, then send the keystroke so the remote pastes the
+          // correct (freshly-synced) content.
+          this.pastePending = true
+          return true
+        }
+
+        this.$client.sendData('keydown', { key: this.keyMap(key) })
       }
       this.keyboard.onkeyup = (key: number) => {
         if (!this.hosting || this.locked) {
+          return
+        }
+
+        if (key === 0x0076 && this.pastePending) {
+          this.pastePending = false
           return
         }
 
@@ -834,10 +845,22 @@
       this.focused = false
     }
 
-    onPaste() {
-      if (this.hosting) {
-        this.syncClipboard()
-      }
+    async onPaste() {
+      if (!this.hosting) return
+
+      await this.syncClipboard()
+
+      // Send the full Ctrl+V sequence. We can't rely on Guacamole having
+      // captured the original Cmd/Ctrl keydown because Safari may intercept
+      // modifier shortcuts before they reach iframe JavaScript. And even if
+      // it did, the await above yields to the event loop, allowing keyup
+      // events to release Ctrl on the remote before we get here.
+      const ctrlKey = this.keyMap(0xffe3)
+      const vKey = this.keyMap(0x0076)
+      this.$client.sendData('keydown', { key: ctrlKey })
+      this.$client.sendData('keydown', { key: vKey })
+      this.$client.sendData('keyup', { key: vKey })
+      this.$client.sendData('keyup', { key: ctrlKey })
     }
 
     onOverlayFocus() {

--- a/images/chromium-headful/client/src/components/video.vue
+++ b/images/chromium-headful/client/src/components/video.vue
@@ -846,7 +846,7 @@
     }
 
     async onPaste() {
-      if (!this.hosting) return
+      if (!this.hosting || this.locked) return
 
       await this.syncClipboard()
 

--- a/images/chromium-headful/client/src/components/video.vue
+++ b/images/chromium-headful/client/src/components/video.vue
@@ -848,19 +848,23 @@
     async onPaste() {
       if (!this.hosting || this.locked) return
 
-      await this.syncClipboard()
+      try {
+        await this.syncClipboard()
 
-      // Send the full Ctrl+V sequence. We can't rely on Guacamole having
-      // captured the original Cmd/Ctrl keydown because Safari may intercept
-      // modifier shortcuts before they reach iframe JavaScript. And even if
-      // it did, the await above yields to the event loop, allowing keyup
-      // events to release Ctrl on the remote before we get here.
-      const ctrlKey = this.keyMap(0xffe3)
-      const vKey = this.keyMap(0x0076)
-      this.$client.sendData('keydown', { key: ctrlKey })
-      this.$client.sendData('keydown', { key: vKey })
-      this.$client.sendData('keyup', { key: vKey })
-      this.$client.sendData('keyup', { key: ctrlKey })
+        // Send the full Ctrl+V sequence. We can't rely on Guacamole having
+        // captured the original Cmd/Ctrl keydown because Safari may intercept
+        // modifier shortcuts before they reach iframe JavaScript. And even if
+        // it did, the await above yields to the event loop, allowing keyup
+        // events to release Ctrl on the remote before we get here.
+        const ctrlKey = this.keyMap(0xffe3)
+        const vKey = this.keyMap(0x0076)
+        this.$client.sendData('keydown', { key: ctrlKey })
+        this.$client.sendData('keydown', { key: vKey })
+        this.$client.sendData('keyup', { key: vKey })
+        this.$client.sendData('keyup', { key: ctrlKey })
+      } finally {
+        this.pastePending = false
+      }
     }
 
     onOverlayFocus() {

--- a/images/chromium-headful/wrapper.sh
+++ b/images/chromium-headful/wrapper.sh
@@ -267,7 +267,7 @@ supervisorctl -c /etc/supervisor/supervisord.conf start kernel-images-api
 wait_for_tcp_port 127.0.0.1 "${API_PORT}" "kernel-images API"
 
 echo "[wrapper] Starting ChromeDriver via supervisord"
-supervisorctl -c /etc/supervisor/supervisord.conf start chromedriver || true
+supervisorctl -c /etc/supervisor/supervisord.conf start chromedriver
 wait_for_tcp_port 127.0.0.1 9225 "ChromeDriver" 50 0.2 "10s" || true
 
 echo "[wrapper] Starting PulseAudio daemon via supervisord"

--- a/images/chromium-headful/wrapper.sh
+++ b/images/chromium-headful/wrapper.sh
@@ -267,7 +267,7 @@ supervisorctl -c /etc/supervisor/supervisord.conf start kernel-images-api
 wait_for_tcp_port 127.0.0.1 "${API_PORT}" "kernel-images API"
 
 echo "[wrapper] Starting ChromeDriver via supervisord"
-supervisorctl -c /etc/supervisor/supervisord.conf start chromedriver
+supervisorctl -c /etc/supervisor/supervisord.conf start chromedriver || true
 wait_for_tcp_port 127.0.0.1 9225 "ChromeDriver" 50 0.2 "10s" || true
 
 echo "[wrapper] Starting PulseAudio daemon via supervisord"


### PR DESCRIPTION
## Summary

- Fixes the "one behind" clipboard paste bug (CUS-163 / KERNEL-459) when the live view is embedded in a cross-origin iframe in Safari
- The root cause was a race condition: the Ctrl+V keydown was sent to the remote *before* the local clipboard was synced, so the remote always pasted stale content
- The fix defers the paste keystroke — `onPaste` now awaits the clipboard sync, then sends the full Ctrl+V sequence (Ctrl down, V down, V up, Ctrl up) to the remote
- Also makes chromedriver startup non-fatal in the wrapper script (fails on ARM/rosetta hosts)

## Details

**Why this only happened in iframes:** Safari restricts `navigator.clipboard.readText()` to direct user gestures in cross-origin iframes. The `mouseenter` pre-sync that works in direct access silently fails in the iframe context, leaving the remote clipboard permanently stale.

**Why the full Ctrl+V sequence is needed:** The `await syncClipboard()` yields to the event loop, allowing pending keyup events (including Ctrl/Cmd release) to fire before the deferred V keydown. Safari may also intercept Cmd+key shortcuts before they reach iframe JavaScript entirely.

## Test plan

- [x] Open the live view inside a cross-origin iframe in Safari
- [x] Copy text on the host machine, then Cmd+V inside the live view — should paste the correct text on the first attempt
- [x] Verify right-click paste still works
- [x] Verify regular typing still works
- [x] Test in Chrome to ensure no regressions

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes keyboard/paste event handling for the remote-control iframe; regressions could impact normal key events or paste behavior across browsers, especially around modifier handling.
> 
> **Overview**
> Fixes a Safari cross-origin iframe paste race by **deferring the remote `Ctrl/Cmd+V` keystroke until after `syncClipboard()` completes**.
> 
> The keyboard handler now detects paste (`Ctrl/Cmd+V`), suppresses sending the initial `V` keydown via a `pastePending` flag, and `onPaste` becomes async to sync the clipboard first and then send the full `Ctrl+V` keydown/keyup sequence to the remote (with cleanup of the pending state).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4aa8a29b42d793eb4a86bdae8a7c5a362429ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->