### PR TITLE
recorder: pad odd source dimensions before libx264 encode

### DIFF
--- a/server/lib/recorder/ffmeg_test.go
+++ b/server/lib/recorder/ffmeg_test.go
@@ -68,6 +68,21 @@ func TestFFmpegRecorder_Params(t *testing.T) {
 	assert.Equal(t, *params.OutputDir, *got.OutputDir)
 }
 
+func TestFFmpegArgs_PadsOddDimensions(t *testing.T) {
+	tempDir := t.TempDir()
+	args, err := ffmpegArgs(defaultParams(tempDir), filepath.Join(tempDir, "out.mp4"))
+	require.NoError(t, err)
+
+	var vf string
+	for i, a := range args {
+		if a == "-vf" && i+1 < len(args) {
+			vf = args[i+1]
+			break
+		}
+	}
+	assert.Equal(t, "pad=ceil(iw/2)*2:ceil(ih/2)*2", vf)
+}
+
 func TestFFmpegRecorder_ForceStop(t *testing.T) {
 	tempDir := t.TempDir()
 	rec := &FFmpegRecorder{

--- a/server/lib/recorder/ffmpeg.go
+++ b/server/lib/recorder/ffmpeg.go
@@ -498,6 +498,10 @@ func ffmpegArgs(params FFmpegRecordingParams, outputPath string) ([]string, erro
 
 	// Output options next
 	args = append(args, []string{
+		// yuv420p requires even width and height; pad odd source dimensions by one pixel
+		// so libx264 doesn't fail to open the encoder.
+		"-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+
 		// Video encoding
 		"-c:v", "libx264",
 		"-profile:v", "high", // Explicit web-compatible profile


### PR DESCRIPTION
## Summary

libx264 with `yuv420p` requires both width and height to be divisible by 2 (4:2:0 chroma subsampling). When the captured display has an odd vertical (or horizontal) pixel count, ffmpeg fails to open the encoder with `width/height not divisible by 2` and exits almost immediately — but `Start()` only waits 250ms for a startup error, so the API still returns 200 and the caller is left with a zero-byte mp4.

This change adds a `-vf pad=ceil(iw/2)*2:ceil(ih/2)*2` filter so odd source dimensions are padded by a single pixel of black before encode. Even dimensions are unchanged.

## Repro

```
$ ffmpeg -f lavfi -i color=red:size=641x481:rate=5 -t 1 -c:v libx264 -pix_fmt yuv420p -y out.mp4
[libx264] width not divisible by 2 (641x481)
[enc:libx264] Could not open encoder before EOF
$ ls -la out.mp4
-rw-r--r-- 1 user user 0 ... out.mp4
```

With the filter:

```
$ ffmpeg -f lavfi -i color=red:size=641x481:rate=5 -t 1 -vf "pad=ceil(iw/2)*2:ceil(ih/2)*2" -c:v libx264 -pix_fmt yuv420p -y out.mp4
$ ffprobe out.mp4
width=642 height=482
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./lib/recorder/... -v` (existing tests pass, new `TestFFmpegArgs_PadsOddDimensions` covers the args)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ffmpeg encoding arguments for all recordings, which could subtly affect output dimensions/compatibility if the filter order or padding behavior differs across inputs/platforms.
> 
> **Overview**
> **Prevents recordings from failing on odd-sized displays** by adding `-vf pad=ceil(iw/2)*2:ceil(ih/2)*2` to the ffmpeg output args before `libx264`/`yuv420p`, ensuring width/height are even.
> 
> Adds `TestFFmpegArgs_PadsOddDimensions` to assert the new `-vf` filter is present in the generated argument list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72b0e42afe636403bbaf6a52ebd8352b5f2e306d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->