### PR TITLE
feat: graceful shutdown improvements for browser VMs

### DIFF
--- a/images/chromium-headful/wrapper.sh
+++ b/images/chromium-headful/wrapper.sh
@@ -186,9 +186,9 @@ cleanup () {
   echo "[wrapper] Cleaning up..."
   # Re-enable scale-to-zero if the script terminates early
   enable_scale_to_zero
+  supervisorctl -c /etc/supervisor/supervisord.conf stop kernel-images-api || true
   supervisorctl -c /etc/supervisor/supervisord.conf stop chromedriver || true
   supervisorctl -c /etc/supervisor/supervisord.conf stop chromium || true
-  supervisorctl -c /etc/supervisor/supervisord.conf stop kernel-images-api || true
   supervisorctl -c /etc/supervisor/supervisord.conf stop dbus || true
   # Stop log tailers
   if [[ -n "${tail_pids[*]:-}" ]]; then

--- a/images/chromium-headless/image/wrapper.sh
+++ b/images/chromium-headless/image/wrapper.sh
@@ -227,11 +227,11 @@ cleanup () {
   echo "[wrapper] Cleaning up..."
   # Re-enable scale-to-zero if the script terminates early
   enable_scale_to_zero
+  supervisorctl -c /etc/supervisor/supervisord.conf stop kernel-images-api || true
   supervisorctl -c /etc/supervisor/supervisord.conf stop chromedriver || true
   supervisorctl -c /etc/supervisor/supervisord.conf stop chromium || true
   supervisorctl -c /etc/supervisor/supervisord.conf stop xvfb || true
   supervisorctl -c /etc/supervisor/supervisord.conf stop dbus || true
-  supervisorctl -c /etc/supervisor/supervisord.conf stop kernel-images-api || true
   # Stop log tailers
   if [[ -n "${tail_pids[*]:-}" ]]; then
     for tp in "${tail_pids[@]}"; do

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -149,9 +151,14 @@ func main() {
 		fs.ServeHTTP(w, r)
 	})
 
+	r.Get("/health", healthHandler(upstreamMgr))
+
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", config.Port),
 		Handler: r,
+		BaseContext: func(_ net.Listener) context.Context {
+			return ctx
+		},
 	}
 
 	// wait up to 10 seconds for initial upstream; exit nonzero if not found
@@ -191,6 +198,9 @@ func main() {
 	srvDevtools := &http.Server{
 		Addr:    fmt.Sprintf("0.0.0.0:%d", config.DevToolsProxyPort),
 		Handler: rDevtools,
+		BaseContext: func(_ net.Listener) context.Context {
+			return ctx
+		},
 	}
 
 	// ChromeDriver proxy: intercepts POST /session to inject the DevTools proxy
@@ -216,6 +226,9 @@ func main() {
 	srvChromeDriver := &http.Server{
 		Addr:    fmt.Sprintf("0.0.0.0:%d", config.ChromeDriverProxyPort),
 		Handler: rChromeDriver,
+		BaseContext: func(_ net.Listener) context.Context {
+			return ctx
+		},
 	}
 
 	go func() {
@@ -266,6 +279,74 @@ func main() {
 
 	if err := g.Wait(); err != nil {
 		slogger.Error("server failed to shutdown", "err", err)
+	}
+}
+
+func healthHandler(mgr *devtoolsproxy.UpstreamManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cdpStatus := "ok"
+		if mgr.Current() == "" {
+			cdpStatus = "not_ready"
+		}
+
+		chromeStatus := "ok"
+		chromeProbeCtx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+		req, _ := http.NewRequestWithContext(chromeProbeCtx, http.MethodGet, "http://127.0.0.1:9223/json/version", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil || resp.StatusCode != http.StatusOK {
+			chromeStatus = "error"
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+
+		status := http.StatusOK
+		if cdpStatus != "ok" || chromeStatus != "ok" {
+			status = http.StatusServiceUnavailable
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		json.NewEncoder(w).Encode(map[string]string{
+			"cdp_status":    cdpStatus,
+			"chrome_status": chromeStatus,
+		})
+	}
+}
+
+// wsTracker tracks active WebSocket connections so they can be
+// closed with a proper close frame during shutdown.
+type wsTracker struct {
+	mu    sync.Mutex
+	conns map[*wsTrackerEntry]struct{}
+}
+
+type wsTrackerEntry struct {
+	closeFunc func()
+}
+
+func newWSTracker() *wsTracker {
+	return &wsTracker{conns: make(map[*wsTrackerEntry]struct{})}
+}
+
+func (t *wsTracker) Add(closeFunc func()) func() {
+	entry := &wsTrackerEntry{closeFunc: closeFunc}
+	t.mu.Lock()
+	t.conns[entry] = struct{}{}
+	t.mu.Unlock()
+	return func() {
+		t.mu.Lock()
+		delete(t.conns, entry)
+		t.mu.Unlock()
+	}
+}
+
+func (t *wsTracker) CloseAll() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for entry := range t.conns {
+		entry.closeFunc()
 	}
 }
 


### PR DESCRIPTION
## Summary

Reorders VM shutdown cleanup and improves kernel-images-api shutdown behavior so WebSocket connections can drain before Chrome is killed.

## Context (KERNEL-1252)

Phase 1 (kernel/kernel#1977) adds provider.Stop() before provider.Destroy(), delivering SIGTERM to the VM. This PR (Phase 2) fixes the image to handle that SIGTERM gracefully.

Note: chromium.conf keeps stopsignal=KILL intentionally for speed (per Raf). Graceful drain happens in kernel-images-api before Chrome is stopped.

## Changes

### 1. wrapper.sh: reorder cleanup (both headful/headless)
kernel-images-api stops first so it can drain active WebSocket proxy connections while Chrome is still alive.

### 2. kernel-images-api: BaseContext on all HTTP servers
SIGTERM cancels all in-flight request contexts.

### 3. kernel-images-api: GET /health endpoint
Returns {"cdp_status":"ok","chrome_status":"ok"} with live Chrome probe. Returns 503 when degraded.

### 4. kernel-images-api: wsTracker type
Tracks active WebSocket connections for future explicit close-on-shutdown.

## Test plan

- [x] go build ./cmd/api/... passes
- [ ] Deploy image to staging
- [ ] Run test-graceful-shutdown.js E2E test
- [ ] Verify kernel-images-api stops before chromium in VM logs
- [ ] Verify GET /health returns {"cdp_status":"ok","chrome_status":"ok"}

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM shutdown ordering and HTTP server context propagation, which can affect session stability and termination behavior. Adds a new `/health` probe that changes runtime observability and may influence orchestration decisions if it reports degraded status.
> 
> **Overview**
> Improves browser VM shutdown behavior by stopping `kernel-images-api` *before* Chromium/ChromeDriver in both headful and headless `wrapper.sh`, allowing API/WebSocket proxy traffic to drain while Chrome is still alive.
> 
> Updates `server/cmd/api/main.go` to propagate the SIGTERM-cancelled root context into all three HTTP servers via `BaseContext`, adds a `/health` endpoint that reports CDP readiness and actively probes Chrome (`/json/version`) returning 503 when degraded, and introduces a `wsTracker` utility to track/close active WebSocket connections during shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ee1e89b865de72834aa2a22d61ef6f3707834f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->