### PR TITLE
Only wait on IPv4 in waitForPort

### DIFF
--- a/server/cmd/chromium-launcher/main.go
+++ b/server/cmd/chromium-launcher/main.go
@@ -125,12 +125,13 @@ func execLookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
 
-// waitForPort waits until the given port is available for binding on both IPv4 and IPv6.
+// waitForPort waits until the given port is available for binding on IPv4.
 // This handles the delay after SIGKILL before the kernel releases the socket.
 // We disable SO_REUSEADDR to get an accurate check matching chromium's bind behavior.
+// Only IPv4 is checked because IPv6 is disabled at the kernel level in the VM.
 func waitForPort(port string, timeout time.Duration) {
 	deadline := time.Now().Add(timeout)
-	addrs := []string{"127.0.0.1:" + port, "[::1]:" + port}
+	addrs := []string{"127.0.0.1:" + port}
 
 	// ListenConfig with Control to disable SO_REUSEADDR for accurate port availability check
 	lc := &net.ListenConfig{
@@ -167,7 +168,7 @@ func waitForPort(port string, timeout time.Duration) {
 }
 
 // killExistingChromium kills any existing chromium browser processes and waits for them to die.
-// This ensures a clean restart where the new process can bind to both IPv4 and IPv6.
+// This ensures a clean restart where the new process can bind to IPv4.
 // Note: We use -x for exact match to avoid killing chromium-launcher itself.
 func killExistingChromium() {
 	// Kill chromium processes by exact name match.


### PR DESCRIPTION
## Summary

- Remove `[::1]` from `waitForPort` address list in `chromium-launcher/main.go`
- IPv6 is disabled at the kernel level in the VM (`disable_ipv6` sysctl), so checking `[::1]` port availability can block or fail, delaying Chromium startup and potentially causing profile load timeouts

One-line change: `addrs` goes from `["127.0.0.1:<port>", "[::1]:<port>"]` to `["127.0.0.1:<port>"]`.

## Test plan

- [x] `go test ./cmd/chromium-launcher/` passes
- [ ] Verify Chromium starts and profiles load correctly in headful + headless VMs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to pre-launch port checks; primary risk is missing an IPv6-only port conflict, which is mitigated by the target environment having IPv6 disabled.
> 
> **Overview**
> Updates `chromium-launcher`’s `waitForPort` to check port availability **only on IPv4** by removing the `[::1]` bind attempt, and updates related comments to reflect that IPv6 is disabled in the VM.
> 
> This avoids unnecessary delays/hangs during Chromium restarts when waiting for the devtools port to become free on an unavailable IPv6 loopback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2076b29fa89ba9ec1008c32360bac7aa67912262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->