### PR TITLE
fix macos local dev

### DIFF
--- a/images/chromium-headful/build-docker.sh
+++ b/images/chromium-headful/build-docker.sh
@@ -10,4 +10,4 @@ source ../../shared/start-buildkit.sh
 
 # Build the Docker image using the repo root as build context
 # so the Dockerfile's first stage can access the server sources
-(cd "$SCRIPT_DIR/../.." && docker build -f images/chromium-headful/Dockerfile -t "$IMAGE" .)
+(cd "$SCRIPT_DIR/../.." && docker build --platform "$DOCKER_PLATFORM" -f images/chromium-headful/Dockerfile -t "$IMAGE" .)

--- a/images/chromium-headful/run-docker.sh
+++ b/images/chromium-headful/run-docker.sh
@@ -52,6 +52,7 @@ cat "$FLAGS_FILE"
 # Build docker run argument list
 RUN_ARGS=(
   --name "$NAME"
+  --platform "$DOCKER_PLATFORM"
   --privileged
   --tmpfs /dev/shm:size=2g
   -v "$HOST_RECORDINGS_DIR:/recordings"

--- a/images/chromium-headless/build-docker.sh
+++ b/images/chromium-headless/build-docker.sh
@@ -10,4 +10,4 @@ source ../../shared/start-buildkit.sh
 
 # Build the Docker image using the repo root as build context
 # so the Dockerfile's first stage can access the server sources
-(cd "$SCRIPT_DIR/../.." && docker build -f images/chromium-headless/image/Dockerfile -t "$IMAGE" .)
+(cd "$SCRIPT_DIR/../.." && docker build --platform "$DOCKER_PLATFORM" -f images/chromium-headless/image/Dockerfile -t "$IMAGE" .)

--- a/images/chromium-headless/run-docker.sh
+++ b/images/chromium-headless/run-docker.sh
@@ -12,6 +12,7 @@ mkdir -p "$HOST_RECORDINGS_DIR"
 
 RUN_ARGS=(
   --name "$NAME"
+  --platform "$DOCKER_PLATFORM"
   --privileged
   --tmpfs /dev/shm:size=2g
   -p 9222:9222

--- a/shared/ensure-common-build-run-vars.sh
+++ b/shared/ensure-common-build-run-vars.sh
@@ -16,6 +16,12 @@ NAME="${NAME:-${IMAGE_TYPE}-test}"
 
 UKC_INDEX="${UKC_INDEX:-index.unikraft.io}"
 
+# Chrome-for-Testing only ships linux/amd64 binaries, so both images must be
+# built and run for amd64 even on arm64 hosts (Apple Silicon). Docker Desktop
+# will emulate via Rosetta. Override with DOCKER_PLATFORM=linux/arm64 only if
+# you have a compatible chromium baked into a custom Dockerfile.
+DOCKER_PLATFORM="${DOCKER_PLATFORM:-linux/amd64}"
+
 # Only require UKC_TOKEN and UKC_METRO when explicitly requested
 # Pass "require-ukc-vars" as second argument to enable this check
 REQUIRE_UKC_VARS="${2:-}"


### PR DESCRIPTION
life happens fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the build/run platform for the chromium Docker images, which can affect local dev behavior and may break workflows that relied on native `arm64` images without explicitly overriding the platform.
> 
> **Overview**
> For the `chromium-headful` and `chromium-headless` images, the build scripts now pass `--platform "$DOCKER_PLATFORM"` to `docker build`, and the run scripts include `--platform "$DOCKER_PLATFORM"` in `docker run`.
> 
> `ensure-common-build-run-vars.sh` introduces `DOCKER_PLATFORM` (defaulting to `linux/amd64`) with rationale for Chrome-for-Testing on Apple Silicon, allowing overrides for custom `arm64` images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26893396efbf74a73360d40efc2a52da99fa483a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->