### PR TITLE
Stabilize browser e2e setup

### DIFF
--- a/server/e2e/e2e_chromium_test.go
+++ b/server/e2e/e2e_chromium_test.go
@@ -72,13 +72,27 @@ func ensurePlaywrightDeps(t *testing.T) {
 
 	playwrightDepsOnce.Do(func() {
 		nodeModulesPath := getPlaywrightPath() + "/node_modules"
+		tsxPath := getPlaywrightPath() + "/node_modules/tsx/dist/cli.mjs"
 		if _, err := os.Stat(nodeModulesPath); os.IsNotExist(err) {
+			t.Log("Installing playwright dependencies...")
 			cmd := exec.Command("pnpm", "install")
 			cmd.Dir = getPlaywrightPath()
 			output, err := cmd.CombinedOutput()
 			if err != nil {
 				playwrightDepsErr = fmt.Errorf("failed to install playwright dependencies: %w\noutput: %s", err, string(output))
+				return
 			}
+			t.Log("Playwright dependencies installed successfully")
+		} else if _, err := os.Stat(tsxPath); os.IsNotExist(err) {
+			t.Log("Installing playwright dependencies...")
+			cmd := exec.Command("pnpm", "install")
+			cmd.Dir = getPlaywrightPath()
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				playwrightDepsErr = fmt.Errorf("failed to install playwright dependencies: %w\noutput: %s", err, string(output))
+				return
+			}
+			t.Log("Playwright dependencies installed successfully")
 		}
 	})
 

--- a/server/e2e/e2e_zip_transfer_bench_test.go
+++ b/server/e2e/e2e_zip_transfer_bench_test.go
@@ -54,6 +54,7 @@ func TestZipTransferTiming(t *testing.T) {
 	err = populateUserData(ctx, client)
 	require.NoError(t, err, "failed to populate user-data")
 	t.Logf("User-data population took %dms", time.Since(populateStart).Milliseconds())
+	stopChromiumForStableUserData(t, ctx, client)
 
 	// Get initial directory size for reference
 	dirSize, fileCount, err := getDirStats(ctx, client, "/home/kernel/user-data")
@@ -137,6 +138,25 @@ func populateUserData(ctx context.Context, client *instanceoapi.ClientWithRespon
 		return fmt.Errorf("playwright execution failed: %s", errMsg)
 	}
 	return nil
+}
+
+func stopChromiumForStableUserData(t *testing.T, ctx context.Context, client *instanceoapi.ClientWithResponses) {
+	t.Helper()
+
+	args := []string{"-c", "/etc/supervisor/supervisord.conf", "stop", "chromium"}
+	req := instanceoapi.ProcessExecJSONRequestBody{
+		Command: "supervisorctl",
+		Args:    &args,
+	}
+	rsp, err := client.ProcessExecWithResponse(ctx, req)
+	require.NoError(t, err, "failed to stop chromium before reading user-data")
+	require.Equal(t, http.StatusOK, rsp.StatusCode(), "unexpected status stopping chromium: %s body=%s", rsp.Status(), string(rsp.Body))
+	if rsp.JSON200 != nil && rsp.JSON200.ExitCode != nil {
+		require.Equal(t, 0, *rsp.JSON200.ExitCode, "supervisorctl stop chromium failed")
+	}
+
+	// Give Chromium's profile databases a brief moment to settle after shutdown.
+	time.Sleep(500 * time.Millisecond)
 }
 
 // getDirStats returns approximate size and file count of a directory
@@ -286,6 +306,7 @@ func TestZstdTransferTiming(t *testing.T) {
 	err = populateUserData(ctx, client)
 	require.NoError(t, err, "failed to populate user-data")
 	t.Logf("User-data population took %dms", time.Since(populateStart).Milliseconds())
+	stopChromiumForStableUserData(t, ctx, client)
 
 	// Get directory stats for reference
 	dirSize, fileCount, err := getDirStats(ctx, client, "/home/kernel/user-data")
@@ -436,6 +457,7 @@ func TestZipVsZstdComparison(t *testing.T) {
 	t.Logf("Populating user-data by browsing...")
 	err = populateUserData(ctx, client)
 	require.NoError(t, err, "failed to populate user-data")
+	stopChromiumForStableUserData(t, ctx, client)
 
 	// Get directory stats
 	dirSize, fileCount, err := getDirStats(ctx, client, "/home/kernel/user-data")


### PR DESCRIPTION
## Summary
- reinstall Playwright dependencies when `node_modules` exists but `tsx` is missing
- stop Chromium before transfer benchmarks archive `/home/kernel/user-data`, avoiding live profile writes during zip/zstd creation

## Test plan
- `PATH="/usr/local/go/bin:$PATH" go test -v -race ./e2e/ -run 'TestZipTransferTiming|TestZstdTransferTiming|TestZipVsZstdComparison' -count=1`
- `PATH="/usr/local/go/bin:$PATH" go test -v -race $(go list ./... | rg -v '/e2e$')`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to e2e/benchmark test setup, mainly improving dependency installation checks and reducing flakiness from live Chromium profile writes.
> 
> **Overview**
> Improves e2e Chromium test reliability by re-running `pnpm install` when Playwright’s `node_modules` exists but the `tsx` CLI is missing, with clearer install logging and early error return.
> 
> Stabilizes the zip/zstd transfer benchmark tests by explicitly stopping `chromium` via `supervisorctl` (and briefly sleeping) before reading/archiving `/home/kernel/user-data`, avoiding races with in-flight profile writes during compression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa5ed6110874415349cee8026afcb3576dcbdd79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->