### PR TITLE
Debounce scale-to-zero re-enable on DebouncedController

### DIFF
--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -49,7 +49,7 @@ func main() {
 	// ensure ffmpeg is available
 	mustFFmpeg()
 
-	stz := scaletozero.NewDebouncedControllerWithCooldown(scaletozero.NewUnikraftCloudController(), 1*time.Second)
+	stz := scaletozero.NewDebouncedControllerWithCooldown(scaletozero.NewUnikraftCloudController(), config.ScaleToZeroCooldown)
 	r := chi.NewRouter()
 	r.Use(
 		chiMiddleware.Logger,

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -49,7 +49,7 @@ func main() {
 	// ensure ffmpeg is available
 	mustFFmpeg()
 
-	stz := scaletozero.NewDebouncedController(scaletozero.NewUnikraftCloudController())
+	stz := scaletozero.NewDebouncedControllerWithCooldown(scaletozero.NewUnikraftCloudController(), 1*time.Second)
 	r := chi.NewRouter()
 	r.Use(
 		chiMiddleware.Logger,

--- a/server/cmd/config/config.go
+++ b/server/cmd/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
@@ -23,6 +24,9 @@ type Config struct {
 	// DevTools proxy configuration
 	DevToolsProxyPort int  `envconfig:"DEVTOOLS_PROXY_PORT" default:"9222"`
 	LogCDPMessages    bool `envconfig:"LOG_CDP_MESSAGES" default:"false"`
+
+	// How long to wait after the last active request before re-enabling scale-to-zero.
+	ScaleToZeroCooldown time.Duration `envconfig:"SCALE_TO_ZERO_COOLDOWN" default:"1s"`
 
 	// ChromeDriver proxy: external port where the proxy listens.
 	ChromeDriverProxyPort int `envconfig:"CHROMEDRIVER_PROXY_PORT" default:"9224"`

--- a/server/lib/scaletozero/scaletozero.go
+++ b/server/lib/scaletozero/scaletozero.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/kernel/kernel-images/server/lib/logger"
 )
@@ -88,19 +89,35 @@ func (o *Oncer) Enable(ctx context.Context) error {
 }
 
 type DebouncedController struct {
-	ctrl        Controller
-	mu          sync.Mutex
-	disabled    bool
-	activeCount int
+	ctrl           Controller
+	cooldown       time.Duration
+	mu             sync.Mutex
+	disabled       bool
+	activeCount    int
+	reenableTimer  *time.Timer
 }
 
+// NewDebouncedController creates a DebouncedController with no re-enable cooldown.
 func NewDebouncedController(ctrl Controller) Controller {
 	return &DebouncedController{ctrl: ctrl}
+}
+
+// NewDebouncedControllerWithCooldown creates a DebouncedController that delays
+// re-enabling scale-to-zero by the given cooldown after the last active holder
+// releases. A new Disable call during the cooldown cancels the pending
+// re-enable, avoiding rapid toggling from sequential requests.
+func NewDebouncedControllerWithCooldown(ctrl Controller, cooldown time.Duration) Controller {
+	return &DebouncedController{ctrl: ctrl, cooldown: cooldown}
 }
 
 func (c *DebouncedController) Disable(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.reenableTimer != nil {
+		c.reenableTimer.Stop()
+		c.reenableTimer = nil
+	}
 
 	c.activeCount++
 	if c.disabled {
@@ -129,10 +146,29 @@ func (c *DebouncedController) Enable(ctx context.Context) error {
 		return nil
 	}
 
-	if err := c.ctrl.Enable(ctx); err != nil {
-		return err
+	// No cooldown: re-enable immediately (original behavior).
+	if c.cooldown <= 0 {
+		if err := c.ctrl.Enable(ctx); err != nil {
+			return err
+		}
+		c.disabled = false
+		return nil
 	}
 
-	c.disabled = false
+	// Schedule re-enable after cooldown. If a new Disable arrives before the
+	// timer fires, it will be cancelled.
+	c.reenableTimer = time.AfterFunc(c.cooldown, func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		if c.activeCount > 0 || !c.disabled {
+			return
+		}
+
+		if c.ctrl.Enable(context.Background()) == nil {
+			c.disabled = false
+		}
+	})
+
 	return nil
 }

--- a/server/lib/scaletozero/scaletozero_test.go
+++ b/server/lib/scaletozero/scaletozero_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -168,4 +169,94 @@ func TestUnikraftCloudControllerTruncatesExistingContent(t *testing.T) {
 	b, err := os.ReadFile(p)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("+"), b)
+}
+
+func TestDebouncedControllerCooldownDelaysEnable(t *testing.T) {
+	t.Parallel()
+	mock := &mockScaleToZeroer{}
+	c := NewDebouncedControllerWithCooldown(mock, 50*time.Millisecond)
+
+	require.NoError(t, c.Disable(t.Context()))
+	require.NoError(t, c.Enable(t.Context()))
+
+	// Enable should not have been called yet — still in cooldown
+	mock.mu.Lock()
+	assert.Equal(t, 1, mock.disableCalls)
+	assert.Equal(t, 0, mock.enableCalls)
+	mock.mu.Unlock()
+
+	// Wait for cooldown to fire
+	time.Sleep(100 * time.Millisecond)
+
+	mock.mu.Lock()
+	assert.Equal(t, 1, mock.enableCalls)
+	mock.mu.Unlock()
+}
+
+func TestDebouncedControllerCooldownCancelledByNewDisable(t *testing.T) {
+	t.Parallel()
+	mock := &mockScaleToZeroer{}
+	c := NewDebouncedControllerWithCooldown(mock, 50*time.Millisecond)
+
+	require.NoError(t, c.Disable(t.Context()))
+	require.NoError(t, c.Enable(t.Context()))
+
+	// New request arrives before cooldown fires
+	require.NoError(t, c.Disable(t.Context()))
+
+	// Wait past what would have been the cooldown
+	time.Sleep(100 * time.Millisecond)
+
+	mock.mu.Lock()
+	// Enable should NOT have been called — the new Disable cancelled the timer
+	assert.Equal(t, 0, mock.enableCalls)
+	// Only one actual Disable write (second Disable was already disabled)
+	assert.Equal(t, 1, mock.disableCalls)
+	mock.mu.Unlock()
+
+	// Release the second request
+	require.NoError(t, c.Enable(t.Context()))
+	time.Sleep(100 * time.Millisecond)
+
+	mock.mu.Lock()
+	assert.Equal(t, 1, mock.enableCalls)
+	mock.mu.Unlock()
+}
+
+func TestDebouncedControllerCooldownCollapsesRapidSequential(t *testing.T) {
+	t.Parallel()
+	mock := &mockScaleToZeroer{}
+	c := NewDebouncedControllerWithCooldown(mock, 50*time.Millisecond)
+
+	// Simulate 10 rapid sequential requests
+	for i := 0; i < 10; i++ {
+		require.NoError(t, c.Disable(t.Context()))
+		require.NoError(t, c.Enable(t.Context()))
+	}
+
+	// Only 1 Disable write; Enable not yet called (still in cooldown)
+	mock.mu.Lock()
+	assert.Equal(t, 1, mock.disableCalls)
+	assert.Equal(t, 0, mock.enableCalls)
+	mock.mu.Unlock()
+
+	// Wait for final cooldown
+	time.Sleep(100 * time.Millisecond)
+
+	mock.mu.Lock()
+	assert.Equal(t, 1, mock.disableCalls)
+	assert.Equal(t, 1, mock.enableCalls)
+	mock.mu.Unlock()
+}
+
+func TestDebouncedControllerCooldownZeroBehavesLikeOriginal(t *testing.T) {
+	t.Parallel()
+	mock := &mockScaleToZeroer{}
+	c := NewDebouncedControllerWithCooldown(mock, 0)
+
+	require.NoError(t, c.Disable(t.Context()))
+	require.NoError(t, c.Enable(t.Context()))
+
+	assert.Equal(t, 1, mock.disableCalls)
+	assert.Equal(t, 1, mock.enableCalls)
 }


### PR DESCRIPTION
## Summary

Adds a configurable cooldown to the scale-to-zero `DebouncedController`. When the last active request completes, the re-enable is delayed by the cooldown period instead of firing immediately. If a new request arrives during the cooldown window, the pending re-enable is cancelled and STZ stays disabled.

This reduces the rate of control file toggling under rapid sequential request patterns while preserving correctness — STZ is always disabled when there's an active request, and always re-enabled after a quiet period.

The cooldown is set to 1 second. Zero cooldown preserves the original synchronous behavior.

## Changes

- `NewDebouncedControllerWithCooldown(ctrl, cooldown)` — new constructor with configurable cooldown
- `DebouncedController.Enable` — schedules a timer-based re-enable when cooldown > 0
- `DebouncedController.Disable` — cancels any pending re-enable timer
- `main.go` — uses 1s cooldown

## Test plan

- [x] Existing tests pass (backward compat with zero cooldown)
- [x] New test: cooldown delays the enable write
- [x] New test: new Disable cancels pending re-enable timer
- [x] New test: rapid sequential requests collapse to single Disable/Enable pair
- [x] New test: zero cooldown behaves identically to original

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces timer-based asynchronous re-enable behavior for scale-to-zero, which changes request/idle semantics and could leave STZ disabled longer or re-enable unexpectedly if the timer logic misfires. Configuration-driven cooldown adds operational variability but is bounded and covered by new unit tests.
> 
> **Overview**
> Adds a configurable *cooldown* to `DebouncedController` so scale-to-zero re-enable is delayed after the last request, and any new `Disable` during the window cancels the pending re-enable to avoid rapid toggling.
> 
> Wires the cooldown into the API server via new `SCALE_TO_ZERO_COOLDOWN` config (default `1s`) and expands `scaletozero` tests to cover delayed enable, cancellation, sequential-request collapse, and zero-cooldown backward compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eac9d3d79887fdee55884c9988401144295eaa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->