### PR TITLE
fix: escape HTML attribute values in markdown htmlTag to prevent stored XSS

### DIFF
--- a/images/chromium-headful/client/src/components/markdown.ts
+++ b/images/chromium-headful/client/src/components/markdown.ts
@@ -37,6 +37,15 @@ interface HTMLAttributes {
 
 interface MarkdownState extends State {}
 
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/'/g, '&#x27;')
+}
+
 function htmlTag(
   tagName: string,
   content: string,
@@ -58,7 +67,7 @@ function htmlTag(
   let attributeString = ''
   for (const attr in attributes) {
     if (Object.prototype.hasOwnProperty.call(attributes, attr) && attributes[attr]) {
-      attributeString += ` ${attr}="${attributes[attr]}"` // md.sanitizeText(attr)
+      attributeString += ` ${attr}="${escapeAttr(attributes[attr])}"`
     }
   }
 


### PR DESCRIPTION
## Vulnerability Summary

**CWE-79 (Stored Cross-Site Scripting)** in `images/chromium-headful/client/src/components/markdown.ts`

The `htmlTag` function constructs HTML by interpolating attribute values directly into the output string without escaping. When user-supplied markdown content flows through the renderer (e.g., link URLs, class names), an attacker can break out of an HTML attribute by injecting quote characters and inject arbitrary HTML/JavaScript.

For example, a crafted markdown link like `[click](x" onclick="alert(1))` would produce an `<a>` tag where the attacker escapes the `href` attribute and injects an event handler. While `md.sanitizeUrl` provides some protection for `href` specifically, it does not prevent attribute breakout via `"` characters, and it does not apply to other attributes like `class` or `title` that also flow through `htmlTag`.

**Severity:** High — any user who can submit markdown content (e.g., in the chat interface) can achieve stored XSS, executing JavaScript in other users' browsers.

## Fix

Added an `escapeAttr` function that encodes `&`, `"`, `<`, `>`, and `'` before interpolating values into HTML attributes. This is the standard mitigation for attribute injection — it ensures user input cannot break out of the quoted attribute context.

The fix is minimal (10 lines added, 1 line changed) and only affects the attribute interpolation path in `htmlTag`.

## Testing

- Verified that the `escapeAttr` function correctly encodes all five dangerous characters
- Confirmed that normal markdown rendering (links, images, formatting) is unaffected since the escaping only transforms characters that should never appear unescaped in attribute values
- Reviewed that the fix does not double-escape, since this is the only point where attribute values are interpolated into HTML

## Security Analysis

We verified this is exploitable because `htmlTag` is the central HTML generation function used by all markdown rendering rules (links, images, code blocks, etc.). User-controlled content reaches attribute values through the markdown parsing pipeline. The existing `sanitizeUrl` check only validates URL schemes — it does not escape HTML metacharacters, and it only applies to `href`/`src` attributes, leaving other attributes completely unprotected. Before submitting, we considered whether the browser's own parsing or a Content Security Policy might prevent exploitation, but there is no CSP configured in the client, and the HTML is inserted via innerHTML-style rendering, so injected scripts and event handlers execute.

---



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the markdown HTML renderer used across user-generated content; while the change is small, it alters HTML output and could affect rendering/escaping behavior broadly.
> 
> **Overview**
> **Hardens markdown-to-HTML output against attribute injection/XSS.**
> 
> Adds `escapeAttr` and applies it when `htmlTag` interpolates attribute values, ensuring characters like `"`, `'`, `<`, `>` and `&` are encoded before being emitted into HTML attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f3c69c3d73adc21d6a380a311f6123cb31c6b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->