### PR TITLE
Sync upstream - v46/v50 (20260609)

### DIFF
--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -304,8 +304,10 @@ RUN set -eux; \
     chmod +x /usr/local/bin/chromedriver /opt/chrome-for-testing/chromium; \
     rm -rf /tmp/chrome.zip /tmp/cd.zip /tmp/chromedriver-linux64
 
-# Copy Chromium policy configuration
-RUN mkdir -p /etc/chromium/policies/managed
+# Chrome for Testing reads managed policies from /etc/opt/chrome_for_testing/policies, but
+# the server writes them to /etc/chromium/policies. Symlink so writes flow to the real path.
+RUN mkdir -p /etc/chromium/policies/managed /etc/opt/chrome_for_testing && \
+    ln -sfn /etc/chromium/policies /etc/opt/chrome_for_testing/policies
 COPY shared/chromium-policies/managed/policy.json /etc/chromium/policies/managed/policy.json
 
 # install Node.js 22.x by copying from the node:22-bullseye-slim stage

--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -279,24 +279,30 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-ap
     chown $USERNAME /var/log/neko/ /tmp/runtime-$USERNAME; \
     chown -R $USERNAME:$USERNAME /home/$USERNAME;
 
-# install chromium and sqlite3 for debugging the cookies file
+# sqlite3 for debugging the cookies file; runtime libs are chrome-for-testing's listed deb.deps.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-apt-cache \
     --mount=type=cache,target=/var/lib/apt,sharing=locked,id=$CACHEIDPREFIX-apt-lib \
-    add-apt-repository -y ppa:xtradeb/apps;
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-apt-cache \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=$CACHEIDPREFIX-apt-lib \
-    apt update -y && \
-    apt -y install chromium && \
-    apt --no-install-recommends -y install sqlite3;
+    apt-get update -y && \
+    apt-get --no-install-recommends -y install \
+        sqlite3 \
+        libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 \
+        libcups2 libdbus-1-3 libdrm2 libgbm1 libglib2.0-0 libgtk-3-0 \
+        libnspr4 libnss3 libpango-1.0-0 libxcomposite1 libxdamage1 \
+        libxext6 libxfixes3 libxkbcommon0;
 
-# Chromedriver and Chromium are not necessarily the same version.
-ARG CHROMEDRIVER_VERSION=146.0.7680.165
+# Install Chrome + ChromeDriver as a matched pair from chrome-for-testing so they cannot drift apart.
+ARG CHROME_VERSION=148.0.7778.97
 RUN set -eux; \
-    curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROMEDRIVER_VERSION}/linux64/chromedriver-linux64.zip" -o /tmp/cd.zip; \
-    unzip /tmp/cd.zip -d /tmp; \
+    curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chrome-linux64.zip" -o /tmp/chrome.zip; \
+    curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chromedriver-linux64.zip" -o /tmp/cd.zip; \
+    unzip -q /tmp/chrome.zip -d /opt; \
+    unzip -q /tmp/cd.zip -d /tmp; \
+    mv /opt/chrome-linux64 /opt/chrome-for-testing; \
+    mv /opt/chrome-for-testing/chrome /opt/chrome-for-testing/chromium; \
+    ln -sf /opt/chrome-for-testing/chromium /usr/bin/chromium; \
     mv /tmp/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver; \
-    chmod +x /usr/local/bin/chromedriver; \
-    rm -rf /tmp/cd.zip /tmp/chromedriver-linux64
+    chmod +x /usr/local/bin/chromedriver /opt/chrome-for-testing/chromium; \
+    rm -rf /tmp/chrome.zip /tmp/cd.zip /tmp/chromedriver-linux64
 
 # Copy Chromium policy configuration
 RUN mkdir -p /etc/chromium/policies/managed

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -166,8 +166,10 @@ RUN set -eux; \
     chmod +x /usr/local/bin/chromedriver /opt/chrome-for-testing/chromium; \
     rm -rf /tmp/chrome.zip /tmp/cd.zip /tmp/chromedriver-linux64
 
