### PR TITLE
fix: add delay between clipboard sync and paste keystroke

### DIFF
--- a/images/chromium-headful/client/src/components/video.vue
+++ b/images/chromium-headful/client/src/components/video.vue
@@ -851,6 +851,13 @@
       try {
         await this.syncClipboard()
 
+        // Give the neko server time to write the clipboard text to the Xorg
+        // selection before we trigger the paste. The clipboard update arrives
+        // via WebSocket while the keystroke travels the WebRTC data channel;
+        // the server processes key injection faster than the X11 selection
+        // write, so without this delay the remote pastes stale content.
+        await new Promise((resolve) => setTimeout(resolve, 80))
+
         // Send the full Ctrl+V sequence. We can't rely on Guacamole having
         // captured the original Cmd/Ctrl keydown because Safari may intercept
         // modifier shortcuts before they reach iframe JavaScript. And even if


### PR DESCRIPTION
## Summary

- Adds an 80ms delay between sending the clipboard update and the Ctrl+V keystroke in the live view paste handler
- Fixes the "one behind" clipboard issue where pasting consistently uses stale content

## Details

The clipboard update travels via WebSocket while the Ctrl+V keystroke travels via the WebRTC data channel. Even though the clipboard is sent first, the neko server processes key injection (X event queue) faster than the X11 clipboard selection write. Without the delay, the remote Chromium always pastes the *previous* clipboard content.

The 80ms delay gives the server time to complete the Xorg clipboard write before the paste keystroke arrives. This is a client-side workaround; the ideal fix would be server-side clipboard write acknowledgment.

Follow-up to #219.

## Test plan

- [ ] Open the live view inside a cross-origin iframe in Safari
- [ ] Copy text, Cmd+V into the live view — should paste correct text on the first attempt
- [ ] Copy different text, Cmd+V again — should paste the new text immediately (no "one behind")
- [ ] Verify right-click paste still works
- [ ] Test in Chrome to ensure no regressions

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized client-side timing change; main risk is introducing a slight paste delay or masking underlying server ordering issues.
> 
> **Overview**
> Adds an 80ms delay in `video.vue`’s `onPaste` handler between `syncClipboard()` and sending the remote Ctrl+V key sequence, to avoid pasting stale (“one behind”) clipboard content due to server-side X11 selection write latency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c1ce3a8b250992193262ba18856db53201fb629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->