### PR TITLE
Add arc-length easing to mouse trajectory for natural velocity profile

### DIFF
--- a/server/lib/mousetrajectory/mousetrajectory.go
+++ b/server/lib/mousetrajectory/mousetrajectory.go
@@ -288,17 +288,28 @@ func normalDist(rng *rand.Rand, mean, stdDev float64) float64 {
 	return mean + stdDev*math.Sqrt(-2*math.Log(u1))*math.Cos(2*math.Pi*u2)
 }
 
-func (t *HumanizeMouseTrajectory) easeOutQuad(n float64) float64 {
-	return -n * (n - 2)
+// easeInOutCubic produces slow-fast-slow movement matching human motor control.
+// t ∈ [0,1] → [0,1] with zero velocity at endpoints and peak velocity at t=0.5.
+func easeInOutCubic(t float64) float64 {
+	if t < 0.5 {
+		return 4 * t * t * t
+	}
+	return 1 - math.Pow(-2*t+2, 3)/2
 }
 
 func (t *HumanizeMouseTrajectory) tweenPoints(points [][2]float64, opts *Options) [][2]float64 {
-	var totalLength float64
+	if len(points) < 2 {
+		return points
+	}
+
+	// Build cumulative arc-length table from source points.
+	cumLen := make([]float64, len(points))
 	for i := 1; i < len(points); i++ {
 		dx := points[i][0] - points[i-1][0]
 		dy := points[i][1] - points[i-1][1]
-		totalLength += math.Sqrt(dx*dx + dy*dy)
+		cumLen[i] = cumLen[i-1] + math.Sqrt(dx*dx+dy*dy)
 	}
+	totalLength := cumLen[len(cumLen)-1]
 
 	targetPoints := int(math.Min(
 		float64(defaultMaxPoints),
@@ -319,18 +330,52 @@ func (t *HumanizeMouseTrajectory) tweenPoints(points [][2]float64, opts *Options
 		targetPoints = 2
 	}
 
+	if totalLength < 1e-9 {
+		res := make([][2]float64, targetPoints)
+		for i := range res {
+			res[i] = points[0]
+		}
+		return res
+	}
+
+	// Sample at non-uniform arc-length positions using ease-in-out.
+	// The previous easeOutQuad sampled by array index, producing
+	// near-constant pixel distances between consecutive output points.
+	// This version samples along the curve's physical arc length with
+	// an ease-in-out profile: small pixel steps at start/end (slow
+	// velocity), large pixel steps in the middle (fast velocity).
+	// This matches the bell-shaped velocity profile of real human
+	// arm movements (Fitts's law / minimum-jerk trajectory model).
 	res := make([][2]float64, targetPoints)
-	for i := 0; i < targetPoints; i++ {
+	res[0] = points[0]
+	res[targetPoints-1] = points[len(points)-1]
+
+	for i := 1; i < targetPoints-1; i++ {
 		tt := float64(i) / float64(targetPoints-1)
-		easedT := t.easeOutQuad(tt)
-		idx := int(easedT * float64(len(points)-1))
-		if idx < 0 {
-			idx = 0
+		easedT := easeInOutCubic(tt)
+		targetLen := easedT * totalLength
+
+		// Binary search for the segment containing targetLen.
+		lo, hi := 0, len(cumLen)-1
+		for lo < hi-1 {
+			mid := (lo + hi) / 2
+			if cumLen[mid] < targetLen {
+				lo = mid
+			} else {
+				hi = mid
+			}
 		}
-		if idx >= len(points) {
-			idx = len(points) - 1
+
+		// Interpolate within the segment [lo, hi].
+		segLen := cumLen[hi] - cumLen[lo]
+		var frac float64
+		if segLen > 1e-9 {
+			frac = (targetLen - cumLen[lo]) / segLen
 		}
-		res[i] = points[idx]
+		res[i] = [2]float64{
+			points[lo][0] + frac*(points[hi][0]-points[lo][0]),
+			points[lo][1] + frac*(points[hi][1]-points[lo][1]),
+		}
 	}
 	return res
 }

--- a/server/lib/mousetrajectory/mousetrajectory_test.go
+++ b/server/lib/mousetrajectory/mousetrajectory_test.go
@@ -163,6 +163,55 @@ func TestGenerateMultiSegmentTrajectory_SinglePoint(t *testing.T) {
 	assert.Equal(t, 100, result.Points[0][1])
 }
 
+func TestHumanizeMouseTrajectory_VelocityProfile(t *testing.T) {
+	// Arc-length easing should produce a bell-shaped velocity profile:
+	// small pixel steps at start/end, large steps in the middle.
+	traj := NewHumanizeMouseTrajectoryWithSeed(0, 0, 400, 0, 42)
+	points := traj.GetPointsInt()
+	require.GreaterOrEqual(t, len(points), 10)
+
+	distances := make([]float64, len(points)-1)
+	for i := 1; i < len(points); i++ {
+		dx := float64(points[i][0] - points[i-1][0])
+		dy := float64(points[i][1] - points[i-1][1])
+		distances[i-1] = math.Sqrt(dx*dx + dy*dy)
+	}
+
+	// First quarter should have smaller average step than middle half.
+	n := len(distances)
+	q1End := n / 4
+	midStart := n / 4
+	midEnd := 3 * n / 4
+
+	var sumFirst, sumMid float64
+	for i := 0; i < q1End; i++ {
+		sumFirst += distances[i]
+	}
+	for i := midStart; i < midEnd; i++ {
+		sumMid += distances[i]
+	}
+	avgFirst := sumFirst / float64(q1End)
+	avgMid := sumMid / float64(midEnd-midStart)
+
+	assert.Greater(t, avgMid, avgFirst,
+		"middle steps (avg=%.2f) should be larger than initial steps (avg=%.2f) for acceleration profile",
+		avgMid, avgFirst)
+
+	// Step distance variance should be substantial (not near-constant).
+	var wN int
+	var wMean, wM2 float64
+	for _, d := range distances {
+		wN++
+		delta := d - wMean
+		wMean += delta / float64(wN)
+		wM2 += delta * (d - wMean)
+	}
+	distVariance := wM2 / float64(wN-1)
+
+	assert.Greater(t, distVariance, 5.0,
+		"step distance variance (%.2f) should be substantial for human-like velocity profile", distVariance)
+}
+
 func TestGenerateMultiSegmentTrajectory_ContinuousPath(t *testing.T) {
 	waypoints := [][2]int{{100, 100}, {500, 500}, {900, 100}, {1300, 500}}
 	result := GenerateMultiSegmentTrajectory(waypoints, 1920, 1080, nil)


### PR DESCRIPTION
## Summary

Replaces index-based `easeOutQuad` point sampling in `tweenPoints` with arc-length-based `easeInOutCubic` sampling, so the Bezier trajectory produces physically varying pixel distances per step — small at start/end, large in the middle.

## Problem

PR #228 added Gaussian timing jitter to mouse movement delays, but velocity = distance / time. The distance component was still near-constant (~15px per step) because the old `easeOutQuad` sampled by array index, which doesn't translate to physical spacing:

```
step 1: 15px in 28ms → velocity 0.54
step 2: 15px in 42ms → velocity 0.36
step 3: 15px in 35ms → velocity 0.43
step 4: 15px in 51ms → velocity 0.29
```

Velocity variance stays low (~0.08-3.21) despite varying timing, because pixel distance is constant.

Real human movement has a bell-shaped velocity profile (Fitts's law):

```
step 1:  3px in 45ms → velocity 0.07  (starting slow)
step 2: 12px in 20ms → velocity 0.60  (accelerating)
step 3: 25px in 15ms → velocity 1.67  (fast middle)
step 4:  8px in 55ms → velocity 0.15  (decelerating)
```

## Fix

`tweenPoints` now:

1. Builds a cumulative arc-length table along the raw Bezier curve
2. Maps uniform `t ∈ [0,1]` through `easeInOutCubic` to get non-uniform arc-length positions
3. Binary searches the arc-length table and linearly interpolates to get precise point coordinates

This produces:
- **Start/end:** dense points, small pixel steps → slow velocity (acceleration/deceleration)
- **Middle:** sparse points, large pixel steps → fast velocity (peak speed)

Combined with Gaussian timing from #228, velocity = (varying distance) / (varying time) → high variance matching human motor noise.

## Test plan

- [x] `TestHumanizeMouseTrajectory_VelocityProfile` — verifies middle steps are larger than initial steps (acceleration profile) and step distance variance is substantial (>5)
- [x] All 15 existing mousetrajectory tests pass
- [x] All computer API tests pass

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the core point-sampling algorithm and could alter downstream mouse movement behavior/anti-bot characteristics, though it’s localized and covered by a new regression test.
> 
> **Overview**
> Updates `HumanizeMouseTrajectory.tweenPoints` to replace index-based `easeOutQuad` sampling with **arc-length-based sampling** driven by `easeInOutCubic`, including binary search + interpolation and guards for short/zero-length paths, so consecutive step distances vary (slow at start/end, faster mid-curve).
> 
> Adds `TestHumanizeMouseTrajectory_VelocityProfile` to assert the new bell-shaped step-distance profile (middle steps larger than early steps, with non-trivial variance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2c8aa547bf1d24c35c3f1e9767092c5bd570d02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->