### PR TITLE
Respect provided live-view credentials

### DIFF
--- a/images/chromium-headful/client/src/components/connect.vue
+++ b/images/chromium-headful/client/src/components/connect.vue
@@ -102,8 +102,13 @@
         displayname = this.$accessor.displayname || usr
       }
 
-      // KERNEL: auto-login
-      this.$accessor.login({ displayname: 'kernel', password: 'admin' })
+      // KERNEL: auto-login, but respect caller-supplied credentials first.
+      // This keeps the legacy fallback for existing deployments while allowing
+      // embeds and links that provide explicit credentials to work as intended.
+      this.$accessor.login({
+        displayname: displayname || 'kernel',
+        password: password || 'admin',
+      })
       this.autoPassword = null
     }
 


### PR DESCRIPTION
Summary
- make the headful live-view client use caller-supplied pwd and usr values when present
- preserve the current kernel/admin fallback for existing deployments that do not provide explicit credentials

Why
The live-view client already parses pwd and usr from the URL and reads persisted login state, but the mounted login path currently ignores those values and always logs in as kernel/admin.

That means credential-bearing embed links and custom login state do not work as intended, and the client always falls back to the hardcoded admin path even when explicit credentials were supplied.

This PR keeps the change narrow. It does not redesign Neko auth or change existing default behavior when no credentials are supplied. It only makes the existing credential hooks actually take effect.

Testing
- manual code-path validation on images/chromium-headful/client/src/components/connect.vue
- no frontend test harness appears to be configured in this repository for the Vue client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the headful client’s auto-login behavior to use URL/persisted `usr`/`pwd` when present, which can affect authentication flows and embedded link behavior. Risk is limited because it preserves the existing `kernel`/`admin` fallback when no credentials are provided.
> 
> **Overview**
> Updates the headful live-view client’s `connect.vue` auto-login path to **prefer caller-supplied credentials** (URL `usr`/`pwd` or persisted accessor values) instead of always logging in as `kernel`/`admin`.
> 
> Keeps the legacy `kernel`/`admin` defaults as a fallback, while still removing `usr`/`pwd` from the URL after they’re consumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b7411d2b2f664a0ecf636c8d9236748b62a3171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->