-# Copy Chromium policy configuration
-RUN mkdir -p /etc/chromium/policies/managed
+# Chrome for Testing reads managed policies from /etc/opt/chrome_for_testing/policies, but
+# the server writes them to /etc/chromium/policies. Symlink so writes flow to the real path.
+RUN mkdir -p /etc/chromium/policies/managed /etc/opt/chrome_for_testing && \
+    ln -sfn /etc/chromium/policies /etc/opt/chrome_for_testing/policies
 COPY shared/chromium-policies/managed/policy.json /etc/chromium/policies/managed/policy.json
 
 # Install FFmpeg (latest static build) for the recording server

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -124,7 +124,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-ap
     libxfixes3 \
     libxrandr2 \
     libgbm1 \
-    libnss3; \
+    libdbus-1-3 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libxext6; \
     apt-get -yqq --no-install-recommends install \
     ca-certificates \
     curl \

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -136,6 +136,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-ap
     dbus-x11 \
     xvfb \
     x11-utils \
+    x11-xserver-utils \
     xclip \
     xdotool \
     fontconfig \

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -146,24 +146,25 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-ap
     supervisor; \
     fc-cache -f
 
-# install chromium and sqlite3 for debugging the cookies file
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-apt-cache \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=$CACHEIDPREFIX-apt-lib \
-    add-apt-repository -y ppa:xtradeb/apps
+# sqlite3 for debugging the cookies file; unzip for the chrome-for-testing archives below.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-apt-cache \
     --mount=type=cache,target=/var/lib/apt,sharing=locked,id=$CACHEIDPREFIX-apt-lib \
     apt-get update -y && \
-    apt-get -y install chromium && \
     apt-get --no-install-recommends -y install sqlite3 unzip;
 
-# Chromedriver and Chromium are not necessarily the same version.
-ARG CHROMEDRIVER_VERSION=146.0.7680.165
+# Install Chrome + ChromeDriver as a matched pair from chrome-for-testing so they cannot drift apart.
+ARG CHROME_VERSION=148.0.7778.97
 RUN set -eux; \
-    curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROMEDRIVER_VERSION}/linux64/chromedriver-linux64.zip" -o /tmp/cd.zip; \
-    unzip /tmp/cd.zip -d /tmp; \
+    curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chrome-linux64.zip" -o /tmp/chrome.zip; \
+    curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chromedriver-linux64.zip" -o /tmp/cd.zip; \
+    unzip -q /tmp/chrome.zip -d /opt; \
+    unzip -q /tmp/cd.zip -d /tmp; \
+    mv /opt/chrome-linux64 /opt/chrome-for-testing; \
+    mv /opt/chrome-for-testing/chrome /opt/chrome-for-testing/chromium; \
+    ln -sf /opt/chrome-for-testing/chromium /usr/bin/chromium; \
     mv /tmp/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver; \
-    chmod +x /usr/local/bin/chromedriver; \
-    rm -rf /tmp/cd.zip /tmp/chromedriver-linux64
+    chmod +x /usr/local/bin/chromedriver /opt/chrome-for-testing/chromium; \
+    rm -rf /tmp/chrome.zip /tmp/cd.zip /tmp/chromedriver-linux64
 
 # Copy Chromium policy configuration
 RUN mkdir -p /etc/chromium/policies/managed


### PR DESCRIPTION
## Summary

Sync branch updated with new commits from the private `main` branch. Upstream and kernel-browser were already up to date.

## Date of sync

2026-06-09

## Private sync

Merged new commits from `origin/main` into `sync/upstream-release`:

- `274851b` — Merge pull request #240 from kernel/raf/nvenc-preroll-forced-idr
- `062b138` — Address review: honest probe-failure path, basename ffprobe resolution, surface ffprobe stderr
- `1722c4d` — Fix NVENC startup-preroll trim so it actually removes the preroll

**Files changed:**
- `server/lib/recorder/ffmpeg.go` — NVENC preroll trim fix and related recorder improvements
- `server/lib/recorder/ffmeg_test.go` — Test coverage for preroll trim behavior

## kernel-browser

No update needed — already at latest release `v145.0.7632.75-r16`.

## Upstream merge

No upstream merge needed — `sync/upstream-release` already contains all commits from `upstream/main`.

## Merge conflicts

None — the private main merge was clean.

## New image versions

- headless: v46
- headful: v50