### PR TITLE
fix: use paste event clipboardData for reliable first-paste in Safari iframes

### DIFF
--- a/images/chromium-headful/client/src/components/video.vue
+++ b/images/chromium-headful/client/src/components/video.vue
@@ -845,17 +845,32 @@
       this.focused = false
     }
 
-    async onPaste() {
+    async onPaste(event: ClipboardEvent) {
       if (!this.hosting || this.locked) return
 
       try {
-        await this.syncClipboard()
+        // Read clipboard text directly from the paste event. This is
+        // synchronous and works in every browser — including Safari
+        // cross-origin iframes that block navigator.clipboard.readText()
+        // when the parent page lacks a Permissions-Policy header.
+        const text = event.clipboardData?.getData('text/plain')
+
+        if (text && text !== this.clipboard) {
+          this.$accessor.remote.setClipboard(text)
+          this.$accessor.remote.sendClipboard(text)
+        } else if (!text) {
+          await this.syncClipboard()
+        }
+
+        // Give the neko server time to write the clipboard text to the Xorg
+        // selection before we trigger the paste. The clipboard update arrives
+        // via WebSocket while the keystroke travels the WebRTC data channel;
+        // without this delay the remote pastes stale content.
+        await new Promise((resolve) => setTimeout(resolve, 80))
 
         // Send the full Ctrl+V sequence. We can't rely on Guacamole having
         // captured the original Cmd/Ctrl keydown because Safari may intercept
-        // modifier shortcuts before they reach iframe JavaScript. And even if
-        // it did, the await above yields to the event loop, allowing keyup
-        // events to release Ctrl on the remote before we get here.
+        // modifier shortcuts before they reach iframe JavaScript.
         const ctrlKey = this.keyMap(0xffe3)
         const vKey = this.keyMap(0x0076)
         this.$client.sendData('keydown', { key: ctrlKey })


### PR DESCRIPTION
## Summary

- Read clipboard text directly from `event.clipboardData.getData('text/plain')` in `onPaste`, which works synchronously in every browser — including Safari cross-origin iframes that block `navigator.clipboard.readText()` when the parent page lacks a `Permissions-Policy` header.
- Fall back to `navigator.clipboard.readText()` (via `syncClipboard()`) only when `clipboardData` is unavailable.
- Add an 80ms delay before sending the Ctrl+V keystroke so the neko server has time to write the clipboard to the Xorg selection.

Supersedes #222. Fixes the "first paste doesn't work in Safari through the dashboard" issue (CUS-163 / KERNEL-459).

## Root Cause

The dashboard embeds the live view in a cross-origin iframe with `allow="clipboard-read; clipboard-write"` but does **not** send the `Permissions-Policy: clipboard-read=*, clipboard-write=*` HTTP header. Safari blocks `navigator.clipboard.readText()` in this configuration, so `syncClipboard()` silently errors and no clipboard text reaches the remote on the first paste.

`event.clipboardData` is always populated by the browser during a native paste event regardless of iframe permissions, making it the reliable primary clipboard source.

## Test plan

- [x] Safari: Open dashboard → live view iframe → copy text → Cmd+V → text should paste on first attempt
- [x] Chrome: Same flow, verify no regression
- [ ] Firefox: Same flow, verify no regression
- [x] Verify subsequent pastes with new clipboard content also work without "one behind" lag


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches clipboard and input-simulation timing; regressions could affect paste behavior across browsers or introduce subtle latency/race conditions in remote control.
> 
> **Overview**
> Improves remote paste reliability by changing `video.vue`’s `onPaste` handler to prefer synchronous clipboard reads from the native paste event (`event.clipboardData`) and only fall back to `syncClipboard()` when unavailable.
> 
> Adds a short (~80ms) delay before sending the Ctrl+V key sequence so the remote clipboard update can land before the paste keystroke, reducing “stale/one-behind” pastes (notably in Safari cross-origin iframes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff019f69be7f52919dda67ae429203bb7ec317cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->