### PR TITLE
Rename server e2e test job to disambiguate Vanta reporting

### DIFF
--- a/.github/workflows/server-test.yaml
+++ b/.github/workflows/server-test.yaml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/chromium-headless-image.yaml
     secrets: inherit
 
-  test:
+  test-server-e2e:
     runs-on: ubuntu-latest
     needs: [build-headful, build-headless]
     permissions:


### PR DESCRIPTION
## Summary

- Renames the `test` job in the "Test for the server/ directory" workflow to `test-server-e2e`
- The required branch protection check `test` now unambiguously maps to the "Test chromium-launcher" workflow, which has a 100% pass rate (vs server e2e at 45%)
- Prevents Vanta from potentially reporting success on the wrong `test` check when two checks share the same name

Same fix as kernel-images-private#160.

## Test plan

- [ ] Verify the `test` check from "Test chromium-launcher" still runs and is recognized as the required check
- [ ] Verify the renamed `test-server-e2e` check from "Test for the server/ directory" runs correctly under its new name

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only rename with no code or test behavior changes; main risk is misconfigured branch protection/required check names after the rename.
> 
> **Overview**
> Renames the GitHub Actions job in `server-test.yaml` from `test` to `test-server-e2e` so server e2e runs publish a distinct check name and don’t collide with other required `test` checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95c01d5f2c1283ca443728d5a3557e09a34676a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->