### PR TITLE
add VM-internal failure telemetry (OOM + service crashes)

### DIFF
--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -33,6 +33,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=$CACHEIDPREFIX-go-build \
     GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
     go build -ldflags="-s -w" -o /out/wrapper ./cmd/wrapper
 
+# Build supervisord eventlistener shim
+RUN --mount=type=cache,target=/root/.cache/go-build,id=$CACHEIDPREFIX-go-build \
+    --mount=type=cache,target=/go/pkg/mod,id=$CACHEIDPREFIX-go-pkg-mod \
+    GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -ldflags="-s -w" -o /out/kernel-images-supervisord-shim ./cmd/supervisord-shim
+
 # webrtc client
 FROM node:22-bullseye-slim AS client
 WORKDIR /src
@@ -378,6 +384,7 @@ RUN chmod +x /usr/local/bin/init-envoy.sh
 # copy the kernel-images API binary built in the builder stage
 COPY --from=server-builder /out/kernel-images-api /usr/local/bin/kernel-images-api
 COPY --from=server-builder /out/chromium-launcher /usr/local/bin/chromium-launcher
+COPY --from=server-builder /out/kernel-images-supervisord-shim /usr/local/bin/kernel-images-supervisord-shim
 COPY --from=server-builder /out/wrapper /wrapper
 
 # Copy and compile the Playwright daemon

--- a/images/chromium-headful/supervisor/services/supervisord-shim.conf
+++ b/images/chromium-headful/supervisor/services/supervisord-shim.conf
@@ -1,6 +1,10 @@
 [eventlistener:supervisord-shim]
 command=/usr/local/bin/kernel-images-supervisord-shim
 events=PROCESS_STATE_EXITED,PROCESS_STATE_FATAL
+; buffer_size defaults to 10 which overflows when several supervised
+; services flap in quick succession. Bump it so a burst of crashes
+; doesn't cause supervisord to drop events before the shim drains them.
+buffer_size=100
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/supervisord/supervisord-shim

--- a/images/chromium-headful/supervisor/services/supervisord-shim.conf
+++ b/images/chromium-headful/supervisor/services/supervisord-shim.conf
@@ -1,0 +1,7 @@
+[eventlistener:supervisord-shim]
+command=/usr/local/bin/kernel-images-supervisord-shim
+events=PROCESS_STATE_EXITED,PROCESS_STATE_FATAL
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/supervisord/supervisord-shim
+; stdout is the eventlistener protocol channel; do not redirect.

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -34,6 +34,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=$CACHEIDPREFIX-go-build \
     GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
     go build -ldflags="-s -w" -o /out/wrapper ./cmd/wrapper
 
+# Build supervisord eventlistener shim
+RUN --mount=type=cache,target=/root/.cache/go-build,id=$CACHEIDPREFIX-go-build \
+    --mount=type=cache,target=/go/pkg/mod,id=$CACHEIDPREFIX-go-pkg-mod \
+    GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -ldflags="-s -w" -o /out/kernel-images-supervisord-shim ./cmd/supervisord-shim
+
 FROM docker.io/ubuntu:22.04 AS ffmpeg-downloader
 
 # Allow cross-compilation when building with BuildKit platforms
@@ -256,6 +262,7 @@ RUN chmod +x /usr/local/bin/bake-certs.sh && /usr/local/bin/bake-certs.sh && rm 
 # Copy the kernel-images API binary built in the builder stage
 COPY --from=server-builder /out/kernel-images-api /usr/local/bin/kernel-images-api
 COPY --from=server-builder /out/chromium-launcher /usr/local/bin/chromium-launcher
+COPY --from=server-builder /out/kernel-images-supervisord-shim /usr/local/bin/kernel-images-supervisord-shim
 
 # Copy and compile the Playwright daemon
 COPY server/runtime/playwright-daemon.ts /tmp/playwright-daemon.ts

--- a/images/chromium-headless/image/supervisor/services/supervisord-shim.conf
+++ b/images/chromium-headless/image/supervisor/services/supervisord-shim.conf
@@ -1,6 +1,10 @@
 [eventlistener:supervisord-shim]
 command=/usr/local/bin/kernel-images-supervisord-shim
 events=PROCESS_STATE_EXITED,PROCESS_STATE_FATAL
+; buffer_size defaults to 10 which overflows when several supervised
+; services flap in quick succession. Bump it so a burst of crashes
+; doesn't cause supervisord to drop events before the shim drains them.
+buffer_size=100
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/supervisord/supervisord-shim

--- a/images/chromium-headless/image/supervisor/services/supervisord-shim.conf
+++ b/images/chromium-headless/image/supervisor/services/supervisord-shim.conf
@@ -1,0 +1,7 @@
+[eventlistener:supervisord-shim]
+command=/usr/local/bin/kernel-images-supervisord-shim
+events=PROCESS_STATE_EXITED,PROCESS_STATE_FATAL
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/supervisord/supervisord-shim
+; stdout is the eventlistener protocol channel; do not redirect.

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -30,6 +30,7 @@ import (
 	oapi "github.com/kernel/kernel-images/server/lib/oapi"
 	"github.com/kernel/kernel-images/server/lib/recorder"
 	"github.com/kernel/kernel-images/server/lib/scaletozero"
+	"github.com/kernel/kernel-images/server/lib/sysmon"
 	"github.com/kernel/kernel-images/server/lib/telemetry"
 )
 
@@ -102,6 +103,11 @@ func main() {
 		os.Exit(1)
 	}
 	telemetrySession := telemetry.NewTelemetrySession(eventStream)
+
+	// VM-internal failure telemetry (OOM kills via /dev/kmsg).
+	// service_crashed events arrive via POST /telemetry/events from the
+	// supervisord-shim child process, not through this monitor.
+	sysmon.New(eventStream, slogger).Start(ctx)
 
 	// Optional S2 storage sink.
 	var s2Writer *events.S2StorageWriter

--- a/server/cmd/supervisord-shim/main.go
+++ b/server/cmd/supervisord-shim/main.go
@@ -1,0 +1,228 @@
+// Command supervisord-shim is a tiny supervisord eventlistener that
+// translates PROCESS_STATE_EXITED (expected=0) and PROCESS_STATE_FATAL events
+// into BrowserServiceCrashedEvent payloads and POSTs them to the local
+// kernel-images-api telemetry endpoint.
+//
+// All schema-mapping and event publishing logic lives here; lib/sysmon does
+// not handle supervisord events. Keeping the shim as the sole owner of the
+// supervisord protocol means lib/sysmon stays single-purpose (kmsg only).
+//
+// Wire protocol per supervisord docs:
+//
+//	stdout: "READY\n"
+//	stdin:  header line ("ver:3.0 ... eventname:PROCESS_STATE_EXITED len:54\n")
+//	stdin:  payload of `len` bytes (no trailing newline)
+//	stdout: "RESULT 2\nOK\n"  (always; ACK regardless of downstream success)
+//
+// We always ACK with OK so supervisord doesn't quarantine us when the
+// downstream HTTP target is briefly unavailable. The events are
+// best-effort; if the API is down, we drop and log.
+//
+// All logging goes to stderr — stdout is the supervisord protocol channel.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultTelemetryURL = "http://127.0.0.1:10001/telemetry/events"
+	httpTimeout         = 2 * time.Second
+)
+
+func main() {
+	log.SetOutput(os.Stderr)
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+
+	telemetryURL := os.Getenv("KERNEL_IMAGES_TELEMETRY_URL")
+	if telemetryURL == "" {
+		telemetryURL = defaultTelemetryURL
+	}
+
+	pub := &publisher{
+		url:    telemetryURL,
+		client: &http.Client{Timeout: httpTimeout},
+	}
+
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+
+	for {
+		if _, err := out.WriteString("READY\n"); err != nil {
+			log.Fatalf("write READY: %v", err)
+		}
+		if err := out.Flush(); err != nil {
+			log.Fatalf("flush READY: %v", err)
+		}
+
+		header, payload, err := readEvent(in)
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			log.Fatalf("read event: %v", err)
+		}
+
+		// Try to publish but always ACK supervisord.
+		if ev, ok := mapEvent(header, payload); ok {
+			if perr := pub.publish(context.Background(), ev); perr != nil {
+				log.Printf("publish telemetry event: %v", perr)
+			}
+		}
+
+		if _, err := out.WriteString("RESULT 2\nOK\n"); err != nil {
+			log.Fatalf("write RESULT: %v", err)
+		}
+		if err := out.Flush(); err != nil {
+			log.Fatalf("flush RESULT: %v", err)
+		}
+	}
+}
+
+// readEvent reads one supervisord event: a header line followed by a payload
+// of declared length.
+func readEvent(in *bufio.Reader) (map[string]string, map[string]string, error) {
+	headerLine, err := in.ReadString('\n')
+	if err != nil {
+		return nil, nil, err
+	}
+	header := parseFields(strings.TrimRight(headerLine, "\n"))
+
+	lenStr, ok := header["len"]
+	if !ok {
+		return nil, nil, fmt.Errorf("missing len in header: %q", headerLine)
+	}
+	n, err := strconv.Atoi(lenStr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid len %q: %w", lenStr, err)
+	}
+
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(in, buf); err != nil {
+		return nil, nil, fmt.Errorf("read payload: %w", err)
+	}
+	payload := parseFields(string(buf))
+	return header, payload, nil
+}
+
+// parseFields parses supervisord's "key:value key:value" tokenization.
+// Values are split on the first colon; supervisord does not escape colons in
+// values, but in practice the values we care about (process names, states,
+// ints) never contain them.
+func parseFields(s string) map[string]string {
+	out := make(map[string]string)
+	for _, tok := range strings.Fields(s) {
+		i := strings.IndexByte(tok, ':')
+		if i < 0 {
+			continue
+		}
+		out[tok[:i]] = tok[i+1:]
+	}
+	return out
+}
+
+// telemetryEventBody mirrors oapi.TelemetryEvent but is duplicated here so the
+// shim does not pull in the entire server module — keeps the binary tiny.
+type telemetryEventBody struct {
+	Type     string                `json:"type"`
+	Category string                `json:"category"`
+	Source   telemetryEventSource  `json:"source"`
+	Data     serviceCrashedPayload `json:"data"`
+}
+
+type telemetryEventSource struct {
+	Kind  string `json:"kind"`
+	Event string `json:"event"`
+}
+
+type serviceCrashedPayload struct {
+	ServiceName string `json:"service_name"`
+	FromState   string `json:"from_state"`
+	Pid         *int   `json:"pid,omitempty"`
+}
+
+// mapEvent decides whether to publish and constructs the event payload.
+// Returns ok=false for events we deliberately skip (intentional stops,
+// non-crash event types).
+func mapEvent(header, payload map[string]string) (telemetryEventBody, bool) {
+	eventName := header["eventname"]
+	switch eventName {
+	case "PROCESS_STATE_EXITED":
+		// expected=0 means the exit was not in `exitcodes` — i.e. a crash.
+		// expected=1 means clean shutdown (supervisorctl stop, or a configured
+		// exitcode). Skip the latter.
+		if payload["expected"] != "0" {
+			return telemetryEventBody{}, false
+		}
+	case "PROCESS_STATE_FATAL":
+		// FATAL: supervisord exhausted startretries. Always a crash.
+	default:
+		return telemetryEventBody{}, false
+	}
+
+	name := payload["processname"]
+	if name == "" {
+		return telemetryEventBody{}, false
+	}
+	fromState := payload["from_state"]
+	if fromState == "" {
+		return telemetryEventBody{}, false
+	}
+
+	body := telemetryEventBody{
+		Type:     "service_crashed",
+		Category: "system",
+		Source: telemetryEventSource{
+			Kind:  "local_process",
+			Event: "supervisord.process_" + strings.ToLower(strings.TrimPrefix(eventName, "PROCESS_STATE_")),
+		},
+		Data: serviceCrashedPayload{
+			ServiceName: name,
+			FromState:   fromState,
+		},
+	}
+	if pidStr := payload["pid"]; pidStr != "" {
+		if pid, err := strconv.Atoi(pidStr); err == nil {
+			body.Data.Pid = &pid
+		}
+	}
+	return body, true
+}
+
+type publisher struct {
+	url    string
+	client *http.Client
+}
+
+func (p *publisher) publish(ctx context.Context, body telemetryEventBody) error {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.url, bytes.NewReader(buf))
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status %d: %s", resp.StatusCode, bytes.TrimSpace(b))
+	}
+	return nil
+}

--- a/server/cmd/supervisord-shim/main_test.go
+++ b/server/cmd/supervisord-shim/main_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bufio"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseFields(t *testing.T) {
+	in := "processname:mutter groupname:mutter from_state:RUNNING expected:0 pid:1234"
+	got := parseFields(in)
+	want := map[string]string{
+		"processname": "mutter",
+		"groupname":   "mutter",
+		"from_state":  "RUNNING",
+		"expected":    "0",
+		"pid":         "1234",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseFields = %v, want %v", got, want)
+	}
+}
+
+func TestReadEvent(t *testing.T) {
+	payload := "processname:cat groupname:cat from_state:RUNNING expected:0 pid:2766"
+	header := "ver:3.0 server:supervisor serial:21 pool:listener poolserial:10 eventname:PROCESS_STATE_EXITED len:" +
+		itoa(len(payload)) + "\n"
+	in := bufio.NewReader(strings.NewReader(header + payload))
+
+	hdr, pl, err := readEvent(in)
+	if err != nil {
+		t.Fatalf("readEvent: %v", err)
+	}
+	if hdr["eventname"] != "PROCESS_STATE_EXITED" {
+		t.Errorf("eventname = %q", hdr["eventname"])
+	}
+	if pl["pid"] != "2766" || pl["processname"] != "cat" || pl["expected"] != "0" {
+		t.Errorf("payload = %v", pl)
+	}
+}
+
+func TestMapEventExitedUnexpected(t *testing.T) {
+	hdr := map[string]string{"eventname": "PROCESS_STATE_EXITED"}
+	pl := map[string]string{
+		"processname": "mutter",
+		"from_state":  "RUNNING",
+		"expected":    "0",
+		"pid":         "1234",
+	}
+	body, ok := mapEvent(hdr, pl)
+	if !ok {
+		t.Fatal("expected publish")
+	}
+	if body.Type != "service_crashed" {
+		t.Errorf("Type = %q", body.Type)
+	}
+	if body.Category != "system" {
+		t.Errorf("Category = %q", body.Category)
+	}
+	if body.Source.Kind != "local_process" {
+		t.Errorf("Source.Kind = %q", body.Source.Kind)
+	}
+	if body.Source.Event != "supervisord.process_exited" {
+		t.Errorf("Source.Event = %q", body.Source.Event)
+	}
+	if body.Data.ServiceName != "mutter" || body.Data.FromState != "RUNNING" {
+		t.Errorf("Data = %+v", body.Data)
+	}
+	if body.Data.Pid == nil || *body.Data.Pid != 1234 {
+		t.Errorf("Pid = %v", body.Data.Pid)
+	}
+}
+
+func TestMapEventExitedExpectedSkipped(t *testing.T) {
+	hdr := map[string]string{"eventname": "PROCESS_STATE_EXITED"}
+	pl := map[string]string{
+		"processname": "mutter",
+		"from_state":  "RUNNING",
+		"expected":    "1",
+		"pid":         "1234",
+	}
+	if _, ok := mapEvent(hdr, pl); ok {
+		t.Fatal("expected skip for expected=1")
+	}
+}
+
+func TestMapEventFatal(t *testing.T) {
+	hdr := map[string]string{"eventname": "PROCESS_STATE_FATAL"}
+	pl := map[string]string{
+		"processname": "chromium",
+		"from_state":  "BACKOFF",
+	}
+	body, ok := mapEvent(hdr, pl)
+	if !ok {
+		t.Fatal("expected publish")
+	}
+	if body.Source.Event != "supervisord.process_fatal" {
+		t.Errorf("Source.Event = %q", body.Source.Event)
+	}
+	if body.Data.ServiceName != "chromium" || body.Data.FromState != "BACKOFF" {
+		t.Errorf("Data = %+v", body.Data)
+	}
+	if body.Data.Pid != nil {
+		t.Errorf("Pid should be nil for FATAL, got %v", *body.Data.Pid)
+	}
+}
+
+func TestMapEventUnrelatedSkipped(t *testing.T) {
+	hdr := map[string]string{"eventname": "PROCESS_STATE_STARTING"}
+	if _, ok := mapEvent(hdr, map[string]string{"processname": "x", "from_state": "STOPPED"}); ok {
+		t.Fatal("expected skip for non-crash event")
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/server/lib/oapi/oapi.go
+++ b/server/lib/oapi/oapi.go
@@ -578,6 +578,57 @@ func (e BrowserPageTabOpenedEventType) Valid() bool {
 	}
 }
 
+// Defines values for BrowserServiceCrashedEventType.
+const (
+	ServiceCrashed BrowserServiceCrashedEventType = "service_crashed"
+)
+
+// Valid indicates whether the value is a known member of the BrowserServiceCrashedEventType enum.
+func (e BrowserServiceCrashedEventType) Valid() bool {
+	switch e {
+	case ServiceCrashed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserServiceCrashedEventDataFromState.
+const (
+	BACKOFF  BrowserServiceCrashedEventDataFromState = "BACKOFF"
+	RUNNING  BrowserServiceCrashedEventDataFromState = "RUNNING"
+	STARTING BrowserServiceCrashedEventDataFromState = "STARTING"
+)
+
+// Valid indicates whether the value is a known member of the BrowserServiceCrashedEventDataFromState enum.
+func (e BrowserServiceCrashedEventDataFromState) Valid() bool {
+	switch e {
+	case BACKOFF:
+		return true
+	case RUNNING:
+		return true
+	case STARTING:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserSystemOomKillEventType.
+const (
+	SystemOomKill BrowserSystemOomKillEventType = "system_oom_kill"
+)
+
+// Valid indicates whether the value is a known member of the BrowserSystemOomKillEventType enum.
+func (e BrowserSystemOomKillEventType) Valid() bool {
+	switch e {
+	case SystemOomKill:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserTargetType.
 const (
 	BrowserTargetTypeBackgroundPage BrowserTargetType = "background_page"
@@ -2196,6 +2247,77 @@ type BrowserPageTabOpenedEventData struct {
 
 	// Url Initial URL of the new tab.
 	Url string `json:"url"`
+}
+
+// BrowserServiceCrashedEvent A supervisord-managed service exited unexpectedly. Only fires when supervisord reports the exit as unexpected (`expected=0`); intentional stops via `supervisorctl stop` do not produce this event.
+type BrowserServiceCrashedEvent struct {
+	// Data Per-crash payload for `service_crashed` events. Fields are derived from the supervisord eventlistener wire protocol, which exposes the process name, the state the process exited from, and (for EXITED but not FATAL transitions) the PID. Exit code and signal are not surfaced by supervisord on this channel.
+	Data *BrowserServiceCrashedEventData `json:"data,omitempty"`
+
+	// Source Provenance metadata identifying which producer emitted the event.
+	Source BrowserEventSource `json:"source"`
+
+	// Truncated True if the data field was truncated due to size limits.
+	Truncated *bool `json:"truncated,omitempty"`
+
+	// Ts Event timestamp in Unix microseconds.
+	Ts   int64                          `json:"ts"`
+	Type BrowserServiceCrashedEventType `json:"type"`
+}
+
+// BrowserServiceCrashedEventType defines model for BrowserServiceCrashedEvent.Type.
+type BrowserServiceCrashedEventType string
+
+// BrowserServiceCrashedEventData Per-crash payload for `service_crashed` events. Fields are derived from the supervisord eventlistener wire protocol, which exposes the process name, the state the process exited from, and (for EXITED but not FATAL transitions) the PID. Exit code and signal are not surfaced by supervisord on this channel.
+type BrowserServiceCrashedEventData struct {
+	// FromState Supervisord state the process was in before the unexpected exit. `RUNNING` means a healthy process died; `STARTING` means it died during startup; `BACKOFF` is paired with FATAL and means supervisord gave up restarting it.
+	FromState BrowserServiceCrashedEventDataFromState `json:"from_state"`
+
+	// Pid PID of the crashed process. Absent for PROCESS_STATE_FATAL transitions, which fire after all start attempts are exhausted.
+	Pid *int `json:"pid,omitempty"`
+
+	// ServiceName Supervisord program name (e.g. `chromium`, `mutter`, `kernel-images-api`).
+	ServiceName string `json:"service_name"`
+}
+
+// BrowserServiceCrashedEventDataFromState Supervisord state the process was in before the unexpected exit. `RUNNING` means a healthy process died; `STARTING` means it died during startup; `BACKOFF` is paired with FATAL and means supervisord gave up restarting it.
+type BrowserServiceCrashedEventDataFromState string
+
+// BrowserSystemOomKillEvent The Linux kernel OOM-killer terminated a process inside the VM. Sourced from `/dev/kmsg`. Fires for any process killed by the kernel due to memory exhaustion, including Chrome renderer subprocesses that are not supervised.
+type BrowserSystemOomKillEvent struct {
+	// Data Per-kill payload for `system_oom_kill` events.
+	Data *BrowserSystemOomKillEventData `json:"data,omitempty"`
+
+	// Source Provenance metadata identifying which producer emitted the event.
+	Source BrowserEventSource `json:"source"`
+
+	// Truncated True if the data field was truncated due to size limits.
+	Truncated *bool `json:"truncated,omitempty"`
+
+	// Ts Event timestamp in Unix microseconds.
+	Ts   int64                         `json:"ts"`
+	Type BrowserSystemOomKillEventType `json:"type"`
+}
+
+// BrowserSystemOomKillEventType defines model for BrowserSystemOomKillEvent.Type.
+type BrowserSystemOomKillEventType string
+
+// BrowserSystemOomKillEventData Per-kill payload for `system_oom_kill` events.
+type BrowserSystemOomKillEventData struct {
+	// OomScoreAdj oom_score_adj of the killed process at the time of kill.
+	OomScoreAdj *int `json:"oom_score_adj,omitempty"`
+
+	// Pid PID of the killed process.
+	Pid int `json:"pid"`
+
+	// ProcessName Comm of the killed process as reported by the kernel (max 15 chars, truncated by the kernel).
+	ProcessName string `json:"process_name"`
+
+	// RssKb Resident set size of the killed process in KiB (sum of anon-rss, file-rss, and shmem-rss).
+	RssKb int `json:"rss_kb"`
+
+	// TotalVmKb Total virtual memory of the killed process in KiB.
+	TotalVmKb *int `json:"total_vm_kb,omitempty"`
 }
 
 // BrowserTargetType CDP target type of the page that produced the event.
@@ -3940,6 +4062,62 @@ func (t *KnownBrowserTelemetryEvent) MergeBrowserCaptchaSolveResultEvent(v Brows
 	return err
 }
 
+// AsBrowserSystemOomKillEvent returns the union data inside the KnownBrowserTelemetryEvent as a BrowserSystemOomKillEvent
+func (t KnownBrowserTelemetryEvent) AsBrowserSystemOomKillEvent() (BrowserSystemOomKillEvent, error) {
+	var body BrowserSystemOomKillEvent
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromBrowserSystemOomKillEvent overwrites any union data inside the KnownBrowserTelemetryEvent as the provided BrowserSystemOomKillEvent
+func (t *KnownBrowserTelemetryEvent) FromBrowserSystemOomKillEvent(v BrowserSystemOomKillEvent) error {
+	v.Type = "system_oom_kill"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeBrowserSystemOomKillEvent performs a merge with any union data inside the KnownBrowserTelemetryEvent, using the provided BrowserSystemOomKillEvent
+func (t *KnownBrowserTelemetryEvent) MergeBrowserSystemOomKillEvent(v BrowserSystemOomKillEvent) error {
+	v.Type = "system_oom_kill"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsBrowserServiceCrashedEvent returns the union data inside the KnownBrowserTelemetryEvent as a BrowserServiceCrashedEvent
+func (t KnownBrowserTelemetryEvent) AsBrowserServiceCrashedEvent() (BrowserServiceCrashedEvent, error) {
+	var body BrowserServiceCrashedEvent
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromBrowserServiceCrashedEvent overwrites any union data inside the KnownBrowserTelemetryEvent as the provided BrowserServiceCrashedEvent
+func (t *KnownBrowserTelemetryEvent) FromBrowserServiceCrashedEvent(v BrowserServiceCrashedEvent) error {
+	v.Type = "service_crashed"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeBrowserServiceCrashedEvent performs a merge with any union data inside the KnownBrowserTelemetryEvent, using the provided BrowserServiceCrashedEvent
+func (t *KnownBrowserTelemetryEvent) MergeBrowserServiceCrashedEvent(v BrowserServiceCrashedEvent) error {
+	v.Type = "service_crashed"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t KnownBrowserTelemetryEvent) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"type"`
@@ -4010,6 +4188,10 @@ func (t KnownBrowserTelemetryEvent) ValueByDiscriminator() (interface{}, error) 
 		return t.AsBrowserPageNavigationSettledEvent()
 	case "page_tab_opened":
 		return t.AsBrowserPageTabOpenedEvent()
+	case "service_crashed":
+		return t.AsBrowserServiceCrashedEvent()
+	case "system_oom_kill":
+		return t.AsBrowserSystemOomKillEvent()
 	default:
 		return nil, errors.New("unknown discriminator value: " + discriminator)
 	}
@@ -17915,328 +18097,342 @@ func (sh *strictHandler) StreamTelemetryEvents(w http.ResponseWriter, r *http.Re
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+z9+3Ibt5YojL8Kir+pijRDUrKT7Jlt1/lDkeQdTXzRT5KTmWzlI8HuRRJbTaADoCXR",
-	"KU+dhzhPeJ7kK6wF9IVE8yYptvfnqqnZjti4rTsW1uWPTqJmuZIgrem8+KOjweRKGsD/+IGnF/B7Acae",
-	"aq20+1OipAVp3T95nmci4VYoefAPo6T7m0mmMOPuX/+iYdx50fn/HVTzH9Cv5oBm+/jxY7eTgkm0yN0k",
-	"nRduQeZX7Hzsdo6VHGci+bNWD8u5pc+kBS159ictHZZjl6BvQTP/YbfzVtlXqpDpn7SPt8oyXK/jfvOf",
-	"EynYZHqsZnlhQR8l7vOAKLeTNBXuTzw71yoHbYUjoDHPDCyucMRGbiqmxizx0zGO8xlmFYN7SAoLzLjJ",
-	"pRU8y+b9TreT1+b9o+MHuH82Z3+nU9CQskwY65ZYnrnPTvEfQklmrMoNU5LZKbCx0MYycJBxCwoLM7MO",
-	"jk2AOHzNhDyjkc+6HTvPofOiw7XmcwSoht8LoSHtvPh7eYbfyu/U6B9A1PeDVncG9FEujnmWnd56hC9A",
-	"UrIfr67OWcKzjE25TDNI2WiOh7kBLSHriRmfgOnxXDCDhLUMypTbteQS2c6JG+ZIRBU6gQ0nwJGXNOJj",
-	"t2N1IRNuHTgWz3alC2BijGdxO2RjAVnK7rhh5SiWFuAQa8QHYJmYCWvc8TwwR0plwBEnNkIouBVmxQyM",
-	"5bOcCcneS3HPZiLRykCiZIqzjZWecdt50RHS/uW7anohLUwAWZT+8kcHZDFDxOZi4HBSw6yxWsjJEglY",
-	"EyYsAbkhNZx4rG3BeOege0gqOZ9niqdsrDQbhs0OGbh5TYRACo0iZjCLgPEXnmW9JFPJDQvfObZzaCOK",
-	"1A6yM5FlogZUf0JZzEYEQrceLSIixPAuB3l0fsbKr87SsMjMyRJImVZOaOxBf9Jnw1yrBIxxfD7ssqHl",
-	"N3CZaABppsoO92s7CHghtICx0fUd5PzvTKROKo0FaDbWatbCbOHrmUjTDO64huiixnJbRKCKbB00MaOv",
-	"WKLS+iwlAS7QVO0gC3At1+s2cLqC4hy5XVqe3Cxv8fjknF0U0jFQHz+50jwBpiHXYByI5ARh85/8ll/i",
-	"OJJTxn3LuMUf3WiU0pKor89eOTY3rDDA3AqSz9xEiZLuZ5TkmtspaGanXDIj+Q0MEm5QDiAt4LzHU61m",
-	"wE7g9kqpzLBzraxKVMbuhAZGLN2/lkuk7nb4SvMZbKBZ8DRj/LjLHPXpmTKWtEhDfywsobJiJt8S5S8t",
-	"8ito1RtxAymjDxnxCLsTdipIT2VCRumg2xkXEnXKWz6D5blrmAgfOvhClynNYJbbOSPKRMHApZLzmSpM",
-	"+bGJkrDbzQancZ9FzkJfx09Dv52lcdqj/66xY3R3hc6Wh7+/eO2O7M4exIifbSyyGKMucFgDzLV90nIN",
-	"kHSb+I6xWtNGWBDay5KQhD3L+AgyRBRuH5nKIgeSDORmLhOW8MJAXN7lXAcrMsvejTsv/r6RBq8kwsff",
-	"lhQMTtnYDFISbgX/avpLwKyx3EpBlNtkyi9VdgsXYIrMttlELKFPmXHfMm6tI22mgaOe4MwxqnAgVIVN",
-	"1AweZBG17OurcdRqHHn0DBA9A40we2xDaRVWtreZAgk1zKbYMdpNqPB1AMaCOPMUewsyVZqN+Uxk875T",
-	"WmmRgDZMOjBnDpG5VrciBd0zOSRiLBJmublBUWaYkFYxOxWGGbAvGLgrZa6FAXbLteDSGifuNAQOSVSW",
-	"8dxAGAhCs1vQximGUZHcgGV7t8/ZAbv9dr/LuEwZl3MnuidMKssSdYsKkQSOA+6JctrkjfUH6rI840Ky",
-	"d8cX+0wYZxso7UiTGzZUTosPSQkH2pj6nXUc8gPMbp83//NbRwmFlsaKzJHDBMC6W2i3g1NGaKm7vQmL",
-	"ph1JEGO5to6TYoJjyZDF6+PAmWrLCyE91lCH36JZ566gYy6yQpc27OnFxbuLwfHR+dXxj0eD928v373+",
-	"+eiH16fD/T47GjkLyw0yReIs3a2My6vFc7Chn2b4gs6smQYHYpSXheGjDNwPeGfus6Hfaexr6Q+1ZwDY",
-	"sAKG2/XQyRNV2GpcKlKkJBpftwucVgD9jWF3XFg2KtIJ2D4b8hGXqZKQDl/4T1jCZQKZu/l6XZjzCTDJ",
-	"b8UExSC/43NnhvdwzSa9+WM7QUZHcmCkTXa6nXKxKEk5voteFjyWuTFi4mBSs1DYu5z/XkDXmbfjgtS3",
-	"KXLHFcwJVtPTMAYNMoE4Su9gZISFwVSZiO77UZFlWkLhbgoaPDyJ5Z2KQECkK+fPuZ1GrkHcTjefn/3/",
-	"C9ClSQn3SVak0WWXDIKarNzhypLmx0pKSGy71wTuvbMtyYRjJGK5pDBWzUCzy5Ofuuw84/M7LSZT22Xn",
-	"RZ6DBdD77ibi5oaUkcjEW8ovMLpUKC9zre7n5FAShv38ZlkVfDUJlk2CNB94uD66JZDmJ8Ik2xJEWo6B",
-	"tLrmr0E1O+eCLjf4tZjNIBXcQjZnuYYEUscHw9phh8HzaNxNxFgNfPYwa3TptF8N0ZVUV+H56QlvR+uz",
-	"2uKCAdrY/uN77/zE7i+bOPBmYAyfwCBRRYzH6P7r5nZM5D92FmHG505Jo/aLrAsCnT2p0PS3uKdAAzex",
-	"2/Iv0/ninCCdEmJDYvRBkinjDBn8inhfSGEFEi79URlnIRU58ecgmXI5QQMEnUyimDENaCNCSnYGGLSg",
-	"nb2MmhLlhFUaWKruJDOqvlqiiix1NrnHMZ9wIQ15xyTcsbBufQtoVg1flL+xVDhrTge4sryY5WSI0VmV",
-	"tHBvB6Wp5A8cnJT+d2Tbypzas/NcOCNr7p8OmJkW1h1hv2lF1UHZ6XYWIVX/E+4JnSILO1rPfnU6XiS3",
-	"kgJWMaSSRmWAD1+tvoMRfesg4j72xqzSzMmyYjK1dXcm3CeQE1GR7/J0JmylMO6UUyNWyMQi0ZPMMKQg",
-	"UjFGQ8+S2DRTnoPplw5Vv/7R+dkxJ2T4v/T9nYFnmdl3pOVuiIZlcAtZlzmYdhnXE0PXNfS5DNATU81d",
-	"bvtqqh097pVnK3+pT01zZkJC17sku/4og0JnkXW8B9fZ9f590l0fvLVEIxnXwDheYmJe2G003iJWvyq8",
-	"doVHsPJM+Nj6LoqIbb2LOPKYhEPnY3fRd+4oO8K2WVYyLNeTYuZmZokCnZCZTgc0fXZOTxNMyWzuLi/S",
-	"06Nn2Tbua3jzly+CC/5bYpKIl6fhz2/4v2sXqUqoIE0hi2688QXWjitLlBVxn3qAohvEbnnmrqo8u+Nz",
-	"w67Js3HdeRAUo68Hy3t5XXss+HSAqqRcyxPC0tMBs1N82NJw19zjI2ys4dcJ0nZjL3XptO92kLeW5Q7q",
-	"lWBAuG+qPQvJRspOg/DOuZ2a9fd4XGdZYvy2JDNeq8nGCjlTE9K2lUbM1KQbfu8LOVbVf91xLbsMbNLf",
-	"7z+Clgkb/apj1uqYTE2eSMM0kPB56Zet1MQKMdxqBbo5uiznxuDtRKtiMmWFHIvMoiceRQm9ffe993WI",
-	"jndVeI9Vwwbwd0bmLhzA05eMZxlDJzpb1AbG2XLANXPyt88ugbwhJoekfIQcF1nGHCGQTffnyK1XGLS1",
-	"iJ5l7KyXV4SQ7gZyq0FFSzvyH3kxFe5WyGlVeFaQazMlhXVXDGkVgv/45LwXNIO/0rOz4EGmG7LlegK2",
-	"S7EHZIB7dzfeRXKVTB1L302Fj4agnagkKbS7EEYsbpwq6s12WMZf64EvNUc9bSau2xVPQbfOmqqEcEXf",
-	"1ebvuhs14PsG8GRaO110HclvBwZ+X17ljZLKKukvsUIm7paIr1cVuCjMMAnmRpc+c/uCtNyAVXkPyaM+",
-	"MgqEDUSm9w+0wiX4D+qBRp7DaJ2aOyMKD/oqOn+gTT9RbYk9Y/Ge5j0x1TlNOChnlo/2V60YlMEGnH2F",
-	"I67cgFVRGhoyuOWSnt+mwhApv6TXB/fBGOM4Spw4XsDfiHW6pYuj/BbsndI3NW/ZaqFQQ1YdsM0jVyS4",
-	"Qn3V9f+WXkCtbkFyR6QzsBxNAo+5uaNmYnR/YdcMvBei5Pxl0wfi5lZ4cK69UKLkwEAZ/yzZppuGCN66",
-	"9Cp9KAjqOOHcCJm22SfhQH30dQZ/Wyyoy6ux0k/vhWufDSkwb8BzMXzBfsL/YEfnZ8GhtefkjL4FcqnS",
-	"H3sTkKDRxgo7Z0O4tyAdIQxfMCH/Qe8Cfj/lb302zFTCs4EPPxy+YGZuLMyY/wPThZQOYzxTcmJECo3t",
-	"Np1qad7pdqr9u5/CQh0nW2sLRd8nA6m0E1vESFlHD0GbETE4aUV8cOD55IBUxdlJA9+BFxZ4C5G/gmN+",
-	"tDb/EZxuMO2HsLpYYhiMnpzSSDbjucPuHdcpRh70hKcUt3sn2lRhywALUjLsZ3f1NeilqjlBycpjo8Ky",
-	"GZ+zETAu5+w/L9+9RROpYfUsHQbj+yni+zgTyc3aG0+B1x73abAkeG4LZ+XdCl4RIUq7Kopu5ytOdH9f",
-	"LzqtFx1RwWuAWHrs6047Qh750mMgg8SqSPjm8eUlC7/irT94cfHATkBmaCm12ASTWFzzm9fM8kkj9nJh",
-	"NoelIs9BY1gvSZof3l9dvXvbZUdddnL2c4sRErXGfxZGoP/ZiS2fOtOycJdZjY+20envY3PDHcZu3PcS",
-	"pXQqJLfNU7mzOCjm4h4yE3czzVdMPN994gXiu++4lboVtglDK+85NRL8CeZrJdYNzEeK6/TPlldhb1+l",
-	"1UbS6gbmTyirGsh4ZEnldr4EtZ9gTq7qyv77yRMiAZQkyKnbYpf9wJMbk/PE3ZvjYmQHcRgEF3p/p/hA",
-	"nxSGvLyUHjJHMsk1GNMiXjYXlzj5anF59vb8/VWXXZ3+19XRxWm70Fw0yOABEuIy0SrLLsHaDNK1ssLg",
-	"18zQ515ihJsLH9vqk1wZUcvVw0dlISfdP0++LJ/sq6TZSNIQBgceyU8odFow9Mjix8mXQcQMoNXZfa8k",
-	"VZ/dRJHD1TOR+2oCxlHtJoYBrjdvXW/+2Ot5l8YOApDWWmcQqhjwXmEkslkGIcoAN3k4QZAVm5xExeDW",
-	"WGr+KEstJgYRhZSo84f2G1qG8ErZ+lrcgjME10SzskzcArsVcFeFFC2EqLqr8LjIgvD9xrBfYHRxdVy6",
-	"Qd7Cjdrvsx/9d0pm85cYwBEk8lhpnCUDYxilOT5IusbO9lWotgpVh+KBQ/FThcm24mP7eMXgvm4EKy4d",
-	"oD1ecZV7/HVJ6stO8j67bHiwy5A602VGMc6s5tIggwQn8CgTOUu4RDLHgC3vSSxjeDEwd1htabiVx3gD",
-	"gK8PTl7m73hw8qZMXgUpx7Aymi8d98FM/jUkeXs+f7rA5FVYeXRu/4wClHeVKy99iYEQnawpLZ+C+dvk",
-	"2pYPSxumtryhx+KTGv+3SI0rn61Qg5FV4cHCsUKmjO2zK7TXrJ4Hwef92qlWeQ4pK6QVWXijHpQS1V3R",
-	"tBa3YPrsSgO36AgXspdrNXF33FDYBSNDLbA9L3EHIs0wgGECg4zPVWHD5WCfccMKqSETKMRpZTsF+SAR",
-	"1AaxrzKoVQYFbNe1zGPLoJVoWSeEmsTQFvp/gX8vX86r0+ADT4KcMCgD98vHxfKlLvzSr7/JLYxaD5b1",
-	"YekeFGdS2FdcZGs5OggoyhtwNvoIfMpCJj7Qfh/KLgub+cosa5nFIWAwRpA9Ea/EcLIdpxgLeTtdzcBO",
-	"FebQlsTkA2Qs5OTZpPN5FyMFcPQN2KPCqiNreTLdwMWIm1h/2ougajbiiaiWazCIhh5ggIsw09LBCPdT",
-	"XhhLD/JZdWEgjwrm/Js+e6vYuNBUcmZRXd6JLPOqsEwE9Az6GHwYg8JXZlzLjCUin5YjW7HzJAqsQZ0+",
-	"W71f/XXgidmpMiJmR6aBitkdaGD4alDkZdCDz34fF1k2R4WndCja1OSqug6MrPiIavACHmzZLpwqwvd8",
-	"0Ro4JW4Ozq60KOEw4TlGgZC5fNy0arGihQGL/oWFILTgYrCaJzduNm80sLEGMw23dmFYroS0jyosvgqK",
-	"rQXF08uIh8iHwHCbXpSxqNrClZhZfgPIKrVU09Lv3eSHTYC6xOCxTa6HT1WVr9X9lYMWKhUJM+W3wQMQ",
-	"HhNvfbjEY7DRwo6+ctFaLqrw8kRMFEPJdjyUy8jj+g/cwF++64FMVAopO3/7tw1JrITVaG5hrcXr1l5x",
-	"xrekKM7SDNY+mgelItIQVrvwZM7Z94eHM8N+LwRYzznk65WKCdkbZ2IytcxXl8TI6Ie94yy8mH5lk2U2",
-	"qbu+HptBPPG8VjwVcrLyrrRMRRmNCtc6n8N+Nm6UBnAg5pkGns4dUDwBYWSLs8I43vvcpVAqlmuhNBuG",
-	"A/sphjhH/SFR2P0uGxY6G3bZMGSeuH+XCSNDymoZavA5mA4Aw1rW+Es2jFAg5jrlXFPRaJarvMiQNDBN",
-	"g1uWcAMPTDhvBflXTbGWBTzFPdG1bDVmHjkWhApXrENUnYvCiMUMMAylmEQqodbwRXXU4gGub0NGC2b0",
-	"1X7zjhoJ9sWL04uLwfG7t29Pj6/O3r0dXJy+en95erJ9IWTH85FCyPhCEu5MSouJkBz9KguyoPVxxK1a",
-	"Y/X4wv6k/Qv/6dU8h9r9GFdYyo6sB/z7xMifpLqTFDNomJBYl4yd+Gy0LnsFNpl22X/9eNFlVOmjyy7t",
-	"PAMzBXfZO5vxCXTZG0gF77JXyo25gnt75a56XVZj6W5VLarL3nApxrjDcw1jWuOdnYImWTdTeoPKs43a",
-	"zjWq6FYEuTKmxIMw9HTYVFUE9GE2eEtO0fYytL6Lr9JzrfT0SHgisbmEjEcWmCHbc205hTItFDV2sxiT",
-	"B0FUgExrmULb7LueZbRc0tiDJWQT9d1Kfk+O91pl1Vn4po+1NIRMsU8HZuuhIVKY5pl2FlzGi6ica+OE",
-	"Sa7B6VmSKpjMHQWXMAMNVFZrFbugj8vLe+P3a4qMWmuwMEOcT+hJoaW4vX9v4IaFUqZucizPTnrrb6dX",
-	"XXb+7vKqpXy1MnYQZE4cZyOVzlE/uFkOzt9flXeerjscv+Ui46MMWvQRHS1Or+9Ix2WYVzqCsfJFScIo",
-	"RAMeDE3lGrARjLqAR1K9XVZI8XsBjZrq1QvEVzX7cDXrybjbFGGVwFkSCJtpYOrtsIUK9s0gNCQgbqsL",
-	"2yu36Zovr/wQyd8hxXvCaVgXn8SQKkOGJD1gPY5Gr53qq0rfQKUTvJ5Mpy+i45GVuiOxKGY8+Bu0WMlE",
-	"rIGEEgXuLXtz9uaUaoz8qXrd76yu2DdRWN5KUUEBrDJJZmLWJmjLQ4cJS1CR9nOQOZjaWdZli02+vt7a",
-	"Pnt18kiNfcI0LTf/6Fy19Px3P3VZ2c5tf1etV9bfDoy4Ur2d8wmcqNkxJdq+VjzdwCN58u5NY0Co8OXI",
-	"x03YT8sZcS5UeQ+r6NW6z69aq1VrYdhmqmYDn0aN/rzH9+OtRs1j+/HSfFACKyLAKK5gFgoJMXphpXxT",
-	"IVl4XeXWV2FZIuWxA0IXCx1bcYt4DWQfYg0pMGDP2WWIKqzgtN9n7w2woTVUWeWu+b4bCXFeLKPfONla",
-	"pn2N4bibpm9S8G5L+uYzDxZvlKJ3E4PDq5coC/oWsBRKmGkqxngvqy7Kt8IUHPuFjUQm7LzPTnkybQyg",
-	"+Au6lz7r+VXdofXXV60/QRY0Q7ifQg54qnS4Xl8ispgVnskaNLJ3/Ppy35NomS1zDhpPLRNgV2IG2J7s",
-	"6PzswUplccdf9clmNOQA9mdQ0JP4Nn3MyzL0ThZyVhqECdLq+VKgzp4vuHuIYr8hHlkOGksu7kczXOqg",
-	"HKRgucjM9ik9gS1qgGPcWi1GhQWzhoPwSMs8NOXpQEPibAYh88KupuMGkHzdhARSejrDskg4SXB5YchD",
-	"1zeYcYpDeD4/fn0Zp3NU35EsoPq6JlE63FOE8bjac5YPQiLEHb6+3I+r4iWa9BelLSsthpoP+Peq+HED",
-	"RGVhx2jWtYi1gowir2LyGLWuz7FaDPVeOLDfS5XttIFRkuRrxf5rrifukurNrnGRsXMu3PXh9fH5nyj3",
-	"/Va/yvs18j7Jn0TM18H/yOI9S/IdxamnzYo0iTIfKk59lYWoFBFpNX3g49fH51WNKzEOfrjWoq2DuNBw",
-	"N5qyY+/CvBulYEqVtou+k3dvmPsgIv1q67T1f5Ep6JZtX+CPm278pVe81I6NvGK+4kEZOH8lZkJOekdZ",
-	"pu569BQUTzkVH6C9IhnXwFs2RAUnmPm94E25Xs297hm1PiMGXbkjMKXZrUhBhZ9aKqA+rfKqb80JLsLe",
-	"E+gvXChmZO2svNZrLMXX356rG/GioysLwx/JxVVu56taWqOWFH+aC2wDAZ+58wptvoosvxTX1dsy9WYz",
-	"zqtX//Z9uxb5EPn+beghut9nx1xrAVgXuyyCO6ZGR0Ki9BlhGVnLfCnoLsOuJKFkdd1TtVis/cFcvgCA",
-	"r7y+mtcr+D8Fx8eQsV22wm5atup4i19sW5H/Ldyx1VX5WdnRtrwVrynMTy3mV1gNvmH80pGoL+6I/l4r",
-	"Rf/Sh3/TDiJF+VsaIW9dcf/R6ur/ueXyKxqw6tFq21O0S80SqqhoY1ZY/a4Q+uZhVErLK1NZ2n/B68ym",
-	"/BaoPRHqq/Jp2TRpp/G0UDYwFobVpqcXByz1jXFh7EymkDvrlGoG11M5XjLOjJCTDJj7glI86bk8VUDt",
-	"70ao88RDe9x9fY7YVq4/5ZPEFR+9y0GueCSTcFcaHJaPsC85yQUHS4WDydbwRRRCFs2Voj8gDSN90jiz",
-	"T2FeJoQa8kYpEGGqPBxf8c9tIbSJMapR0mtdzo23X5rZNjVDpqRupDln58UycfrsWElTzEC7+x0lGi3Y",
-	"TdhnIdTWn2K1BovFhIR1thNHT7fg2WNk7Swj7quRtJqZLB8NiFSfnol2sJFwa3FL5mqpt423kBwvYlC5",
-	"Z0EkaiWBooHlfFulX7W/iPXqkXCXzcul+OhJLAErbBZxj1D0eeZliPumtBJRMMQ3EzUrwlQ111L7HIt0",
-	"sdKmWEEitUOugno9fo6O6rDr+8YsNMCpE3en2xnx5GaiVSHTgf+LAX0rEhg4DQ/a/WHKNaTVf2MsfbTV",
-	"Sth1KA9zzC1MlLsvHis5FpMd6uolNMW8VnPG17vGoAtsROIobVRvNhbJ5eW52NrrsHiOuT/FchQlddTp",
-	"oW+xl/G5uyQkVtwKOw+tMIElhbFqBpqlWDLuBRNy5ACPjXiwkXHQWje16UyP5yLUrnSKqex+0/Nt9VOE",
-	"SDLlzKjsFmolexyJUNdtNzBbKu6XiTEk86TsTYSqTsix5sbqIkEolyN9UD29yvaUZENq6jNkAUdON2Hf",
-	"V+x39ITg9h0QmSpsXli2h50vfY9LrZXex11H2jn7tJWyXvYT7vE9vc+WSwUQ72HbCtNlNzBP1Z00XV+J",
-	"eR83503rJ9xYPen9oIyaDF2S+nRfnTwl+s7R7btIe3v1Owpl7izERL0+PndA+rhCXrbsYTu5Q4NCxIKT",
-	"LuUVpy6FPNEvv0pJd2lKY134gcpnOX1bCjb8N1Xwdxct1szPUe5KSFc1YbzxlMKYF5klceHsq71yMr/2",
-	"Ps10dHX845q59rDfF93bsABwbueM4MqGf3wc7qNVzaTqqfwlibGwlgbLhTRMWMPw4V1aKgjUZ1fK78TZ",
-	"/KkwVI+4GnorOO2uy+aqYLOCcipT3MJ9nolEWDZ0Zxu6GYaIpmGjsVRpFm5EDruQQVUUNIkQRNlbraGl",
-	"FnVTn72bOTO+OjrC2wZEvSAEWlWOFLbPLusf4N7cFxTYQV/grPXs6RtwyLdCQzavT8ezLKwtwNDU7m9j",
-	"J9KrH3D+pRWTDLhvuBiHRew24ne0qRnXaitEEYuufFHMAotSn/UtEfuKqobRm/MIi9qmVAlTFLPygMD+",
-	"7//+PyHA3oTmglNuwFeKWOZ83zU62lEORy7LhHK1AU0947mh6kTokj8YiwxIzx7kKhPJ/KDU/we5Vu7n",
-	"g1SYPONz5hTHy9L35SfExEXHqN4l5FDBrfChpPWins2dUDPH2kxRiy9eS/FdTpiowXKxemJ9ZWNVPgjw",
-	"p0h7bet/8PVGEQAO1LUWgO4//PnDh6KYDcYZnxjCjwPR+qtbOHNAYcwox/Zjb1RhwGdWbnlXGxXWxoLj",
-	"cEpGvzrcB6sB39lrcMpgbDvdjhaTqfvfmUjTLNjwdMO94zqN4gmNjpbklCt/e6B+Wt4wqlZ1Roq7qeQd",
-	"P010ganK0sENzE3seCndCN3P7nzu23pxOZp1m57RsphRszm/HOrDzotni5z+llrnu6uRmIFnrByCQe7X",
-	"XfYERPpz/Bdr60AW+mds2tTsv3eZKdrFrIVIc2z65INttqTReIbNsVfvSZi80UZu1w743Y4vJKiPKmt8",
-	"czF+FIwyX2Rbe9olXQlJYYFxqoNDWdoo6vvsagpsSIV0yAaiNiRexF/LapacoivIIbhc9ZxGOyCgHYS3",
-	"Ixqbc81nYEGb/rU8veeJzeZMyfJ3GtnIO8M7PBpCI6y+fCvSeItqYuWZkxnrdOyywPrY7aSaTzYbfqL5",
-	"ZHH0TN3CZqPfqFtYHI2Nvwa+fdmqwefuw59gXhtLt6R1A6knUH0Y2EFSaKPWWiSXYI/xw/roDEjBrRzo",
-	"PvIkXHMjLtfrDH6aJQpr6OEafhvwpplDnZMKlCVoGrhtnDwcJCa5q0nXHNPpiSu4tyV4Frk8nvPd7Rxr",
-	"4BZOMO1f6fluynOmUlhhaaRhduY+ZHsqsZgzo7FFGqYB/vv33+/32Unt8vTv33+PRhy3FrSb7v/5+2Hv",
-	"33/749vudx//Jf6Qa6eRl46RUZmTNtUmQlOoBI++sMhB/1/XV8tzK8WAeQIZWDjndrobHNccIWw8xWUe",
-	"f+MXkKDum+y2+5j7+WzJwa3DIrWTsKMsn3JZzECLxN3CpvM8dFWo4Z/3Phz1fj3s/bX327/9y2YxgSdk",
-	"fm54x1xICAA05loVbjDt6bsqJLIl+hOL6g40t7B+Sv8101jCV7IfP7A93/ZCFlnGxBhft1KwkOAz8H50",
-	"0TuRxghqcTX8bOX+o6Bd1EBPY3A7sdlibJdGNlndMQGagrt81O3Qw0VT5cR9spThMgJ7ByDDRpyhjZYG",
-	"3n889Tr5T23SvXffYpjUTEgxcxs9jOFkZYFc/yxklROQZS+Zxb2F1xvyKRCE3F5mZS0XM1PKTv8X1nAh",
-	"fwQ6RgqrZtyKxFnc7gwjbiDFsja4IMqXDOTEn4Pf0zmeHR4eHtbO9X30YA+5ZbgjbHXJiEvKdxpjdFkm",
-	"DJqVf7/vsvlvdZM+50KbEnchk/9uKjLaxETISZ+9caaetx0ZtywDbix7TnWw8QGj3OnilmsAmfH7M/r1",
-	"OQKv+o/F06z8kXDZoOFYP/n3Bti0mHHZy8QNsB/gg8B8Q30LFTUjhu/4nA7ChDQWONaLyIQE7p3iucp8",
-	"j/lfsDusWw2dBGaQgx4YmCClETtAPkAmG8z8E8VEqmacdO2RuPF540jfb8mXZcAn7msJg2e0i2VuWMuf",
-	"S+ds3mIP26+x5ZaQtmhfmAzn4eUfaVBMtG+QvaHtsWeNvT5be+1sVe6lG25Th9jCxKvcLqd0lzvP+PwO",
-	"pfCmyiBeDat2O6ymxNITy1etqM3p7GCqrHHwn/yW0z9xgtrcdM3EP065YRxr8bvfv8n5BL7psm98FMg3",
-	"dLv8JrSrY7dcY+snf3Wc5Rm8YNcdfseFxdfd/kRZtffN1NrcvDg4APqmn6jZN/svmQZbaMlqn+O7997+",
-	"y+tO3X/ezCygQLKkQYd/WaLDNySt/RnxCuNLrIdAi2BeM2HYXw4bEv7bhnxfT2sI/A3pweCGtySHUL5t",
-	"gQqq0y2/7AQqXwhBwYqjnoSd3VTBx1d4jVeM8ZtevidSZDphsiqUipvboxCNfRIjKejIfi4tlyn2n8eN",
-	"lalV9YNFPLmpiiWklpP5x9YNZ6PmE6vewKAObUgb/SrizzyNmE2/QIxAXokMzuRYLcsjYQap0Kt3hfoL",
-	"H73K61xLWT/VmiDmVPkMDRKqV1TG+5dRSCm30PN5oMv1kqJyxx2LbrcjYQ3Vtumy606q7+51z/3fdcdd",
-	"bK47PX3X0z33f9edeJUkyWP7/oEbaLZYF+EJbxkSG9+Kg826TCTiAwxGcwsROrkUH1Cw4M99n4sWtiFg",
-	"kybEeEa/u8Zi3UAHNRx6oLeR0yU+wbREOr4q32ioKzu0lYbdhPz4eBwauG9Ih7vislxqV6RuRyVxt5gP",
-	"35vnUPeBHV+cHl2ddrqdXy7O8H9PTl+f4j8uTt8evTndIBSP4qtaDRasorX4BtmC3xPh/muG1n3KCunr",
-	"GJShrYvdsEL9Fy+3KTiIEg+dWSAMoTXE2PCMWX6vpJrNX2ADSYov9ZVAq9mN1cBn7G6KwaYpt3yID2xK",
-	"z9CyULLENdoQbisjyNQd2yMPN22JXN/+XX/YDodhl2mYcE29rtXYLczyIrQQErbPjnmWge5Vf/QAwOf9",
-	"d5dX7KDc/UEtwoiCZqWxmp4lMepJGILsS2YA2HBhL+V9FAujminPoc9+5plIy7ISCW4mNGA1jE+4u3vQ",
-	"1AHAoXhr4oNyvzGhcFh4EUUbKa0wTgp/xvNcUPMMnouBW2vNw/ZRLhx4iKS6HR+iNcAQrUFQ/itnOKYh",
-	"l24EWSvlZGleNsBeM0eaN9qm09haU921wxcbM5fxXQNvDa2egL5FC2lxfKYmm41+rSZhbC2gih4A18xw",
-	"Vn2PjyGxefA5YtNZfoJ5bA7ywJfh9htPR88VjayQbqTL+fZN5BvTbIzvtm7c3Xg31N16ztZmq7eL3KUj",
-	"Z22qpWZ3O3cWjE269XzLc9XaA+3SgKnTbXZQ2agObdVNp9vWfGLHLh+1CUM99q1r3Tfm8AVgty+v2+m2",
-	"FuTbsfRhmHGhrNfGNa+a3Lxc3Wn74lnlNEm+RQmWcpTi6TY58mFcLT9069zb5Tm2gGNLvlx3KSNj22QX",
-	"eoNGk3z+Fs1msgw/djtKwuaxrouK6WN3m2E1bbjhwBjzbDu0zjLbjY1w/3YTVGJow3ExgtpiaJyrt5ig",
-	"YoUtBi2R2s618rYaG5h9+/XqvLUTYnaZIW6RbT+4NMS2HxoxujacpEU1bzd62SDabvySjbHj8B34ucUK",
-	"23B040q0qchcuMBsPmzRht1wZNSY3nLsjku3XfiwzsdrYSw6miJOGa353F2Bl108QpLHERNQpA2es/JF",
-	"cdWuSjdq5G201HyRtN9MTXy1odJXXCvdvjJqerHO1qT0qlu4t611kVrqvlyJma8SWO6IqihSXtym/tiW",
-	"p6r60jEPEwYZnPuIzovSvl10SW8aahoCuXYPMW2bYePQ0qWIvu2iMR4xKgFD3B4Yj5AKY7lMoPFI9f1T",
-	"RyG4PW8VhfDwp3nvSa7e4d0/ubQLUIw7l9eRZxXmECiMWbUTmW4601bkunucXArGDtbF+4Gx2CtCyfKV",
-	"Y124XLdjdLJuYkoe33jOxbexsEC3dooYhN7d1OXSFo+nf6OSBezdT2XfhWW5rm7WUu0ZlSKBslt9f/3L",
-	"n7qJnuWc22TqQ/F2w3hbLN5JewxeKSief3e4fUTeSWskHrafVfSM0GWFAfJaT8VkCsZWHbtoSNVEBMnH",
-	"K1n/lvKXw+63h93n33efHf4W3yKC1juV1uFr7CN1NIwLyhHTgGUbUARXGcZKV0GYBxrwmMJQUjTEJY3P",
-	"eKryfpYDPavVqd5ayAbzBfar84d3OMxqM5RWx3jKc4r7lXCHxSYa4QqU9eZgOQWejousS7l54S9ZC3m2",
-	"hkCetIY+lmTz7fPDzQIhF+Phd9O8a4IUg9YNaotS0eeGIhMXS0fWSNSh+7BL33INzPI8J/tqdRzUCkVa",
-	"BnbP1mnUG5hjIVfDjAOO1+ibK9j4+q99eJ+b3cxnI0XZ+biQb8DglggFW0bAeO1bZoo8V9q/uN2nyiqV",
-	"Xcs9A8D+69kzPMt8xlIYY8s0Jc1+n/lgn6qpz3XnAkNArjtddt1B9wD989jqjP51lPk/vfr+utO/phA/",
-	"igIThmIUE9wgz4xyu0zUbORVlvFx8TTfv9kQPYD/hav92xUf4bRbAHRBWiN0o/KaKiee3kPyaPFc3B1v",
-	"hjGDc+nkiFSFySIp2lxPmqGBf4/UGKCZuJ4UZYXYzamKm4FWqhnYFz9G4UP2fCVJ7A3ihrJci1uRwQRa",
-	"xA43g8In2q6eMhRgdF+7qWSRofYIMn45W5DOHnmtR0CHxG4zhSwrQe50QRGvf5fcxbLhlb5xPFxdVvd4",
-	"Pbpg38/o32tpESowvHiA9TYXyNt28vojFtPtcfbHx0WEncpboZXEi0cZq4fli3zBqhroa9CoKH8p3m67",
-	"ELt2BLZH0hE617Lhg8LoeJ3pSoSV54gU91x1Hzwtz992GYxXwIZ7YQfxuE1/VOY+WdlqLAWtB6O/fBcP",
-	"qvnLdz2QbnjK6FM2KsbjlgqHFFW36WSqsO2TfWzH3k+iSnnbDn2XYuKULFKvLKum1ai3iTKDnzeEWufq",
-	"9OJNZ/W89dAe//lPZ69fd7qds7dXnW7nx/fn6yN6/NoriPgCTdFdtQmasZydX/13b8STG0jbwZCozMQr",
-	"h1rQM0GZ71kxozKcq2Jeux2t7tbN5T7ZMlAbZ+3SRldA7DLnd7IOsI0KvkRU93JNZp5lyl3tBtbO12vB",
-	"I/814yw3UKSqV55+7/zqv/cXBWtVr6KqsXMLpJFa1GUcaaGs1yLi6EJTP0S9YfEuKF1ayX22+zIfo9Wg",
-	"m3jdQZ6f1RzGfOQEEmfGzbaKH/JYWt67yxJZZydxUet/jxaVu8SKV72y1m6kslxtP6UftyhE2tKH0pnj",
-	"A27jfmIqHojYqJOZH7aFq7iV1cpGmNtUIqqV1SkMadl2qZQXgzzWxfzUWDHD2MXj8/esQH96DjoBafkE",
-	"ol0VVqjR06A+Q1nHAKspJ91K4Fpno3Q7M5i1Rf9WO9ZgEPNsBjNnI9Luy8Dg1mahK/Q/1SiqqSRdSOnQ",
-	"R8duK/TYjthUyN2Uzgm33EmyOy3IAbpAehR4j02e4rXRNzIs0voq64sVlvP+tvbMD7IX3XZ8kqNx0y2f",
-	"0H1hQbYRSZUVhR8w/3m/s6lLxR9FA68iu7exnS5PQ7Qp0+B7ybgTBQz6jAmll4qdPRSb5cNaRSzuFFET",
-	"FOLvdK+bW1oKwXasEE133Ug0lIKUJheGXePA604by7r9R7QAOcJ96LOq1ZFNpoW8aVYRwgSWMi1mQyam",
-	"2GXE/8P8ENhmHgsW05ShohoBQHruXgznjohxXymsaWVTfsGSnU3h8/VadLVyTliFsSop2A01P+sFELtY",
-	"GbMb5o/mN/uqtG3V0eiEnhP6D64lvCZNYHVN+U1LUlAZAtDxNKGxkBjPvom1UNUaCKPabIW1bhcyg5b/",
-	"bMqiCbXfGxmvG9s21W79oB03uwBntLnq+4zBvIqauYDJJuV+Nnue+ZGeZcrSDxPvK1hRKKHFYf8LOuq3",
-	"mWjDx3ua6xvjWzWMnZDUEh70nL/FnNEX0wCFbgDsOpTt8vCgS0SvqdnTJIyopG5W9tn2MTezfHC/+v3j",
-	"R6XFByWxbgyuxfhMFdL2GUVxuPsl/t0wzBbtMgkT3vi7w0NcwdEO1pSJ+NntONlg/VTdycjyRR5f/CEB",
-	"C2Vtoc193+u4ouqzVBZAai61PVNsPeXGUQRLVaG2lFoiTUGuyYOlaIfqKckPWvsU7r9r2fYrkcE56JnA",
-	"Ys9mt/1PtCryuH8Kf/Iphpr9rXHJ3zaXNVKu6S/ffbe/XXUmdSdjzyFur/gTPoCE/b5v2e8meY+UgpdX",
-	"sKVXT3pgw5fndNfKSSvyUOtlxrYspM4LA/WsdCppnEPieD8tXexb+ujrD8ZYXyzmoq/n/zdiqw7XMmV9",
-	"8ShAnAnzyvzCbfKoxbDKSmV4a8aigfEMfse44hbWuzdLbvfzsXJsNt8g5KU1gAch8MCSWtgEJR6gclHZ",
-	"tuEjh+Jx7jj2FrQWKZhQm95DYL+O8+eH63ylUc9hePuP+PxqBiwVsX+kwl646UDQZ/KSCLj9fa7aR/19",
-	"quxdvhI6KwEy4/eYcC4+wJl880P7DjDY1/g0+Tc/bIiRxTpLzzYMQLm0Kn8ooSmdgJtnPb+czXxvA+xB",
-	"pfKy4+xE8wTGRcbMtLDOCvIJ1TMMo0LXkpAYB6B1kVtIfZtXB6z4s8A2FeWIg92GnrCcXJX5LG8hU/m2",
-	"sXlXWLWLhlat6qxyEr9WYoMtZG1H6tgHx9HKopDN3HksuPl7q++1V/XgDME6jJzO1U45dhymuG0xhnq7",
-	"YqJr6qqJcRKvubE9XLl3duKj0Qof9H15eRr8Rt5dJgxV16KAlqWGQFs8r7kzBs/abytx2BYkv1A0gMoF",
-	"3QkNvpUfOVUw0R2LB+W1ggIecwxkiuehtiAhFEsunL7PjvRIWM11yP33dpahPldUSKBKm9fAeEqT9dmr",
-	"pdYqq6obdGNlCXDHoHvovCGyKZsrQhoqVoXmWf/q8/0PFv5ygvPWAqa6bLmoQbRcbsOd9nn4ziqE/Ofl",
-	"u7el6ywG7UwYD6XVpRqocg05oxeh36xaHIMrocX3b3miTmCXYAPNeP1UOolbG4NZJ7mpWHfVHGzz3mDY",
-	"CKzRGqzRFaxRC9ZfxHToJka78wGOWzYQe1rfZYn7y/DOtcOLYltDh0jjpDwTLc7FX5oNjZsNlAMwm80z",
-	"HH79lJSlUfa7rHYkQl893zwg3bxyUlIWYd2q94TvOLGz8vL6KePGLulVdhIaBWLr46DfmmChW2O8Ud0W",
-	"NyZ/fDpHlHYWajhv7UZ7WKXTG5gbq9UNmGh1wmjsQ7yC4k5ZMSFcr9pHyAqqZcc4SXTvLsXuJP1rebLU",
-	"bQc7qnKD6SqYD3WQhjq1+9RhxcmtEE5+LX38rxMBbi20XLhkKlxzaus1IMX28G//69DBxSft7PevZa1i",
-	"Jpbhd1Cb56Ql7pROe05WpvRC5gNKy5MLaTXvua9oQXMtnRUgORUiQvVGP+e8MA5PzjChvZGEdntZgbpo",
-	"j55uS18BR4oIVyyMTspgqowtS/q3FJJSA8cwCaymRezMM+VOXTvLfZ4rJqTjBMdx7jL7ks2EsfwGyOxB",
-	"PYkWBcJsxJMbk/MEKiJgh332TmZzL8JMDAJsz4gMpM3mDThdy+ozpI19AlV5MzvsP4tSfUtv+NaeCr9o",
-	"YaHsArEbo6/GViNcIRQ+Cwvu2gziI3Zmo9c4383Rt9VjZ9gHjx2dn3W6nVvQhrZz2H/WP0S/Xw4S+/t1",
-	"vu0f9r/1Zb/wIAchm+SAOsKQzyeJOH3egJ5QS0f8kkgA7oXBJ30lwXRZkTvlwxYmjeSj3Ap32cpB3wqj",
-	"dNolJsOSnIW0IkPIlV+fwO2VUplh1x0096SQk+sOZq1iR31hmBqhzZSGxrdUGxLdID5xConJ4ZA8GCm6",
-	"/WwyDau88h1xfLWWH1Q6p1DGqktIlaR78A9DTkbSmJEX0gDNBesiHIlgaBWbIVh9rcK/X3d6vRuhzA0l",
-	"LfR6vjdYb5IX153f9nfPM6ANxcmq+s7xJ6UaYc4arvP88DDin8b9E76pJ3Z5NI/sxYqVH7ud72immOVR",
-	"rnjwAw88STVzP3Y7328yDusXSJ75UVhjczbj7mLTeU90WW4x44VMph4JbvN+zzisot6yn9I6rigM6F7o",
-	"SVItA1jIWQsDjHpTscoFVQY8jHj5c99RVfdarmUXtj23XMtt2eUYNNbeDlBgMy75hK6TN/5S22yFiVTM",
-	"TkPrqUvf4617LbHJZg+LM0NazkjnKOcPZIi+zOOT84OQm6zkPuofbJMO6bVEf0WA5VrOPq/aYu3K3HHV",
-	"ELOoNkF+n/0UMsH8T5LPwFzLPZ9v5LXpsVI3AoyH43WH2nZi8Vv/ojItZ6C/9q/lJQALpY+pL1i1k/5E",
-	"qUkGJWEf0EtHmS0Z/k4g9YWT3fl/4EYkR4WdvrsF/aO1+Wno4UgwiG4YHUXuY/M+n2iegilHeaX6ht/7",
-	"MhJCSXMO+tzRSefFt8+7nXOVF7k5yjJ1B+krpd/rzOCb3nJZ585vHx9LrgVa+WJF2yLZubO0S7gizxRP",
-	"e1W3uB6XaS9868SeMhFD5z0Oo4Kams2cBCmnYB9EzrhOpuLWcTjcW2zVZqcwY4VMQbODqZrBAYmQqluf",
-	"ObguDg+/TRwr4L+gey3dfVA7GTerr0ByW8gdDI1Scl7LP9HQIHiVgtEcyfTCw3iVTJoVmRU5djlUetYL",
-	"vrI2m6PW8681XbP6xhkfhH6ECSYIcNuovdCcPl5G95XKHE7x1dgqlmc8AV/+OqBrO6wvPBAc9X7lvQ+H",
-	"vb/2B73f/njWff799/HH7Q8iH2Arw6Ut/loRZGgo4WMPC5lTJkvFPuWu97DXWEg1nXEpxmAsquj9uhdi",
-	"JKTjxHVWfbk9X484djNZacDVsLubFfcsFo9aUgORAqTdiLQjrimZAztm8vRTy70lEVRis0bke9w4gWT2",
-	"60KwPKKXhv4ufTAKNl5c6p2GLFrJ1EKTk4UOe4Ye2Xz7vdC+vM+O/K+o+SkKx5kz5C2zgmfZ3HfRmKqs",
-	"bDl8n2SFccTrzJ8uM4pJxbDJPIW+s1LYGJZwST6KDPgtYIeEENRgrMpNcCKMhTbW178PzfvKXteirDpB",
-	"3srQlI8ak17LUKK5MPjUiF1Tp56rUqD8HXcvrPyAmJpB5VTcajcwpy6JHlzXMrxf5nzuZvHPCgwb7/es",
-	"FjlzpqNMKIIYML1cpuJWpAXP/DQxyfsDGoLNLoq7m4ErfabLK1WN4HYzRnDKlgYAn5L3SkagjpFRBqjT",
-	"9AKbLTRoDMzWRFzVmvGJ8BXp/bgjmqhbVuhsGdj6k2LoUsyKjNIFievqvWvjjsQlHJG76sCJ+nY0XQBP",
-	"j2uurRi0HgtdzbatiK2Fu1fZfdUviXpqiW8eDF13aPIsl3kmS16+NnCib7Adnk3n5BORftwDuiv5o9fT",
-	"5xZRU/SAhc9GYP1CDtngTN8AX2VD1DiayqDXJ8LQcqvVjZHzKOvXCl/F+IzicW9FaApQ3pY/G4z/KFJf",
-	"gkPd1av7NdHcbPUbt/qwshBaLRj5HQQq9STslo9UznLjoaaeW1ZbehXC0AO52KdwIm5DKzgyTDPgBtC2",
-	"qnfYWdNEL2bxlC0hn4g0l5se7yg33ESfibrErVR1EwlNHPGwQDETsEQwg7IXeauQ+BvYRo3Lp1SP8WKa",
-	"cd7FqAM6aXmIx4Di38A2Ahu85UHCIqy0ifHR7KEdB25Za/OJyHy5O/eDrEMPBXeyT0vqb0IJyQZ2glYs",
-	"I94rSWM2wVijb/kKOerr9FXr4DM+yszae38Zbk9+8irvo1Zs7FrGSohRiBiWuco1TEHSvXm5VlmXGYBr",
-	"6TYTrzfGuK3c6BNh+2MNkIK5sSrvKz05uHf/L9fKqoP7Z8/oH3nGhTygyVIY96ckz30411RJpU098MPH",
-	"Mobzuhu1DyZPPCgwbcB4FxphQaXRFw9fAO+J2GGp3/yO3IAIRWr5nKwF0vF1XxLS5QaEX29a0iaqrvgN",
-	"VCl8T2UxLmUifvQ4WqlxMCz1IKfM2Wql9d7NJcVSbYBiXT8pQo95ji+SnFUICkFoa9CpsqxdiFGOJbv1",
-	"eYjZ3FlvB8rxdsiNdH+zNRuvJkmb1mLDz9eo4ujNwEaSo2/sK1mmJpgCaUVyY9ieVNYn4JKLs0ZBbART",
-	"fiscSfM5u+V6/pLZAr10vo95YOAQMzVSdlo7Cj03hpxLzND0vkv/1N2tR6uGkB986Wm4NPfKOdAUrhbY",
-	"p7gP9CJRsFCI7A6icBhiw8iB0etpyIFb9pb1ehR0dcjoBYEMcnpDGMYk5GVIdXwi9qsl3+4qHT15fSY+",
-	"JNpMZSsQerh1lvEW1lwI+m0Rjj7g8onwshjP+SAnBwURfjZay52NnBqrsOBjhNtlWlVJNjw3Mvf/KAx5",
-	"vhiejFKrfCIyljsDzao8x9SKBNgeBSR0r6V/k61eY7pOcGBaln+O69ZsPl8M2IgPQk72/a25XEiUpaYY",
-	"3PPEZvNrics1XqY08FRIp8vd7dndxzGKOqwxpALKhc6GuJ4XO5yNwNgejMdK22tZdWQqyyaHWcMrhZsZ",
-	"DTV3seETYJSe8IOTjQ4JoY2jnvEMQ02tupbDYE4Offl9LucIaTZXBUsVhkBLcDs+Cu3unUnibUGMz3Bf",
-	"47vkCJgvqNO/xncGDJxp4oq6n+tClvVu8dnqRS3+po4bj4EuPa930TiWixjrR1GiZDYn7HvVBzKlwNgy",
-	"BYdi1q+l1VyaYN6+YGLMOD7t6Cr8x+0bH5vcBrnOnFqsmI4ZkQIDbM0a8tpmXEhHD7g2BQIn4GnV/Ukq",
-	"2Xt+f+/fu3Ktcj5xCrl/Lc81jNG0duC5xU7xOcdEzmEVXfCvQ0oFOvAwGuJ7no9uJbbJILwu9qwWkwk4",
-	"O+laEg6Ik4REfPq8zCp8P6asApSPS/59xEABCgsa1MPbFuI7rl71/sPn3jRjl9iM5+z//u//wzDG28CM",
-	"SysSLKF7fnR1/CNbjp6LV7z1Xw1aAiVrO6A3bjb845qCGK87L+pxkr99HG64IRwd3Y1H6ybbmDmhgZZJ",
-	"/J60XGV/yPawksgB1RE5AJv09/sMDS6qNh0CqpcJiELKTTe8z2I2a5kgsiiNRSWKG2FLDU5tMmm0INaK",
-	"OJLTepiPQS9k2H3iNFZSYMGNaoo+RobQMarMgJVxR/v99UEoDw4Refr4DYwZd0MGXnYuQ9Ny3f9gbCw6",
-	"BdO+wCB4h43YGQw29UmJXjh7UWD6zIuzEH/lKzFguWzf3qgKHPSD3f8zB7XW4WjBG8jc+D18bqdQOzb0",
-	"YX4HtAo+7A/3Kd106OCWDyqWGJJWQBFJ6PbxDOGwdsrL+Brj9B1+cKd5nsNSK/O16PJVnpxyj7Dxxevy",
-	"9cerd/DKvZLCK9V36QvqsgzkhPzzCSdes+z54Xf/QVX2uhXrOQQmGOxLYRQoIzwCaBejDFqqIjdhucJo",
-	"qxKsAgTx9aAaSxnZWuT0WLlAkyVV7DkdWRbM8ZlEWBkd7u3+RuWWP6snqoYl5OXly8rcLKnAzZzB4ttV",
-	"/yGG/XeHf10/zm0wE8nSdeBxHssXrYdwfWiFE6DB5f4XZXkZ052yfMoRxPWbxxHaM3RtT0uDBq/yPju3",
-	"aYnmWWGWYB8KWR3UtG8ZZR8J5/Za9akcnJH2OH8yRfvVQ7LlMrLe+1fWcFdqAPmTUeyDY5dbjuNIY2wO",
-	"Eg3cwqDsgoBkUsQihvDDsjbNU4UNNVfZilSerSqlQ+f8jNwLdFLGMeerAn/ASwpObG6AlxP88KnxQqvU",
-	"25nt/C5dooSOmD6Ms75bP+6tsq9UIdNHfNDGnTPejrdgB69A2Ssydz9vbGGhtH8CRCE+ShypO+ksZsdd",
-	"gw8CCwJNwMYKUNlCS8M4+/XsnJV3gdodIlwNyhIxVVGzQBr95RgSv/6J0L+KHCPyNZ+BBW2w+UFbu7+S",
-	"c9AGtaq09Z1pEA6Ftzs37vcCUBzQnS6Ud2vSQLfuxFhXLu63rZSzh+uDHr0c1MMZy0pISFh1AH+JdOmR",
-	"VRch7jZAhBYutHF6NTbdgGDD3XfPcl27AM/C4zDaoW6u/ZV0fS1XEDb71diUqfEYtGFGTKQYi4Rj6vmY",
-	"G7r+0YLefr2WKdT/5P7NNd0AP4jcO1x4MhVwi81SwS7OgmwUj8yqcZWD0ZfCVt0/llt/lcfFCIY++1FM",
-	"pqDpv8oOwszMeJbV3RGjwjLLb4BlSk5A969ljzBh7Av2Pw7bNAV71mU+8d8hFlK29z/fHh72vj88ZG9+",
-	"ODD7bqAvbNAc+G2XjXjGZeJMKTfyADHA9v7n2fe1sYS45tB/7wZ8hiHfH/b+ozFoaZvPuvjXcsTzw953",
-	"5YgWjNSoZYDTdOroqEqah39VdZc8qDrd2m+0ZfyHiRWk31Yqeu59kFi8WvBr/X9ENC6480rxiA6XULvB",
-	"i8WmaChbiW8qE1ASeLAudTX/XDTsdjZh1U59maDQyqv1av8CyeZvYBvd5kPzoCXslWSTCWPRTjetdFM1",
-	"vd9NmXyZlFKdOkIq1fUto9okXyCtYLYuYp4SCZdpA9ukt13fQmPvJwyNfYyrG4aiVu6OLxBPeAJs5Yyv",
-	"XKuYWQNPy0t3lJcvgKf+yr0ZK+NiwSR0838u3KwSC7ZXtax5kC2Boj+ax/WFEQtmjTWe60riMECCflAr",
-	"md7K3cuV658uCamlRP7O1TVqFeF9ytAXiMhLsMuMXq92f4DV9M1U5CWG6QW0PQgL65yY2kOpzx1Xuoov",
-	"IYXgQ/U1zJSXAZTL1m+pOhHMg0eLHiktkpYn+hSMHazpEuC+8V22Swnmq6Z5g3aT/gDdzq6v+f4lv9rq",
-	"1uUYCAqPVokBsVQWYfjSRV2kOMPY22t1dgiuzZVFZjg6XigGDfslUz0ZYU3l21xKX1mkrzbmIO/mo7HG",
-	"tqSf1hsp1CrlVDESajM+eKTIllX8sCNh/yryiqxrCPynIXJeL3i0QKJL9O6dK2sIflvXaBtfXMv1jLHe",
-	"RdrwiF7LBZdoe7kj7+N8NOZqjaK6msKi66VUIRvEDX0ypo1H+bQVa327eaCP707l94bFjLC8ryOnXg+/",
-	"6VXj9vvb1VAOeHgScXHkYfhPLjIWybVFbNwtFiRauAnU+vs81R0g0kJoc9zuWDwVjx1tev1eit8LiPW9",
-	"qbjyzoNjo3i1xXrtNpmyx67x94mIjQ5Td1L7Qk1yUrPEEFoHfwSQf/RlzIGKlCzSm8orcltwUqDjwXsa",
-	"vN+hxOMq38N6V8N3scL6hCgKdv7CEXWJDXxCXHnM27eIpAPKkWt1JVHP5lfmlD77E3G16BaycG9pt1F/",
-	"0Lr3gEu82vrWOZGc06qFjRrX7sI+hxB7d/IUT/1H5796l5enPV8+qHcVbUXxBlLBfbX1MfaIwdYbPiVx",
-	"b1GI7Tde7sIr3ZKoizzKffwSyZR6BS1C2Zc8IbFbUqy7zK8OMsKiPJs4PE9qxhdfcn7+ie/e76qGBKE7",
-	"Y2tjxkbvlL98913bNrGbYcu2VrZzJObbROM/0B27ozejLAn1patRdEs5zRniIatQrUxNzEEF2PgTnZr4",
-	"HvotcniBIHx3oVWUGwSNJ/Gqvm20p3t8mbHKMnUXjzxodLSu9VxcRDMmeJRpe2LMaO9MGOa3toIx27XK",
-	"NuvUzh5frfpgkFObms4n02iv1WRDVeYI67PWXjHN4DZNOZSXl6fEIHnG53ea0t6oaOQG5VXL5l/n5WiW",
-	"OGGLb6FjDWZa69WKqLm3jE+4kIZu4iELQRcSSzhLJVmmEp5NlbEv/vr8+XPKTsVZp9xgBzmDovqbnE/g",
-	"my77xs/7DSX0fOOn/KbsFBOqNPiuij4WA2esNoelcm2hZdXILZBXzHHiQVCd+5i0w1Pc7JbW+kRZD5F9",
-	"OIDGk1VK4H6O5VCrI2DZgUvcOVFEhDg9g5BMQu5ov+j7BltuoSer71Ou8InooLGDNgqoqhlr/81nUQY3",
-	"UbOZkxJmLpOpVlIVJlS9DQg2Ob+TazF8iV89KYpxiU+LY7+FNiTjz5+4+MkybvkK5P7h/4F38xvRrCAU",
-	"RfRPAkvRrL+XVzOvNAlLS74oRPqQy8JOCHWn+Swrlb776YuML3CiREzcTdMqFszWdoqjwgBrae6CPvun",
-	"oTo6z1e6e7wAJawvwdn51X/3RtRKYT3xGctt0e6KDCKfvvqzae+J9RgdKqbC/C9fZJSyRwAz4XjtqE/F",
-	"BjYNfvVPI3XwOJ/YfqIttNlPP8yxdQe5375Yj1ul+RjR2Uo6VIVd54irgKcKu9Ij94nk0QM8S+XZ3LAN",
-	"fUwBuqqweUE98jMxhmSeZPD1AeXpHlBqVK0Ku+Aw05BgudDJQfUIG5eulDl8Eb5/0kTtcpX1tWUX0z39",
-	"wE+Xov2JaluUid25hluBd0ZGyIWU3YoUVO0doYZ1n1zWKsVC9lkd8Stfz8pHK7+6rjfZpypkvol/o5pr",
-	"EWp1+1eBcnjbQxYKvfgzFu99OOr9etj7a++3f/uXnUQjAuxgln/34HSCiiJ9zGNDwJW/9l4JiU3qe0ex",
-	"Rs9iBsbyWe6EHFa4Is9uNTUN7rO/FVxzaYHi5UbALl4df/vtt3/tr34BaWzlkuJRdtqJj2XZdSNuK88P",
-	"n69ibCwuJ7KMCSwWOdFgTJfl2M+CWT0n3yfVeGyC+wKsnveOxu6H5VK4xWRCuaLYVgM7QArJqob5ofui",
-	"nhMTVIcoY9meRWLZPn7BCadUitcgL1ID9Q0kSiZIe7TmD154xjYP7U9R5gOsUihhNcr0XAqyX+LX0LhS",
-	"l7t8tAQ7nmX1aZtgW+qAGgm9e2rl21xkpe59topFvRD4AitEIQTKKu6VXOuzd1Ryti7rctDs7ARbIGJt",
-	"84kwFrs0YslqJ0H6y1hW+Sokq/zpcVxbY3fzyofCfdqC4VblTfVD4DYJz8CqD6DVge9nv7JNCN0V3EQ/",
-	"v6GihW4GLPyhmJul65DLdZrh9WXMfry6OmdW8/FYJExJJmyfHfMsC7VCjs7PqES2MG7KO6et7vgNMGHZ",
-	"CBJeGGDvpbjRfGzp19B5PPGNnW7ANymZhyIGIefk5zfRUh90zEt38iv1K2jV2SSsEb/vWdVzp2QeVumj",
-	"IOcshVmuLKkNPzPCFQJUayDqLyMO5Gq8XYCxSoPxZTNp6vIoZSeCao2uk7/qDk0IhGZzM2Q1oEUj0gwI",
-	"oTS2NHN+fsOk8qVEsHK28bbNFLKUcYe26Cu7fDhuQD4RamjidZixkMHM2T5rC+3UGzKVo5ql9vosfPzd",
-	"4XdMjGvfUdXuqkhqtPXM38Belft5Qu9Xucil5Tbqdr+KH3BX2225u1X7/GXlygVxxrVvgkH5roSQVkSg",
-	"Vku4hQlV4oV7ByzhCMNg/Yh6HRU2Uukcq8lSUHf6Mtzk6lNosJzGCV1SgqEO/WYr1DPf1x8NpzHmJFXL",
-	"2JInXjDs7s+SDLg2oVhT7ZSx7kUOek0ieoIOvRR4US5TL7T55/lwd6biT5UxHSvZuYoRiljfHLBrKD/Q",
-	"4fPDZ006vONEiDU/SkWTL314lRt36MYJ6wY8Fqm+JLHr/q+U0V79bCcizwv76aj7s6fmbbOFnmZDBj5t",
-	"ONHlKgXTUPq19I+4MXYm/4HdMbgkzzsTIRO0WoAeAnyXDvrIMG6MmEigNqdSWSW9CSxkooFjS6bQ0z2U",
-	"HucyZWMu3ShVoCXnmE7lIMNjQ6KkBOoLHmeOUSZMJf7p/eKJHvFoLVziEz3iVeeUt5CpPEqkuEEMS82t",
-	"z4LMaesPUQDNpnc03wZEskh+Sw9tix5nkNS89hZY882pmplIuM9OeTJlY81nFIiL5R+UnrGhSF+wPwz8",
-	"/vH6Wqbc8hfsD/AA6zmAu79fX8uhk/UNgixblCVgTK8kY4IhaIOun0QrYxYEgE+Ne8k4e82N7SEOemcn",
-	"dAfFbj1eB9Uo2nHNLc9EihdEDaaYhWtn4LATrXLaFAX1UMfKCc9NMOiGIh1SjwzsiOPv0CBuIaXfhKEq",
-	"CnbKJXvG+BR4GkKOM7dXAyDx0254a7sD7RhbYN5s2ad8VIzHoPvsOBP4le+taTVPbiKzOW5OwUJicb99",
-	"9gqjr2sMTcnoUi2ADF1O1bKV3elR5ZCBYf0GAAtMB3pw4uhOOFhNeY4h/thKDyRokbBhU0gMqd9nCPf2",
-	"JwdvBI/mOPYnbJtBTQnZnvt8ju17HKVQkznOUpUUM5Bu1NDOcxhSAyqa8RvDhtRvw9GL0rOy4ETVDMZr",
-	"33/FbZ3gx8TvXWYgg8TvhyaPdqdDYmkeb21VtwtHbqGTBZoqC8LZd5pSmhmQKTukHPEoakJLt035qcuM",
-	"ajLFLc8KioefgWMRrSHBOgK0FHdrCGxYFZ6Q6DGgekNq0NCny9PYSEK/3kC6fXEpHIsnYNywS3wQ7F06",
-	"IvFk6Ub/vwEAAP//O92XVQ+aAQA=",
+	"H4sIAAAAAAAC/+y96XIjN5Yw+ioI3omwNENSKi8901UxP2RJ1da4Fl1Jtnu65UuCmYckWkkgDSAl0Y6a",
+	"+B7ie8LvSW7gHCA3IrlocZX7q4iJ6bKY2M6Gg7P+1kvUIlcSpDW9l7/1NJhcSQP4H9/y9AJ+KcDYU62V",
+	"dn9KlLQgrfsnz/NMJNwKJQ/+YZR0fzPJHBbc/etfNEx7L3v/z0E1/wH9ag5otg8fPvR7KZhEi9xN0nvp",
+	"FmR+xd6Hfu9YyWkmkt9r9bCcW/pMWtCSZ7/T0mE5dgn6FjTzH/Z775R9rQqZ/k77eKcsw/V67jf/OZGC",
+	"TebHapEXFvRR4j4PiHI7SVPh/sSzc61y0FY4ApryzEB7hSM2cVMxNWWJn45xnM8wqxjcQ1JYYMZNLq3g",
+	"WbYc9vq9vDbvbz0/wP2zOft7nYKGlGXCWLfE6sxDdor/EEoyY1VumJLMzoFNhTaWgYOMW1BYWJhNcGwC",
+	"xOFrIeQZjXzR79llDr2XPa41XyJANfxSCA1p7+XfyzP8XH6nJv8Aor5vtbozoI9yccyz7PTWI7wFScm+",
+	"u7o6ZwnPMjbnMs0gZZMlHuYGtIRsIBZ8BmbAc8EMEtYqKFNuN5JLZDsnbpgjEVXoBLacAEde0ogP/Z7V",
+	"hUy4deBon+1KF8DEFM/idsimArKU3XHDylEsLcAh1ohfgWViIaxxx/PAnCiVAUec2Aih4FaYFQswli9y",
+	"JiT7QYp7thCJVgYSJVOcbar0gtvey56Q9k9fV9MLaWEGyKL0l996IIsFIjYXI4eTGmaN1ULOVkjAmjBh",
+	"CcgtqeHEY20HxjsHPUBSyfkyUzxlU6XZOGx2zMDNayIEUmgUMaNFBIw/8SwbJJlKblj4zrGdQxtRpHaQ",
+	"XYgsEzWg+hPKYjEhELr1aBERIYb3Ocij8zNWfnWWhkUWTpZAyrRyQmMPhrMhG+daJWCM4/Nxn40tv4HL",
+	"RANIM1d2vF/bQcALoQWMja7vIOd/ZyJ1UmkqQLOpVosOZgtfL0SaZnDHNUQXNZbbIgJVZOtwEzP6iiUq",
+	"rc9SEmCLpmoHacG1XK/fwOkainPkdml5crO6xeOTc3ZRSMdAQ/zkSvMEmIZcg3EgkjOEzX/xW36J40hO",
+	"Gfct4xZ/dKNRSkuiviF77djcsMIAcytIvnATJUq6n1GSa27noJmdc8mM5DcwSrhBOYC0gPMez7VaADuB",
+	"2yulMsPOtbIqURm7ExoYsfTwWq6Qutvha80XsMXNgqeZ4sd95qhPL5SxdIs07o/WEiorFvIdUf7KIn8D",
+	"rQYTbiBl9CEjHmF3ws4F3VOZkFE66PemhcQ75R1fwOrcNUyEDx18oc+UZrDI7ZIRZaJg4FLJ5UIVpvzY",
+	"REnY7WaL07jPImehr+Onod/O0jjt0X/X2DG6u0Jnq8N/uHjjjuzOHsSIn20qshijtjisAebaPmm5Bkj6",
+	"TXzHWK2pI7SE9qokJGHPMj6BDBGF20emssiBJAO5WcqEJbwwEJd3OddBi8yy99Pey79vdYNXEuHDzysX",
+	"DE7Z2AxSEm4F/2qGK8CssdxaQZTbZM4vVXYLF2CKzHbpRCyhT5lx3zJurSNtpoHjPcGZY1ThQKgKm6gF",
+	"PEoj6tjXZ+WoUzny6BkhekYaYfbUitI6rOyuMwUSaqhNsWN0q1Dh6wCMljjzFHsLMlWaTflCZMuhu7TS",
+	"IgFtmHRgzhwic61uRQp6YHJIxFQkzHJzg6LMMCGtYnYuDDNgXzJwT8pcCwPslmvBpTVO3GkIHJKoLOO5",
+	"gTAQhGa3oI27GCZFcgOW7d1+yQ7Y7Vf7fcZlyrhcOtE9Y1JZlqhbvBBJ4Djgnih3m7y1/kB9lmdcSPb+",
+	"+GKfCeN0A6UdaXLDxsrd4mO6hANtzP3Oeg75AWa3Xzb/8ytHCYWWxorMkcMMwLpXaL+HU0Zoqb+7Couq",
+	"HUkQY7m2jpNigmNFkcXn48ipaqsLIT3WUIffolrnnqBTLrJClzrs6cXF+4vR8dH51fF3R6Mf3l2+f/Pj",
+	"0bdvTsf7Q3Y0cRqWG2SKxGm6OymXV+1zsLGfZvySzqyZBgdilJeF4ZMM3A/4Zh6ysd9p7GvpD7VnANi4",
+	"Aobb9djJE1XYalwqUqQkGl/XC9ytAPoLw+64sGxSpDOwQzbmEy5TJSEdv/SfsITLBDL38vV3Yc5nwCS/",
+	"FTMUg/yOL50aPsA1m/Tmj+0EGR3JgZE22ev3ysWiJOX4LvpY8FjmxoiZg0lNQ2Hvc/5LAX2n3k4Lur5N",
+	"kTuuYE6wmoGGKWiQCcRRegcTIyyM5spE7r7vFGmmJRTu5qDBw5NY3l0RCIh07fw5t/PIM4jb+fbzs/+3",
+	"AF2qlHCfZEUaXXZFIajJygc8WdL8WEkJie22msC9N7YlmXCMRCyXFMaqBWh2efJ9n51nfHmnxWxu++y8",
+	"yHOwAHrfvUTc3JAyEpn4SvkJJpcK5WWu1f2SDErCsB/frl4Fn1WCVZUgzUcerk+uCaT5iTDJrgSRlmMg",
+	"rZ75G1DNzrmgxw1+LRYLSAW3kC1ZriGB1PHBuHbYcbA8GvcSMVYDXzxOG1057WdFdC3VVXh+fsJ7oPZZ",
+	"bbGlgDa2//TWOz+x+8s2BrwFGMNnMEpUEeMxev+6uR0T+Y+dRpjxpbuk8faLrAsCjT2p0PS3uKVAAzex",
+	"1/JP82V7TpDuEmJjYvRRkinjFBn8inhfSGEFEi79URmnIRU58ecomXM5QwUEjUyiWDANqCNCSnoGGNSg",
+	"nb6MNyXKCas0sFTdSWZUfbVEFVnqdHKPYz7jQhqyjkm4Y2Hd+hZQrRq/LH9jqXDanA5wZXmxyEkRo7Mq",
+	"aeHejkpVyR84GCn978i2lTq1Z5e5cErW0rsOmJkX1h1hv6lF1UHZ6/fakKr/CfeERpHWjjazX52O2+RW",
+	"UsA6hlTSqAzQ8dVpO5jQtw4i7mOvzCrNnCwrZnNbN2fCfQI5ERXZLk8XwlYXxp1y14gVMrFI9CQzDF0Q",
+	"qZiiomdJbJo5z8EMS4OqX//o/OyYEzL8X4b+zcCzzOw70nIvRMMyuIWszxxM+4zrmaHnGtpcRmiJqeYu",
+	"t301144e98qzlb/Up6Y5MyGh702SfX+UUaGzyDreguv0eu+fdM8Hry3RSMY1MI6PmJgVdpcbr43Vzxde",
+	"94VHsPJM+NT3XRQRu1oXceQxCYfeh37bdu4oO8K2WVYyLNezYuFmZokCnZCaTgc0Q3ZOrgmmZLZ0jxfp",
+	"6dGzbBf3Naz5qw/Blv2WmCRi5WnY8xv279pDqhIqSFPIoltvvMXa8csSZUXcph6g6AaxW565pyrP7vjS",
+	"sGuybFz3HgXFqPdgdS9vas6CjweoSsp1uBBWXAfMztGxpeGuuccn2FjDrhOk7dZW6tJo3+8hb63KHbxX",
+	"ggLhvqn2LCSbKDsPwjvndm42v+NxnVWJ8fOKzHijZltfyJma0W1b3YiZmvXD70Mhp6r6rzuuZZ+BTYb7",
+	"wye4ZcJGP98xG++YTM2e6YZpIOHTul92uibWiOFOLdDN0Wc5NwZfJ1oVszkr5FRkFi3xKErI9z301tcx",
+	"Gt5V4S1WDR3AvxmZe3AAT18xnmUMjeisfRsYp8sB18zJ3yG7BLKGmByS0gk5LbKMOUIgne73kVuvMWir",
+	"jZ5V7GyWV4SQ/hZyq0FFKzvyH3kxFd5WyGlVeFaQawslhXVPDGkVgv/45HwQbgb/pGdnwYJML2TL9Qxs",
+	"n2IPSAH35m58i+QqmTuWvpsLHw1BO1FJUmj3IIxo3DhV1JrtsIy/1gNfaoZ62kz8blc8Bd05a6oSwhV9",
+	"V5u/717UgP4N4Mm8drroOpLfjgz8srrKWyWVVdI/YoVM3CsRvVcVuCjMMAnqRp8+c/uCtNyAVfkAyaM+",
+	"MgqELUSmtw90wiXYD+qBRp7DaJ2aOSMKD/oqOn+gTT9RbYk9Y/Gd5i0x1TlNOChnlk/2160YLoMtOPsK",
+	"R1y5AeuiNDRkcMslud/mwhApvyLvg/tginEcJU4cL+BvxDr90sRRfgv2TumbmrVsvVCoIasO2OaRKxJc",
+	"c33V7/8drYBa3YLkjkgXYDmqBB5zS0fNxOj+wa4ZeCtEyfmrqg/E1a3gcK55KFFyYKCMd0t23U1jBG9d",
+	"epU2FAR1nHBuhEy79JNwoCHaOoO9LRbU5a+x0k7vheuQjSkwb8RzMX7Jvsf/YEfnZ8GgtefkjL4FMqnS",
+	"HwczkKBRxwo7Z2O4tyAdIYxfMiH/QX4Bv5/ytyEbZyrh2ciHH45fMrM0FhbM/4HpQkqHMZ4pOTMihcZ2",
+	"m0a1NO/1e9X+3U9hoZ6TrbWFov7JQCrdxBZRUjbRQ7jNiBictCI+OPB8ckBXxdlJA9+BF1q8hchfwzHf",
+	"WZt/B+5uMN2HsLpYYRiMnpzTSLbgucPuHdcpRh4MhKcUt3sn2lRhywALumTYj+7pa9BKVTOCkpbHJoVl",
+	"C75kE2BcLtl/Xb5/hypSQ+tZOQzG91PE93EmkpuNL54Cnz3u06BJ8NwWTsu7FbwiQpR2VRTdg5840f19",
+	"fuh0PnREBa8RYumpnzvdCHniR4+BDBKrIuGbx5eXLPyKr/5gxcUDOwGZoabUoRPMYnHNb98wy2eN2MvW",
+	"bA5LRZ6DxrBekjTf/nB19f5dnx312cnZjx1KSFQb/1EYgfZnJ7Z86kzHwn1mNTpto9Pfx+aGO4zduB8k",
+	"SulUSG6bp3JncVDMxT1kJm5mWq6ZePnwiVvEd99zK/UrbBOG1r5zaiT4PSw3SqwbWE4U1+nvLa/C3j5L",
+	"q62k1Q0sn1FWNZDxxJLK7XwFat/DkkzVlf73vSdEAihJkFO3xT77lic3JueJezfHxcgDxGEQXGj9naOD",
+	"PikMWXkpPWSJZJJrMKZDvGwvLnHy9eLy7N35D1d9dnX616uji9NuodlWyOAREuIy0SrLLsHaDNKNssLg",
+	"18zQ515ihJcLn9rqk1wZUcvVQ6eykLP+7ydfVk/2WdJsJWkIgyOP5GcUOh0YemLx4+TLKKIG0OrsflCS",
+	"qs9uosjhyk3kvpqBcVS7jWKA6y0711s+9XrepPEAAUhrbVIIVQx4rzES2ayCEGWAmzycIMiKbU6iYnBr",
+	"LLV8kqXaiUFEISXq/KH9hlYhvFa2vhG34BTBDdGsLBO3wG4F3FUhRa0QVfcUnhZZEL5fGPYTTC6ujksz",
+	"yDu4UftD9p3/Tsls+QoDOIJEniqNs2RgDKM0x0dJ19jZPgvVTqHqUDxyKH6uMNlOfOwerxjM141gxZUD",
+	"dMcrrjOPvylJfdVIPmSXDQt2GVJn+swoxpnVXBpkkGAEnmQiZwmXSOYYsOUtiWUMLwbmjqstjXeyGG8B",
+	"8M3Byav8HQ9O3pbJqyDlGFYmy5XjPprJP4ck787nzxeYvA4rT87tn1CA8kPlyitfYiBEJ2tKy6dg/i65",
+	"tqNjacvUlrfkLD6p8X+H1Ljy2Qo1GFkVHBaOFTJl7JBdob5m9TIIPm/XTrXKc0hZIa3Igo96VEpU90TT",
+	"WtyCGbIrDdyiIVzIQa7VzL1xQ2EXjAy1wPa8xB2JNMMAhhmMMr5UhQ2Pg33GDSukhkygEKeV7Rzko0RQ",
+	"F8Q+y6BOGRSwXb9lnloGrUXLJiHUJIau0P8L/HvpOa9Ogw6eBDlhVAbul87F0lMXfhnWfXKtUZvBsjks",
+	"3YPiTAr7motsI0cHAUV5A05Hn4BPWcjEr7Tfx7JLazOfmWUjszgEjKYIsmfilRhOduMUYyHvpqsF2LnC",
+	"HNqSmHyAjIWcLJt0Pm9ipACOoQF7VFh1ZC1P5luYGHETm097Ea6arXgiess1GETDADDARZh5aWCE+zkv",
+	"jCWHfFY9GMiigjn/ZsjeKTYtNJWcaV+XdyLL/FVYJgJ6Bn0KPoxB4TMzbmTGEpHPy5Gd2HmWC6xBnT5b",
+	"fVj9deSJ2V1lRMyOTAMVszvQwNBrUORl0IPPfp8WWbbEC0/pULSpyVX1OzCy4hNegxfwaM22daoI3/O2",
+	"NnBK3ByMXWlRwmHGc4wCIXX5uKnVYkULAxbtC60gtGBisJonN242rzSwqQYzD692YViuhLRPKiw+C4qd",
+	"BcXzy4jHyIfAcNs+lLGoWutJzCy/AWSVWqppafdu8sM2QF1h8NgmN8OnqsrXaf7KQQuVioSZ8ttgAQjO",
+	"xFsfLvEUbNTa0Wcu2shFFV6eiYliKNmNh3IZca5/yw386esByESlkLLzd3/ZksRKWE2WFjZqvG7tNWd8",
+	"RxfFWZrBRqd5uFREGsJqWy5zzr45PFwY9kshwHrOIVuvVEzIwTQTs7llvrokRkY/zo/T8ph+ZpNVNqmb",
+	"vp6aQTzxvFE8FXK29q20SkUZjQrPOp/DfjZtlAZwIOaZBp4uHVA8AWFki9PCOL773KNQKpZroTQbhwP7",
+	"KcY4R92RKOx+n40LnY37bBwyT9y/y4SRMWW1jDX4HEwHgHEta/wVG0coEHOdcq6paDTLVV5kSBqYpsEt",
+	"S7iBRyacd4L8802xkQU8xT3Ts2w9Zp44FoQKV2xCVJ2Lwoh2BhiGUswilVBr+KI6avEA13chowUz+mq/",
+	"eUONBPvy5enFxej4/bt3p8dXZ+/fjS5OX/9weXqyeyFkx/ORQsjoIQlvJqXFTEiOdpWWLOh0jrhVa6we",
+	"X9ifdHjhP71a5lB7H+MKK9mR9YB/nxj5vVR3kmIGDRMS65KxE5+N1mevwSbzPvvrdxd9RpU++uzSLjMw",
+	"c3CPvbMFn0GfvYVU8D57rdyYK7i3V+6p12c1lu5X1aL67C2XYoo7PNcwpTXe2zloknULpbeoPNuo7Vyj",
+	"in5FkGtjSjwIQ0+Hba+KgD7MBu/IKdpdhtZ38Vl6bpSeHgnPJDZXkPHEAjNke24sp1CmheKN3SzG5EEQ",
+	"FSDzWqbQLvuuZxmtljT2YAnZREO3kt+T471OWXUWvhliLQ0hU+zTgdl6qIgUpnmmBwsu40VUzrVxwiTX",
+	"4O5ZkiqYzB0FlzAjDVRWax27oI3Ly3vj92uKjFprsDBDnE/IpdBR3N77G7hhoZSpmxzLs9O99ZfTqz47",
+	"f3951VG+Whk7CjInjrOJSpd4P7hZDs5/uCrfPH13OH7LRcYnGXTcR3S0OL2+pzsuw7zSCUyVL0oSRiEa",
+	"8GCoKteAjWDUBTzR1dtnhRS/FNCoqV55ID5fs4+/Zj0Z95sirBI4KwJhuxuYejvscAX7ZhAaEhC31YPt",
+	"tdt0zZZXfojk75DiLeE0rI8uMaTKkCFJDqynudFrp/p8pW9xpRO8nu1Ob6PjiS91R2JRzHjwN2ixkolY",
+	"AwklCtxb9vbs7SnVGPld73W/s/rFvs2F5bUUFS6AdSrJQiy6BG156DBhCSq6/RxkDuZ2kfVZu8nX51fb",
+	"J3+dPFFjnzBNx8s/OlctPf/9931WtnPbf+itV9bfDoy49no75zM4UYtjSrR9o3i6hUXy5P3bxoBQ4cuR",
+	"j5twmJYz4lx45T2uolfnPj/fWp23FoZtpmox8mnUaM97ejveetQ8tR0vzUclsCICjOIKFqGQECMPK+Wb",
+	"CsmCd5VbX4VlhZSnDgh9LHRsxS3iNZB9iDWkwIA9p5chqrCC0/6Q/WCAja2hyip3Tf9uJMS5XUa/cbKN",
+	"TPsGw3G3Td+k4N2O9M0XHixeKUXrJgaHV54oC/oWsBRKmGkupvguqx7Kt8IUHPuFTUQm7HLITnkybwyg",
+	"+At6l74Y+FXdofVnr9bvIAuaIdzPIQc8VTpcby4RWSwKz2QNGtk7fnO570m0zJY5B42nlgmwK7EAbE92",
+	"dH726EulvePP98l2NOQA9ntQ0LPYNn3Myyr0Tlo5Kw3CBGn1ciVQZ88X3D1Esd8QjywHjSUX96MZLnVQ",
+	"jlKwXGRm95SewBY1wDFurRaTwoLZwEF4pFUemvN0pCFxOoOQeWHX03EDSL5uQgIpuc6wLBJOEkxeGPLQ",
+	"9w1m3MUhPJ8fv7mM0zle35EsoPq6JlE6vFOE8bjac5oPQiLEHb653I9fxSs06R9KO1ZaDDUf8O9V8eMG",
+	"iMrCjtGsaxFrBRlFXsXkMWrdnGPVDvVuHdjvpcp22kIpSfKNYv8N1zP3SPVq17TI2DkX7vnw5vj8d5T7",
+	"fquf5f0GeZ/kzyLm6+B/YvGeJfkDxamnzYo0iTIfK059lYWoFBFpNX3g4zfH51WNKzENdrjOoq2juNBw",
+	"L5qyY29r3q1SMKVKu0Xfyfu3zH0QkX61dbr6v8gUdMe2L/DHbTf+yl+81I6NrGK+4kEZOH8lFkLOBkdZ",
+	"pu4G5AqKp5yKX6G7IhnXwDs2RAUnmPml4E25Xs29yY1anxGDrtwRmNLsVqSgwk8dFVCf9/Kqb80JLsLe",
+	"M9xfuFBMyXrw5bX5xlJ88+u5ehG3DV1ZGP5EJq5yO5+vpQ3XkuLP84BtIOATN16hzleR5R/FdPWuTL3Z",
+	"jvPq1b993642HyLfvws9RPeH7JhrLQDrYpdFcKfU6EhIlD4TLCNrmS8F3WfYlSSUrK5bqtrF2h/N5S0A",
+	"fOb19bxewf85OD6GjN2yFR52y1Ydb/GLXSvyv4M7tr4qPys72pav4g2F+anF/BqtwTeMXzkS9cWd0N9r",
+	"pehf+fBv2kGkKH9HI+SdK+4/WV3937dcfkUDVj1ZbXuKdqlpQhUVbc0K6/0KoW8eRqV0eJnK0v4tqzOb",
+	"81ug9kR4X5WuZdOknYZroWxgLAyrTU8eByz1jXFh7EymkDvtlGoG11M5XjHOjJCzDJj7glI8yV2eKqD2",
+	"dxO888Rje9x9dkfsKtef0yVxxSfvc5BrnGQS7kqFw/IJ9iUnueBgqXAw6Rq+iELIorlS9AekYaRPGmf2",
+	"KczLhFBD3igFIkyVh+Mr/rkthDYxRjVKem3KufH6SzPbpqbIlNSNNOf0vFgmzpAdK2mKBWj3vqNEo5be",
+	"hH0WQm39OVZrsFhMSFinO3G0dAuePUXWziriPitJ65nJ8smISPX5megBOhJuLa7JXK30tvEakuNFDCr3",
+	"LIhErSRQNLBc7nrpV+0vYr16JNxly3IpPnkWTcAKm0XMIxR9nnkZ4r4ptUQUDPHNRNWKMFXNtNQ9R5su",
+	"1uoUa0jkEvStSOBYczNfI2hNkbsPjdLpYMEln0GK1Q5FAgzuhcUKZnCfY/59thyy9xh4iJKUWjBWEzAN",
+	"udL+heYGU0GyMJrtjcM///NwvP8KYxgkEauvTH0rOBtXMyaWfhizVKG89P1sarL0kUItAqXPUq1TqnnC",
+	"GCUErqeWal3I2L2kIm6wWVCxtfeylmLoteyu6hQ0hoWXHoU6ceP3mTDWSU3Kssh996S+N/7AvbvNTWhZ",
+	"juYdiQ3mfGlpC43fPIO55Uhz2HNbPf3r2dXpSWkMeX10dfTGV171jaXR2XF2MmSnjskSlQK1kBYzx0ru",
+	"JG6gKfSUJ+TyrR8kVFlK5lxKyOK97NRihPuNlM6uTbV6JEfHQtbzOWoCwJ13yMYXP7x7d/buL2O2AC6d",
+	"ljIHntn5spwkFZC+YuPLq6OLq9qHwuIvobgMGp6K/BUbf3t0/P3716997jI+YTBOikCHQaY4QR0KM/fm",
+	"KfJQVIac3s3+UX6fvX4v7KTX7/m1ov2i8ugD/eykLLdJtBfOOWRH1VP8/OL98enl5ejy6ujqdLSC9EBi",
+	"TvKGSgVZ5o2HZY0ih/qyplBHOKznA0eX65GLlSj5otG6LPH9+p3auyisBe3+RS22BuTiGfBcjLcpY1bf",
+	"SL9OcutEBDYDe68W34ssW1Pe6I2QxT2jfbH3798ObkSWYfkxvcBOMCnjJbkJWfYR+/HtkF3WmwqPD1K4",
+	"PbhZmNk4PCActrisqBWnLnOS/Zpegi9gofSyLJNGb+gQZOGNy953g+YaPyfKEG5rrExoiXee3OW+W4Hf",
+	"5+uu+7pDYI2UWowcjp/8uovjYvfbzm2uddk1d95dONh9gWE6I57+YxW4jZ+DFPP0HsjfN04IvmH3a1zy",
+	"bJKOzXk75qAfO6TXsVosunZpvHa6wql7C37PXnzjrkNt+jWqbHzWkTFizOhmEvOXG3zOMAOWyDq+KyHZ",
+	"9+JbtmcK3DeXSg60MX3shE7/wot9voCF+8/9rl4Nlmej20V0L1fuR3YrtC14FgTSuu1s0aShgQbCbAmM",
+	"NRRfe3itewnWc3ro+eVkodf9W0056w/uXr834cnNTKtCpiP/l3DN3Cl9A9r9Yc41pNV/Y35v9DoPuw4l",
+	"K4+5hZnSAsyxklMxe4hiSlMsa3UwfQ8eDATH5oiOgyf1BsgRvuW52NkT2j7H0p9iNbPr+9p9Psj40ikb",
+	"iRW3wi5De35gSWGsWoBmKZaxfsmEnDjAY3PQhGeZCZa0FfUg1NN3tF125BwsIKU0dQeRZM6ZUdkt1MqI",
+	"OhLJtbpf4sBspeB4JqaQLJOyXypen0JONTdWFwlCuRzpE30pUnSgZBCaYxZw5K7aD/3Qjv0Zwe27sjNV",
+	"2LywbA+78fu++1orvY+7dmKpmM0tg/sEcu+pwVT6sofPM+7xB4oZLZcKIN7DVnqmz25gmao7p6hSd5h9",
+	"3Jw39z/jxuqFuA7KTK7QuXVIPrTZc6LvHENR2rS3V/ebUDWBVp7Gm+NzB6QPa+Rlxx52kzs0KERRo/Ya",
+	"3C51KeSJfjVSTvJJtErPT3Ogkr74mAyCDf9NXcWG7EyyZs0AtRDWu4+E8bpgClNeZJbEhVMX98rJ/Nr7",
+	"NNPR1fF3G+bawx7E5EvCpiS5XTKCKxv/9mG8j5Z+JtVA5a9IjIW1NFgu8JVpGAYDS0vv2yG7Un4nTGmW",
+	"CkM9Uqqht4LT7vpsqQq2KKjOS4pbuM8zkQjLxu5sYzfDGNE0bjS7LbXcrcjhIWRQNSpIIgRR9ntu3FLt",
+	"u2nI3i+ErR8d4W0Dol4SAq0qR7oH/2X9A9yb+4KCzekLnLVe0ekGHPKt0JAt69O5N29SXsM0tfvb1In0",
+	"6gecf2XFJAPum8DHYRF7XPkdbWta7tQVoog99s/pwKJw6uT9joh9TZWM6b06wUYbKQsP9fKAwP7P//rf",
+	"IenXhIbnc27AV69b5fwFGONF56qpw41clQnlaiOaesFzQxVT0VJx4PRaumcPcpWJZHlQ3v8HuVbu54NU",
+	"mDzjS+YujlelP95PiMVUHKN6N7VDBbfCp7fVGw00d0IN5mszRTW+eH3397k3UlewbFd0r69srMpHAf6U",
+	"/att/Q++BwICwIG61pbc/Yc/f/hQFIvRNOMzQ/hxINr8Eg1nDiiMKeXYEvmtKgz4ai87+o8mhbWxhB2c",
+	"ktGvDvdBa0CbXA1OGUytezaI2dz970KkaRZ0eHqw33GdRvGESkdHwvyVfz1Qj1+vGFWrOiWl1+8Vec9P",
+	"E11grrJ0dANLEzteSl4q97M7n/u2XvCaZu33hIVFvEW8/wPXmi9RSyoW1ADbL4f3Ye/lizanv8NYP3wa",
+	"iQV4xsohKOR+3dX3YaRn4F9ZV1fk0NNv20bL//2QmaKdlTuINMdGtD4BYEcajWf9H/vrPQmTN1pbb/bJ",
+	"uUmjm6Xi5vqo0sa3F+NHQSnzjX+0p126KyEpLDBOtTmpchSK+iG7mgMbU3FP0oGoNaIX8deymiWniG+y",
+	"Kax2YqLRDgioB+HriMbmXPMFWNBmeC1P73lisyVTsvydRjZqYeAbHhWhCToHbkUaN14SKy+czNh0x64K",
+	"rA/9Xqr5bLvhJ5rP2qMX6ha2G/1W3UJ7NDYjHvmWyusGn7sPv4dlbSy9kjYNpD6l9WFgR0mhjdqokVyC",
+	"PcYP66MzoAtu7UD3kSfhmlV01cge7DQrFNa4h2v4bcCbZg61FytQlqBp4LZx8nCQmOSuJt1wTHdPXMG9",
+	"LcHT5vJ4Hap+71gDt3CCpciUXj7s8lyoFNZoGmmYnbkP2Z5KLDrJNbZtRl/Mv3/zzf6QndQeT//+zTeo",
+	"xHFrQbvp/r+/Hw7+/effvup//eFf4sGldh4JCpgYlTlpU20iNKpN8OitRQ6G/7q5grdbKQbME8jAwjm3",
+	"84fBccMRwsZTXObpN34BCd59s4ftPmYRP1sJutFhkdpJ2FGWz7ksFqBF4l5h82UeOr3V8M8Hvx4N/nY4",
+	"+PPg53/7l+3ylE5I/dzyjdlKUgZU5jov3KDa03dVmlZHRho2+hjpqBu6PaX/mmlsKyLZd7+yPd+KTxZZ",
+	"xsQUPWkpWEgwNHU/uuidSGME1V4NP1u7/yho2zfQ8yjcTmx2KNulkk1ad0yApuAeH3U99LCtqpy4T1ay",
+	"7idg7wBk2IhTtMl7EfzrVjEn/xnPVBlAbDF1YyGkWLiNHsZwsrZphw9VQxdI1d+yvbcQUUY2BYKQ28ui",
+	"rC9pFkrZ+X9iXUmyR6BhpLBqwa1InMbtzjDhBiiEAhdE+ZKBnPlz8Hs6x4vDw8PD2rm+iR7sMa8Md4Sd",
+	"HhlxSfleY94gy4RBtfLv9322/Lmu0udcaFPiLlQXu5uLjDYxE3I2ZG+dqud1R8Yty4Aby76k3jzowCh3",
+	"2t5yDSALfn9Gv36JwKv+o32atT8SLhs07PAasWmzebHgcpCJG2Dfwq8Ca6DoW6ioGTF8x5d0ECakscCx",
+	"hl0mJHBvFM9VRhYk9pMjJlwNjQRmlIMeGZghpRE7QD5CJhstvItiJlUzd7Pm82583jjSNzvyZZmEhvta",
+	"weAZ7WKVGzby58o5m6/Yw+5nbLklpC3aFxbo8PDyThoUE90bZG9pe+xFY68vNrsxuy730gy3rUGsNfE6",
+	"s8spveXOM768Qym87WUQr9Bbex1WU2JM2OpTK6pzOj2Yqv0d/Be/5fRPCiqr5qZnJv5xzg3j2B/M/f5F",
+	"zmfwRZ994SPTv6DX5RehhTa75Rrb0fqn4yLP4CW77vE7Lix6d4czZdXeF3Nrc/Py4ADom2GiFl/sv2Ia",
+	"bKElq32Osbh7+6+ue3X7eTPbmZJbkgYd/mmFDt+StPZnxCeMb/sU4kaCes2EYX86bEj4rxryfTOtIfC3",
+	"pAeDG96RHEJJ6RYVVKdb9ewEKm9F1GAXBE/CTm+q4OO7TsSrWPpNr74TKVuWMFnFVeDm9ihsfJ/ESAo6",
+	"sp9Ly2XKderbM5TBmfWDRSy5qYoVySkn887WLWejhnjrfGBQhzakjR56cTdPIxjOLxAjkNcigzM5Vavy",
+	"SJhRKvT6XeH9hU6v8jnXUWpcdRatcFf5AhUSqqFa5iCXQVUptzDwtWlWa7hG5Y47Fr1uJ8IaCjDss+te",
+	"qu/u9cD933XPPWyuewN9N9AD93/XvXgcTjwc6FtugKIXQxUFEVx4q5DY+lUcdNZVIhG/wmiytBChk0vx",
+	"KwoW/Hno62OEbQgwW8TchFgbjnp9bbF+oIMaDj3Qu8iJQs864idflz4aDBGeQVe7im3Ij0+nFPu7NR0+",
+	"FJflUg9F6m5UEjeL+WjEZQ51G9jxxenR1Wmv3/vp4gz/9+T0zSn+4+L03dHb0y0iCymosFNhwcq+bR9k",
+	"B35PhPuvEAZbSF9brUy3a3foDTUpvdym4CAqhuLUAmEIrSHGhmfM8nsl1WL5EuNkKefNdyeoZjdWA1+w",
+	"uzkmwKXc8jE62JReoGahZIlr1CHcViaQqTu2RxZu2hKZvr1ff9wNh3GfaZhxnWZOc1FTtzDLi9DWVNgh",
+	"O+ZZBnpQ/dEDAN377y+v2EG5+4NahBEl8kljNbklMepJGILsK2YA2Li1l/I9imkEZs5zGLIfeSbSstRd",
+	"gpsJYZ2G8Rl3bw+aOgA4NJRIfKLgFyYUMw4eUdSR0grjdOEveJ4LaujHczFya21wbB/lwoGHSKrf8yFa",
+	"IwzRGoXLf+0MxzTk0o0gbaWcLM1HvvflpjnS/Jg+rI+tWm9uHl71yy9noOirkdeG1k9A36KG1B6fqdl2",
+	"o9+oWRhbC6giB+CGGc6q79EZEpsH3RHbzvI9LGNzkAW+TAHeejpyVzQy1fu9TNzC6FbA3ZZIfiNu4UcB",
+	"dy1MV9Nsje8w0yrSQ+PNaqqNx/SdNE9qI9qz1VvYbzVZqyN9baqVBtwP7nYem3Tn+VbnqrUsfUhT2F6/",
+	"2dVxq94YVYfPfldDvAd2HqxNGHpE7dx/qzGHb0qxe8uPXr+zSPgDy7GHGVulhreuw9vk5tWKs7sX9C2n",
+	"SfIdykKWoxRPd6nbFcbVatbsXA9odY4d4NhRw6O/kiW+awJ+Lbw9pGTunO7q5mjlueyaQuQTM9zLYPkO",
+	"tXdSUD/0e0rC9iG37fvxQ3+XYbVLecuBMR7edWidc3cbGxFCu01QScMtx8XoeoehceGywwQVR+4wqEXx",
+	"uyzXljq7jA0yZ/f16iz+IMQ8ZIa4Yrj74FIf3H1oRPfbcpIODWG30at62W7jV1SdBw5/AD93KINbjm68",
+	"zLYVma131PbD2qr0liOjOv2OYx+4dNe7c8vh0evuobUlqO7iG2EsGtkiBimtOWbnrZq3hCRrKybfSBus",
+	"hqU3dd2OShNyxC9cXreR6iCZmvnqr6WdvNZKa23EeLvu8az0KFi4t511ajvqcF6Jha/aXu6IqtpTTuC2",
+	"tugON1196Zh1DQMszn0060Wp27fN8duG2YYgtoeH13bNsHVY7Uo0426RKE8YkYHhfY+MxUiFsVwm0HDQ",
+	"ffPcERhuzztFYDw+LMFb0asYBPdPLm0LinHD+ibyrEI8AoUxqx5EptvOtBO5PjxGMAVjR5tiHcFY7N2n",
+	"ZOnh2RQq2O8ZnWyamOoAbD1n2y8YFujXThGD0PubulzawXH8Fyohx95/X/bBi5QJuNlItWdUGhJM8HwO",
+	"N3s91U30LOfcJnMfhvgwjHfFIZ50xx+WguLLrw93j0Y86YxCHLKzKaUqQtpnRSgPNBezORhbdVCmIVVT",
+	"RyQff8l6P9KfDvtfHfa//Kb/4vDn+BYRtN6gtglfUx+lpGFaUH6cBixVgCK4yq5WugpAPdCAxxSGEsIh",
+	"Lml8tleV87Qa5FqtTiVsQiacr21TnT/4IDGjz1BKIeMpzynmWcIdFlhohGpQxp+D5Rx4Oi2yPuUlhr9k",
+	"HeTZGf550hn2WZLNV18ebhcE2s4FeNjNuyFAM9y64dqiNPyloajMdin/Gok6dB/26VuugVme56RfrY8B",
+	"W3ORlkHti0036g0ssbGGYcYBx9/o21+w8fXf+NBGN7tZLiaKKhPgQr4hnlsiFNCcAOO1b5kp8qpuyH2q",
+	"rFLZtdwzAOyvL17gWZYLlsIUW1grafaHzAc6VU1Wr3sXGP5y3euz6x7aJOifx1Zn9K+jzP/p9TfXveE1",
+	"hTdSBJwwFJ+Z4AZ5ZpTbZaIWE39lGZ8TQPP9mw2RE/hfuNq/XfEJTrsDQFvSGqEblddUDeT0HpIni2Xj",
+	"7ngLjJdcSidHpCpMFklP53rWDIv8e6S+As3E9awoO3ZsT1XcjLRSzaDG+DEK2ayFJuycuaEs1+JWZDCD",
+	"DrHDzajwScbrpwwF8d3XbipZZHh7BBm/milJZ49EKiCgQ1K7mUOWlSB3d0ERr0ee3MUqASh943i4eqzu",
+	"8Xpkxb6f0fuqaRFq+NI+wGadC+RtN3n9Fotn9zj77UMbYafyVmgl8eFRxiliJSpfQLgG+ho0KspfiTXc",
+	"LbywG4HdUYSEzo1s+KgQQl5nuhJh5TkizRbWvQdPy/N3PQbjVY3gXthRPGb1vFZAcW3r5xS0Hk3+9HU8",
+	"oOhPXw9AuuEpo0/ZpJhOOyrOU0ThtpOpwnZP9qEbe9+LKt1vN/RdUvVHpF5ZVrGuUW8TZVQssiHUelen",
+	"F2976+ethzX5z78/e/Om1++dvbvq9Xvf/XC+OZrJr72GiC9QFX3obYJqLGfnV/89mPDkpllUrB0TnZl4",
+	"JwdfKtBJxaxYUFuEdfG+/Z5Wd5vmcp/sGKSOs/Zpo2sgdpnzO1kH2FbFbiJX92qPHJ5lyj3tRtYuN9+C",
+	"R/5rxlluoEjVoDz93vnVf++3BWtVq6OqL3QLdCN1XJdxpIUyy23E0YOmfggMm2qnNuyA0pWV3GcPX+ZD",
+	"tDtPE68PkOdnNYMxnziBxJlxs63jh2iRvveXJbLOTtYX5osNv8RqX4Oy90mk0ndtP6UdtyhEGhfE2HBo",
+	"xG3cTkx1IBEbdTLzw3YwFXeyGrXz37EKU62kUGHolu2WSnkxypNYmw9jxQLjNo/Pf2AF2tNz0AlIy2cQ",
+	"7XK35hqtygf7Cp0BVnMeihNvo6P0ewtYdEU+VzvWoSiir0FIuy+Dojtu8Ki55bzCqW1E2upCSoc+OnZX",
+	"iepuxKZCPuzSOeGWO0l2pwUZQFukR0kH2HQ33qtqK8Uira+yucRuOe/PG8/8KH3RbccneBo33eoJ3RcW",
+	"ZBeRVBlh+AHznw9725pU/FE08CqqfRfd6fK0LKCqwff2dCcKGPTZIkqvFHp7LDZLx1pFLO4UURUU4n66",
+	"N80trYSfO1aIpvpuJRpKQUqTC8OuceB1r4tl3f4jtwAZwn3Yt6qVBE7mhbxpVlDC5J0yJWhLJqa4bcT/",
+	"4+wQE5UuqYEMTRmqyREApOfudih7RIz7KmlNLZvCrVb0bEodqNfhq5WywgqUVTnFfqh3Wi/+2MeqoCGc",
+	"K57b7QsMd1WGoxN6Thg+uiz0hhSJ9T2+ti3HQSUYQMdTpKZCYiz/NtpCVWchjOrSFTaaXUgNWv2zKQtG",
+	"1H5vZPturdtUu/WDHrjZFpxR56rvMwbzKlTnAmbblDrazj3zHbllyrIXM28rWFMkosNg/xMa6neZaEvn",
+	"Pc31hfGt86ZOSGoJj3Ln7zBn1GMaoNAPgN2Esoc4HnSJ6A31ipqEEZXUzapGuzpzM8tH9+v9H98pLX5V",
+	"Emvm4FqML1Qh7ZBRFId7X+LfDcNM2T6TMOONvzs8xC842sGGEhk/uh0nW6yfqjsZWb7I44s/JmChrKu0",
+	"ve17E1dUfW/L4k/NpXZnip2n3DqKYKUi1o5SS6QpyA05wBTtULmS/KCNrnD/Xce2X4sMzkEvBBa6Ng/b",
+	"/0yrIo/bp/Ann16p2V8aj/xd83gjpar+9PXX+7tVplJ3MuYOcXvFn9ABEvb7Q8d+t8n5pPTDvIIteT3J",
+	"wYae5/ShVaPW5ODWS6ztWESeFwbqGflUzjmHxPF+WprYd7TR1x3GWFstZqKv1z5oxFYdbmTK+uJRgDgV",
+	"5rX5idvkSQuBlVXa8NWMBRPj1Qsc44pb2GzeLLndz8fKsdlyi5CXzgAehMAjy4lhU8p4gMpFpduGjxyK",
+	"p7nj2FvQWqRgQl1+D4H9Os6/PNxkK41aDoPvP2LzqymwVMD/iYqa4aYDQZ/JSyLgbv9ctY+6fyrEKa6H",
+	"zlqALPg9JtuLX+FMvv22ewcY7Gt8iYC3326JkXaNqRdbBqBcWpU/ltCUTsDNs5lfzha+rwP2BFY5esVV",
+	"YdlM8wSmRcbMvLBOC/LJ5AsMo0LTkpAYB6B1kVtI2a1IQSGw4m6BXarpEQe7DT1jKb0q61veQqbyXWPz",
+	"rrBiGQ2tWodb5SR+rbwIa2WsR2r4B8PR2oKYzboBWGz0l07b62ChpLJKiqQM1mFkdK52yhOtDMW7ZWIK",
+	"oUUQanNI10P2gwGKk3jDjR3gyoOzEx+NVvig78vL02A38uYyYaiyGAW0rPR22sG95s4YLGs/r8VhV5B8",
+	"q2AClUq6Exp8a3UyqmCSPxZOymvFFDzmGMgUz0MtUUIolmydfsiO9ERYzXWoe+D1LEN9h6mIQlUyQAPj",
+	"KU02ZK9X2sqsq+zQj5VkwB2DHqDxhsimbHYPaajWFZoZ/6uvdXDQ+ssJzlsLmOqz1YIO0VLBDXPap2E7",
+	"qxDyX5fv35Wmsxi0sXckQml9mQqq2kPG6Db0mxWbY3AltPjeNc/U1O0SbKAZfz+VRuLOHm/WSW4qVF71",
+	"edu+zRv2dGt0eWs0eGvUwfUPMR0aw9HufIDjjr3gntd2WeL+Mvi5HuBR7GpmEWkalWeiw7j4E8+yQYLN",
+	"9hFk1Su8Bsxm4xCHXz8lZWnYUJyv2pEIfc5944R0+6pRSVmAdqe+G77bxoMvL38/ZdzYlXuVnYTG7RoM",
+	"2HC/NcFCr8Z4z8EdXkz++HSOKO206lfvbEZ7XJXXG1gaq9UNmGhlxmjsQ7x65IOyYkK4XrWPkBVUy45x",
+	"kujePYrdSYbX8mSl05DhC6yqvwj5UAdpqNG7T91lnNwK4eTX0sf/OhHg1kLNhUumwjOntl4DUmwP//af",
+	"hw4uPmlnf3gta9VCsQWBg9oyp1viTul04GRlSh4yH1BanlxIq/nAfUULmmvptADJqQgTXm/0c84L4/Dk",
+	"FBPaG0lot5c1qIv2J+p39FRwpIhwxaLwdBnMFQYtUzuDjiJaauQYJoH1tIhdiebcXddOc1/mignpOMFx",
+	"nHvMvmILYSy/AVJ78J5EjQJhNuHJjcl5AhURsEPfy5xEmIlBgO0ZkYG02bIBp2tZfYa0sU+gKl9mh8MX",
+	"UaoPQRnb9pP4SQsLZQeMhzH6emw1whVC0bew4EMbYXzArnTkjfPd9X1LQXaGPQDZ0flZr9+7BW1oO4fD",
+	"F8NDtPvlILG3Ye+r4eHwK1/yDA9yELJJDqgbDtl8kojR5y3oGbXYxy+JBOBeGHTpKwmmz4rcXT6sNWkk",
+	"H+VW8Hrf6D4xGZYjLaQVGUKu/PoEbq+Uygy77lGrcCFn1z3MWs2ExPZFaoI6Uxp6ZFNdTDSD+MQpJCaH",
+	"Q7JgpGj2s8k8rPLadwPylWq+VemSQhmrDilVku7BPwwZGenGjHhIAzRb2kU4EsEQexk7sPo6jX+/7g0G",
+	"N0KZG0paGAx8X7TBLC+uez/vPzzPgDYUJ6vqO8eflGqEOWu4zpeHhxH7NO6f8J3iO6k8mkd2u1rnh37v",
+	"a5oppnmUKx58ywNPUr3gD/3eN9uMw6IJkmd+FNYXXSy4e9j0fiC6LLeY8UImc48Et3m/ZxxWUW/ZS2oT",
+	"VxQG9CD0Y6mWASxirYUBRn25WGWCKgMeJrz8eeioqn8tN7IL251bruWu7HIMGuuOByiwBZd8Rs9J3+W3",
+	"1QaU2pmfhrZbl76/Xf9aYoPRARamhrSckc5Rzh/IEG2ZxyfnByE3Wcl9vH8mTpOG9FqivSLAciNnn1ct",
+	"wR7K3PGrIaZRbYP8Ifs+ZIL5nyRfgLmWez7fyN+mx0rdCDAejtc9almKhX+9R2VezkB/HV7LSwAWyj5T",
+	"T7RqJ8OZUrMMSsI+IE9HmS0Z/u479lO+lTv/t9yI5Kiw8/e3oL+zNj8N/SsJBtENo6HIfWx+yGeap2DK",
+	"Uf5Sfcvvfe0KoaQ5B33u6KT38qsv+71zlRe5OcoydQfpa6V/0JlBn95qSevezx+eSq4FWvnDirY22bmz",
+	"dEu4Is8UTwdVp7wBl+kgfOvEnjIRRecHHEbFRDVbOAlSTsF+FTnjOpmLW8fhcG+xTZ2dw4IVMgXNDuZq",
+	"AQckQqpOhebgujg8/CpxrID/gv61dO9B7WTcor4CyW0hH6BolJLzWv6OigbBqxSM5kimFx7G62TSosis",
+	"yLHDo9KLQbCVdekctX6Hnema1TdO+SD0I0wwQYDbRu2F5vTxEsKvVeZwil5jq1ie8QR86e+Art2w3nIQ",
+	"HA3+xge/Hg7+PBwNfv7tRf/Lb76JO7d/FfkI2ziubPFvFUGGZho+9rCQOWWyVOxT7noP+6yFVNMFl2IK",
+	"xuIVvV+3QkyEdJy4Sasvt+drMcdeJmsVuBp2H6bFvYjFo5bUQKQAaT8i7YhrSubAbqE8/dhyb0UEldis",
+	"EfkeN04gmf26ECyP6KWhf0sfTIKOF5d6pyGLVjLVavDS6i5oyMnmWw+G1u1DduR/xZufonCcOkPWMit4",
+	"li19B5G5ysp2y/dJVhhHvE796TOjmFQMG+xT6DsrhY1hCZdko8iA3wJ2hwhBDcaq3AQjwlRoY33t/9C4",
+	"sOzzLcqqE2StDA0JqSnrtQzlqQuDrkbsGDv3XJUC5e+4d2FlB8TUDCqn4la7gSV1iPTgupbBf5nzpZvF",
+	"uxWYVoVMB1aLnDnVUSYUQQyYXi5TcSvSgmd+mpjk/RYVwWYHyYergWttpqsrVU3wHqaM4JQdzQ8+Ju+V",
+	"jEDdMqMMUKfpFpu1mlMGZmsirmpL+Uz4ivS9fCCaqFNY6OoZ2PqjYuhSLIqM0gWJ6+p9e+OGxBUckbnq",
+	"wIn6bjRdAE+Pa6atGLSeCl3NlrWIrdbbq+w865fEe2qFbx4NXXdosiyXeSYrVr4ucKJtsBueTePkM5F+",
+	"3AL6UPJHq6fPLaKG8AELn4zA+okMssGYvgW+ymawcTSVQa/PhKHVNrNbI+dJ1q8VvorxGcXj3orQEKF8",
+	"LX8yGP9OpL4Eh7qrV/drornZ5jiu9WFlIdRaMPI7CFTqx9gvnVROc+Ohpp5bVlvyCmHogWz3aJyJ29AG",
+	"jxTTDLgB1K3q3YU2NBCMaTxlO8xnIs3Vhs8PlBtuok/kusStVHUTCU0c8dCimBlYIphR2Ye9U0j8BWyj",
+	"xuVzXo/xYppx3sWoAzppeYingOJfwDYCG7zmQcIirLSN8tHsHx4Hbllr85nIfLUz+aO0Qw8Fd7KPS+pv",
+	"QwnJBnbCrVhGvFeSxmyDsUbP9jVy1Nfpq9ZBNz7KzJq/vwy3Jzt5lfdRKzZ2LWMlxChEDMtc5RrmIOnd",
+	"vFqrrM8MwLV0m4nXG2PcVmb0mbDDqQZIwdxYlQ+Vnh3cu/+Xa2XVwf2LF/SPPONCHtBkKUyHc5LnPpxr",
+	"rqTSph744WMZw3ndi9oHkyceFJg2YLwJjbCg0qjHwxfAeyZ2WOm1/0BuQIQitXxK2gLd8XVbEtLlFoRf",
+	"b9jSJaqu+A1UKXzPpTGuZCJ+8Dhae+NgWOpBTpmz1UqbrZsrF0u1AYp1/agIPeY5eiQ5qxAUgtA2oFNl",
+	"WbcQoxxLduvzELOl094OlOPtkBvp/mZrOl5Nkja1xYadr1HF0auBjSRH39RYskzNMAXSiuTGsD2prE/A",
+	"JRNnjYLYBOb8VjiS5kt2y/XyFbMFWul8D/fAwCFmaqLsvHYUcjeGnEvM0PS2S+/q7tejVUPID3p6GibN",
+	"vXIOVIWrBfYp7gOtSBQsFCK7gygch9gwMmAMBhpy4Ja9Y4MBBV0dMvIgkEJOPoRxTEJehlTHZ2K/WvLt",
+	"Q6WjJ69PxIZEm6l0BUIPt04z3kGbC0G/HcLRB1w+E17a8ZyPMnJQEOEnc2u5s5FRYx0WfIxwt0yrKskG",
+	"dyNz/4/CkJft8GSUWqWLyFjuFDSr8hxTKxJgexSQ0L+W3idbeWP6TnBgWpZ3x/VrOp8vBmzEr0LO9v2r",
+	"uVxIlKWmGNzzxGbLa4nLNTxTGngqpLvL3evZvccxijqsMaYCyoXOxrieFzucTcDYAUynSttrWXWjKssm",
+	"h1mDl8LNjIqae9jwGTBKT/jWyUaHhNDCUi94hqGmVl3LcVAnx778PpdLhDRbqoKlCkOgJbgdH4VW/04l",
+	"8bogxme4r9EvOQHmC+oMr9HPgIEzTVxR53ddyLLeLbqtXtbib+q48Rjok3u9j8qxbGNsGEWJktmSsO+v",
+	"PpApBcaWKTgUs34trebSBPX2JRNTxtG1o6vwH7dvdDa5DXKduWuxYjpmRAoMsC1tyGtbcCEdPeDaFAic",
+	"gKdV9yep5ODL+3vv78q1yvnMXcjDa3muYYqqtQPPLXbJzzkmco6r6IJ/HVMq0IGH0Rj9eT66ldgmg+Bd",
+	"HFgtZjNwetK1JBwQJwmJ+PR5mVX4fuyyClA+Lvn3CQMFKCxoVA9va8V3XL0e/IfPvWnGLrEFz9n/+V//",
+	"m2GMt4EFl1YkWEL3/Ojq+Du2Gj0Xr3jrvxp1BErWdkA+bjb+7ZqCGK97L+txkj9/GG+5IRwd3Y1H6zbb",
+	"WDihgZpJ/J20WmV/zPawksgB1RE5AJsM94cMFS6qNh0CqlcJiELKTT/4ZzGbtUwQaUtjUYniRthSg1Ob",
+	"TBotiLUmjuS0HuZj0AoZdp+4GyspsOBGNcUQI0PoGFVmwNq4o/3h5iCUR4eIPH/8BsaMuyEjLztXoWm5",
+	"Hv5qbCw6BdO+wCB4x43YGQw29UmJXjh7UWCGzIuzEH/lKzFguWzf3qgKHPSD3f8zB7W26ajBG8jc+D10",
+	"t1OoHRv7ML8DWgUd++N9SjcdO7jlo4olxnQroIgkdPt4hnBYO+dlfI1x9x1+cKd5nsNKG/eN6PJVntzl",
+	"HmHjizel98df7+Av90oKr72+S1tQn2UgZ2SfTzjxmmVfHn79H1Rlr1+xnkNggsG+FEaBMsIjgHYxyaCj",
+	"KnITlmuUtirBKkAQvQfVWMrI1iInZ2WLJkuq2HN3ZFkwx2cSYWV0uCeO3Jia/Um5qBqakJeXryp1s6QC",
+	"N3MGbd/V8DGK/deHf948zm0wE8nKc+BpnOVt7SE8HzrhBKhwuf9FWV7GdKcsn3MEcf3lcYT6DD3b01Kh",
+	"wae8z85taqJ5VpgV2IdCVge127eMso+Ec/tb9bkMnJH2OL8zRfvVQ7LlKrJ+8F7W8FZqAPmjUeyjY5c7",
+	"juNIY2oOEg3cwqjsgoBkUsQihvDDsjbNc4UNNVfZiVRerCulQ+f8hMwLdFLGMeerAn/ASwpObG6BlxP8",
+	"8LnxQqvU25k92C9dooSOmD6Os77ePO6dsq9VIdMndGjjzhnvxlvQg9eg7DWpu582trBQ2j8BohAfJY7U",
+	"nXQas+Ou0a8CCwLNwMYKUNlCS8M4+9vZOSvfArU3RHgalCViqqJmgTSGqzEkfv0Tof8mcozI13wBFrTB",
+	"5gdd7f5KzkEd1KpS13eqQTgUvu7cuF8KQHFAb7pQ3q1JA/26EWNTubifd7qcPVwf5fRyUA9nLCshIWHV",
+	"AfxHpEuPrLoIca8BIrTwoI3Tq7HpFgQb3r57luvaA3gRnMOoh7q59tfS9bVcQ9jsb8amTE2noA0zYibF",
+	"VCQcU8+n3NDzjxb0+uu1TKH+J/dvrukF+KvIvcGFJ3MBt9gsFWx7FmSjeGRWjascjP4obNX/bbX1V3lc",
+	"jGAYsu/EbA6a/qvsIMzMgmdZ3RwxKSyz/AZYpuQM9PBaDggTxr5k/+OwTVOwF33mE/8dYiFle//z1eHh",
+	"4JvDQ/b22wOz7wb6wgbNgV/12YRnXCZOlXIjDxADbO9/XnxTG0uIaw79937AZxjyzeHgPxqDVrb5oo9/",
+	"LUd8eTj4uhzRgZEatYxwml4dHVVJ8/Cvqu6SB1WvX/uNtoz/MLGC9LtKRc+9jxKLVy271v8lorFlzivF",
+	"IxpcQu0GLxaboqFsJb6tTEBJ4MG60tX8U7lhd9MJq3bqqwSFWl6tV/sfkGz+ArbRbT40D1rBXkk2mTAW",
+	"9XTTSTdV0/uHXSZ/TEqpTh0hler5llFtkj8grWC2LmKeEglXaQPbpHc930Jj72cMjX2KpxuGolbmjj8g",
+	"nvAE2MoZvVzrmFkDT8tHd5SXL4Cn/sm9HSvjYkEldPN/KtysEgt2ULWseZQugaI/msf1ByMWzBpruOtK",
+	"4jBAgn5UK5neyd2rleufLwmpo0T+g6tr1CrC+5ShPyAiL8GuMnq92v0BVtM3c5GXGCYPaHcQFtY5MTVH",
+	"qc8dV7qKL6ELwYfqa1goLwMol23YUXUiqAdPFj1SaiQdLvoUjB1t6BLgvvFdtksJ5qumeYV2m/4A/d5D",
+	"vfnek19tdedyDASFJ6vEgFgqizD80UVdpDjD1OtrdXYIps21RWY4Gl4oBg37JVM9GWFNZdtcSV9p01cX",
+	"c5B188lYY1fST+uNFGqVcqoYCbUdHzxRZMs6fnggYf9N5BVZ1xD4T0PkvF7wqEWiK/TujSsbCH5X02gX",
+	"X1zLzYyx2UTasIhey5ZJtLvckbdxPhlzdUZRXc2hbXopr5At4oY+GtPGo3y6irW+2z7Qx3en8nvDYkZY",
+	"3teR02CA3wyqcfvD3WooBzw8i7g48jD8JxcZbXLtEBt37YJErZdArb/Pc70BIi2EtsftA4un4rGjTa9/",
+	"kOKXAmJ9byquvPPg2CperV2v3SZz9tQ1/j4SsdFh6kZqX6hJzmqaGELr4LcA8g++jDlQkZI2vam8IreW",
+	"kQIND97S4O0OJR7X2R42mxq+jhXWJ0RRsPMfHFGX2MAnxJXHrH1tJB1QjlynKYl6Nr82p/TZ74irtlnI",
+	"wr2l3UbtQZv8AZf4tPWtcyI5p1ULGzWtvYV9DiH27uQpnvq33l8Hl5enA18+aHAVbUXxFlLBfbX1KfaI",
+	"wdYbPiVxry3E9hueu+ClWxF1Eafchz8imVKvoDaUfckTErslxbrH/PogIyzKs43B86SmfPEV4+fv6Pd+",
+	"XzUkCN0ZOxszNnqn/Onrr7u2id0MO7a1tp0jMd82N/4jzbEPtGaUJaH+6NcomqXczRniIatQrUzNzEEF",
+	"2LiLTs18D/0OOdwiCN9daB3lBkHjSbyqbxvt6R5fZqqyTN3FIw8aHa1rPRfbaMYEjzJtT0wZ7Z0Jw/zW",
+	"1jBm962yyzq1s8dXqz4Y5dSmpvfRbrQ3arblVeYI65O+vWI3g9s05VBeXp4Sg+QZX95pSnujopFblFct",
+	"m3+dl6NZ4oQt+kKnGsy81qsVUXNvGZ9xIQ29xEMWgi4klnCWSrJMJTybK2Nf/vnLL7+k7FScdc4NdpAz",
+	"KKq/yPkMvuizL/y8X1BCzxd+yi/KTjGhSoPvquhjMXDGanNYKtcWWlaN3AJ5xQwnHgTVuY/pdniOl93K",
+	"Wh8p6yGyDwfQeLJKCdxPsRxqdQQsO3CJOyeKiBCnZxCSScgd3Q9932DLLfRs9X3KFT4SHTR20EUBVTVj",
+	"7b/5JMrgJmqxcFLCLGUy10qqwoSqtwHBJud3ciOGL/GrZ0UxLvFxcey30IVk/PkjFz9ZxS1fg9zf/D/w",
+	"bX4jmhWEooj+XmApms3v8mrmtSphqckXhUgf81h4EELdaT7JSqXvv/9Dxhc4USJm7qVpFQtqazfFUWGA",
+	"jTR3QZ/901Adnecz3T1dgBLWl+Ds/Oq/BxNqpbCZ+Izltug2RQaRT1/93rT3zPcYHSp2hflf/pBRyh4B",
+	"zITjdaM+FVvoNPjVP43UweN8ZP2JttClP327xNYdZH77w1rcqpuPEZ2tpUNV2E2GuAp4qrBrLXIfSR49",
+	"wrJUns0N29LGFKCrCpsX1CM/E1NIlkkGnx0oz+dAqVG1KmzLYKYhwXKhs4PKCRuXrpQ5fBG+f9ZE7XKV",
+	"zbVl2+mefuDHS9H+SLUtysTuXMOtwDcjI+RCym5FCqrmR6hh3SeXdUqxkH1WR/xa71nptPKr63qTfapC",
+	"5pv4N6q5FqFWt/cKlMO7HFko9OJuLD749Wjwt8PBnwc//9u/PEg0IsAOFvnXj04nqCjSxzw2BFz56+C1",
+	"kNikfnAUa/QsFmAsX+ROyFFzfrTsVlPT4CH7S8E1lxYoXm4C7OL18VdfffXn4XoPSGMrlxSP8qCd+FiW",
+	"h27EbeXLwy/XMTYWlxNZxgQWi5xpMKbPcuxnwaxeku2Tajw2wX0BVi8HR1P3w2op3GI2o1xRbKuBHSCF",
+	"ZFXD/NB9US+JCapDlLFsLyKxbB/+wAmnVIrXIC9SA/UtJEom6PbozB+88IxtHtufoswHWHehhNUo03Ml",
+	"yH6FX0PjSl3u8skS7HiW1adtgm2lA2ok9O65L9/mImvv3hfrWNQLgT9ghSiEQFnFvZJrQ/aeSs7WZV0O",
+	"mp2dYAtErG0+E8Zil0YsWe0kyHAVyypfh2SVPz+Oa2s8XL3yoXAft2C4VXnz+iFwm4RnYNWvoNWB72e/",
+	"tk0IvRXcRD++paKFbgYs/KGYm6XvkMt1muHzZcq+u7o6Z1bz6VQkTEkm7JAd8ywLtUKOzs+oRLYwbso7",
+	"d1vd8RtgwrIJJLwwwH6Q4kbzqaVfQ+fxxDd2ugHfpGQZihiEnJMf30ZLfdAxL93Jr9TfQKveNmGN+P3A",
+	"qoE7JfOwSp8EOWcpLHJl6drwMyNcIUC1BqLhKuJArsfbBRirNBhfNpOmLo9SdiKo1ug7+avuUIVAaDY3",
+	"Q1oDajQizYAQSmNLNefHt0wqX0oEK2cbr9vMIUsZd2iLetnl43ED8plQQxNvwoyFDBZO99lYaKfekKkc",
+	"1Sy1N2Th468Pv2ZiWvuOqnZXRVKjrWf+Avaq3M8zWr/KRS4tt1Gz+1X8gA/V3Va7W3XPX1aubIkzrn0T",
+	"DMp3JYR0IgJvtYRbmFElXrh3wBKOMAzWj6jXUWETlS6xmiwFdaevwkuuPoUGy2mc0CUlGOrQb3ZCPfN9",
+	"/VFxmmJOUrWMLXniJcPu/izJgGsTijXVThnrXuSg1ySiZ+jQS4EX5TL1Qpu/nw33wVT8sTKmYyU71zFC",
+	"EeubA3YD5Qc6/PLwRZMO7zgRYs2OUtHkKx9e5cYdunHCugFPRaqvSOy6/ytltL9+dhOR54X9eNT9yVPz",
+	"rtlCz7MhAx83nOhy3QXTuPRr6R9xZexM/gO7Y3BJlncmQiZotQA5AnyXDvrIMG6MmEmgNqdSWSW9Cixk",
+	"ooFjS6bQ0z2UHucyZVMu3ShVoCbnmE7lIIOzIVFSAvUFjzPHJBOmEv/kv3gmJx6thUt8JCdedU55C5nK",
+	"o0SKG8Sw1Nz6LMictv6YC6DZ9I7m24JI2uS34mhrW5xBUvPaW2BNn1M1M5HwkJ3yZM6mmi8oEBfLPyi9",
+	"YGORvmS/Gfjlw/W1TLnlL9lv4AE2cAB3f7++lmMn6xsEWbYoS8CYQUnGBEPQBk0/iVbGtASAT417xTh7",
+	"w40dIA4GZyf0BsVuPf4OqlG045pbnokUH4gaTLEIz87AYSda5bQpCuqhjpUznpug0I1FOqYeGdgRx7+h",
+	"QdxCSr8JQ1UU7JxL9oLxOfA0hBxnbq8GQOKn/eBruwPtGFtg3mzZp3xSTKegh+w4E/iV761pNU9uIrM5",
+	"bk7BQmJxv0P2GqOvawxNyehStUCGJqdq2Urv9KhyyMCwfgOABaYDPThxdCccrOY8xxB/bKUHErRI2Lgp",
+	"JMbU7zOEe/uTg1eCJ0sc+z22zaCmhGzPfb7E9j2OUqjJHGepSooFSDdqbJc5jKkBFc34hWFj6rfh6EXp",
+	"RVlwomoG42/ff8VtneDHxO99ZiCDxO+HJo92p0NiaR5vY1W3C0duoZMFqiot4ew7TSnNDMiUHVKOeBQ1",
+	"oaXbtvzUZ0Y1meKWZwXFwy/AsYjWkGAdAVqKuzUENqwKLiRyBlQ+pAYNfbw8ja0k9JstpNsfLoWjfQLG",
+	"DbtEh+Dg0hGJJ0s3+v8PAAD//1Hf9WWfpwEA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/server/lib/sysmon/kmsg.go
+++ b/server/lib/sysmon/kmsg.go
@@ -1,0 +1,129 @@
+package sysmon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kernel/kernel-images/server/lib/events"
+	oapi "github.com/kernel/kernel-images/server/lib/oapi"
+)
+
+// oomKillRe matches the canonical kernel OOM-killer line. Example:
+//
+//	Out of memory: Killed process 1234 (chromium) total-vm:5234572kB, anon-rss:4823900kB, file-rss:0kB, shmem-rss:0kB, UID:0 pgtables:8000kB oom_score_adj:0
+//
+// The comm is bounded to 15 chars by the kernel (TASK_COMM_LEN-1) but may
+// contain parens internally for a few cases (e.g. `(sd-pam)`); we deliberately
+// match a lazy non-paren-aware group since the more-permissive form has bitten
+// other parsers — a comm with `)` would be exceptional and the line still
+// parses for everything except the comm field.
+var oomKillRe = regexp.MustCompile(
+	`Out of memory: Killed process (\d+) \(([^)]+)\) ` +
+		`total-vm:(\d+)kB, anon-rss:(\d+)kB, file-rss:(\d+)kB, shmem-rss:(\d+)kB` +
+		`.*?oom_score_adj:(-?\d+)`,
+)
+
+// parseKmsgLine strips the kmsg envelope `<priority,seq,timestamp,flags>;`
+// and returns the message portion. Returns the original line if no envelope
+// is found (which can happen on truncated reads, though that's rare).
+func parseKmsgLine(line string) string {
+	if i := strings.IndexByte(line, ';'); i >= 0 {
+		return line[i+1:]
+	}
+	return line
+}
+
+// parseOomKill extracts OOM-kill data from a kmsg message body. Returns nil if
+// the line is not an OOM-kill record.
+func parseOomKill(msg string) *oapi.BrowserSystemOomKillEventData {
+	m := oomKillRe.FindStringSubmatch(msg)
+	if m == nil {
+		return nil
+	}
+	pid, _ := strconv.Atoi(m[1])
+	totalVM, _ := strconv.Atoi(m[3])
+	anonRSS, _ := strconv.Atoi(m[4])
+	fileRSS, _ := strconv.Atoi(m[5])
+	shmemRSS, _ := strconv.Atoi(m[6])
+	scoreAdj, _ := strconv.Atoi(m[7])
+	rss := anonRSS + fileRSS + shmemRSS
+	return &oapi.BrowserSystemOomKillEventData{
+		ProcessName:  m[2],
+		Pid:          pid,
+		TotalVmKb:    &totalVM,
+		RssKb:        rss,
+		OomScoreAdj:  &scoreAdj,
+	}
+}
+
+func (m *Monitor) runKmsg(ctx context.Context) {
+	f, err := os.OpenFile(m.kmsgPath, os.O_RDONLY, 0)
+	if err != nil {
+		m.logger.Warn("sysmon: failed to open kmsg, OOM events disabled", "err", err, "path", m.kmsgPath)
+		return
+	}
+
+	// Closing f unblocks the read loop on shutdown.
+	go func() {
+		<-ctx.Done()
+		f.Close()
+	}()
+
+	m.logger.Info("sysmon: kmsg reader started", "path", m.kmsgPath)
+
+	// Each /dev/kmsg read() returns at most one record. The kernel guarantees
+	// EINVAL if the buffer is too small, so use a generous fixed buffer.
+	buf := make([]byte, 8192)
+	for {
+		n, err := f.Read(buf)
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
+				return
+			}
+			// EPIPE can occur if a process between us and the ring buffer
+			// dies; we keep going.
+			m.logger.Warn("sysmon: kmsg read error", "err", err)
+			continue
+		}
+		line := string(buf[:n])
+		msg := parseKmsgLine(line)
+		data := parseOomKill(msg)
+		if data == nil {
+			continue
+		}
+		m.publishOomKill(*data)
+	}
+}
+
+func (m *Monitor) publishOomKill(data oapi.BrowserSystemOomKillEventData) {
+	payload, err := json.Marshal(data)
+	if err != nil {
+		m.logger.Warn("sysmon: marshal oom kill payload", "err", err)
+		return
+	}
+	ev := events.Event{
+		Ts:       time.Now().UnixMicro(),
+		Type:     string(oapi.SystemOomKill),
+		Category: events.System,
+		Source: oapi.BrowserEventSource{
+			Kind:  oapi.LocalProcess,
+			Event: stringPtr("linux.oom_kill"),
+		},
+		Data: json.RawMessage(payload),
+	}
+	m.es.Publish(events.Envelope{Event: ev})
+	m.logger.Info("sysmon: oom kill",
+		"process", data.ProcessName,
+		"pid", data.Pid,
+		"rss_kb", data.RssKb,
+	)
+}
+
+func stringPtr(s string) *string { return &s }

--- a/server/lib/sysmon/kmsg_test.go
+++ b/server/lib/sysmon/kmsg_test.go
@@ -1,0 +1,100 @@
+package sysmon
+
+import (
+	"testing"
+)
+
+func TestParseKmsgLine(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"standard envelope",
+			"<4,123,456789,->;Out of memory: Killed process 1 (init) total-vm:1kB",
+			"Out of memory: Killed process 1 (init) total-vm:1kB",
+		},
+		{
+			"no envelope",
+			"naked message",
+			"naked message",
+		},
+		{
+			"empty after semicolon",
+			"<3,1,2,->;",
+			"",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseKmsgLine(tc.in); got != tc.want {
+				t.Fatalf("parseKmsgLine = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseOomKill(t *testing.T) {
+	t.Run("canonical line", func(t *testing.T) {
+		msg := "Out of memory: Killed process 1234 (chromium) total-vm:5234572kB, anon-rss:4823900kB, file-rss:100kB, shmem-rss:200kB, UID:0 pgtables:8000kB oom_score_adj:0"
+		data := parseOomKill(msg)
+		if data == nil {
+			t.Fatal("expected match")
+		}
+		if data.Pid != 1234 {
+			t.Errorf("Pid = %d, want 1234", data.Pid)
+		}
+		if data.ProcessName != "chromium" {
+			t.Errorf("ProcessName = %q, want chromium", data.ProcessName)
+		}
+		if data.TotalVmKb == nil || *data.TotalVmKb != 5234572 {
+			t.Errorf("TotalVmKb = %v, want 5234572", data.TotalVmKb)
+		}
+		// rss_kb = anon + file + shmem = 4823900 + 100 + 200
+		if data.RssKb != 4824200 {
+			t.Errorf("RssKb = %d, want 4824200", data.RssKb)
+		}
+		if data.OomScoreAdj == nil || *data.OomScoreAdj != 0 {
+			t.Errorf("OomScoreAdj = %v, want 0", data.OomScoreAdj)
+		}
+	})
+
+	t.Run("negative oom_score_adj", func(t *testing.T) {
+		msg := "Out of memory: Killed process 999 (sshd) total-vm:10kB, anon-rss:1kB, file-rss:2kB, shmem-rss:0kB, UID:0 pgtables:1kB oom_score_adj:-1000"
+		data := parseOomKill(msg)
+		if data == nil {
+			t.Fatal("expected match")
+		}
+		if data.OomScoreAdj == nil || *data.OomScoreAdj != -1000 {
+			t.Errorf("OomScoreAdj = %v, want -1000", data.OomScoreAdj)
+		}
+	})
+
+	t.Run("comm with internal space", func(t *testing.T) {
+		// Kernel preserves spaces in comm; bounded by TASK_COMM_LEN.
+		msg := "Out of memory: Killed process 42 (kworker u4:1) total-vm:0kB, anon-rss:0kB, file-rss:0kB, shmem-rss:0kB, UID:0 pgtables:0kB oom_score_adj:0"
+		data := parseOomKill(msg)
+		if data == nil {
+			t.Fatal("expected match")
+		}
+		if data.ProcessName != "kworker u4:1" {
+			t.Errorf("ProcessName = %q, want %q", data.ProcessName, "kworker u4:1")
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		if got := parseOomKill("just some other kernel log line"); got != nil {
+			t.Fatalf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("preamble (oom dump task list)", func(t *testing.T) {
+		// We must NOT match the per-process audit lines the kernel emits
+		// before the canonical "Killed process" decision.
+		msg := "[1234]   0  1234   1308611  1205975  9678848        0             0 chromium"
+		if got := parseOomKill(msg); got != nil {
+			t.Fatalf("expected nil for preamble line, got %+v", got)
+		}
+	})
+}

--- a/server/lib/sysmon/sysmon.go
+++ b/server/lib/sysmon/sysmon.go
@@ -1,0 +1,55 @@
+// Package sysmon emits VM-internal failure telemetry — OOM kills surfaced
+// through /dev/kmsg, and (via the supervisord-shim binary POSTing to the
+// telemetry HTTP endpoint) supervised-service crashes.
+//
+// The package only owns the in-process kmsg reader; service crashes are
+// delivered as ordinary caller-published events via POST /telemetry/events
+// from the shim. Both paths terminate in the same EventStream.
+package sysmon
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/kernel/kernel-images/server/lib/events"
+)
+
+// DefaultKmsgPath is the standard kernel log device.
+const DefaultKmsgPath = "/dev/kmsg"
+
+// Monitor runs the in-process sysmon goroutines and publishes events directly
+// to the EventStream. System-category events are always captured regardless
+// of any active TelemetrySession config, so we deliberately bypass
+// TelemetrySession here.
+type Monitor struct {
+	es        *events.EventStream
+	logger    *slog.Logger
+	kmsgPath  string
+}
+
+// Option configures a Monitor.
+type Option func(*Monitor)
+
+// WithKmsgPath overrides the default /dev/kmsg path. Intended for tests.
+func WithKmsgPath(path string) Option {
+	return func(m *Monitor) { m.kmsgPath = path }
+}
+
+// New constructs a Monitor. The Monitor does nothing until Start is called.
+func New(es *events.EventStream, logger *slog.Logger, opts ...Option) *Monitor {
+	m := &Monitor{
+		es:       es,
+		logger:   logger,
+		kmsgPath: DefaultKmsgPath,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// Start launches background goroutines. It returns immediately; goroutines
+// shut down when ctx is cancelled.
+func (m *Monitor) Start(ctx context.Context) {
+	go m.runKmsg(ctx)
+}

--- a/server/lib/sysmon/sysmon_test.go
+++ b/server/lib/sysmon/sysmon_test.go
@@ -1,0 +1,93 @@
+package sysmon
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/kernel/kernel-images/server/lib/events"
+	oapi "github.com/kernel/kernel-images/server/lib/oapi"
+)
+
+// TestKmsgRoundTrip pipes a synthetic OOM line through a FIFO and verifies an
+// event lands in the EventStream with the right schema. Linux only — /dev/kmsg
+// semantics don't apply here, but we open a regular FIFO so the goroutine just
+// reads bytes; the parser is what we exercise.
+func TestKmsgRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "kmsg")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+
+	es, err := events.NewEventStream(events.EventStreamConfig{RingCapacity: 16})
+	if err != nil {
+		t.Fatalf("event stream: %v", err)
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mon := New(es, logger, WithKmsgPath(fifo))
+	mon.Start(ctx)
+
+	// Open writer side after the goroutine has had time to open the reader.
+	// Opening the FIFO for write blocks until a reader is present, which
+	// gives us synchronization for free.
+	w, err := os.OpenFile(fifo, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open writer: %v", err)
+	}
+	defer w.Close()
+
+	line := "<4,123,456789,->;Out of memory: Killed process 4242 (renderer) total-vm:200kB, anon-rss:150kB, file-rss:10kB, shmem-rss:5kB, UID:1000 pgtables:1kB oom_score_adj:300\n"
+	if _, err := w.Write([]byte(line)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Poll the stream until the event arrives or we time out.
+	reader := es.NewReader(0)
+	readCtx, readCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer readCancel()
+	res, err := reader.Read(readCtx)
+	if err != nil {
+		t.Fatalf("read envelope: %v", err)
+	}
+	ev := res.Envelope.Event
+	if ev.Type != string(oapi.SystemOomKill) {
+		t.Fatalf("Type = %q, want %q", ev.Type, oapi.SystemOomKill)
+	}
+	if ev.Category != events.System {
+		t.Errorf("Category = %q, want system", ev.Category)
+	}
+	if ev.Source.Kind != oapi.LocalProcess {
+		t.Errorf("Source.Kind = %q", ev.Source.Kind)
+	}
+	if ev.Source.Event == nil || *ev.Source.Event != "linux.oom_kill" {
+		t.Errorf("Source.Event = %v", ev.Source.Event)
+	}
+
+	var data oapi.BrowserSystemOomKillEventData
+	if err := json.Unmarshal(ev.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if data.Pid != 4242 {
+		t.Errorf("Pid = %d", data.Pid)
+	}
+	if data.ProcessName != "renderer" {
+		t.Errorf("ProcessName = %q", data.ProcessName)
+	}
+	if data.RssKb != 165 { // 150+10+5
+		t.Errorf("RssKb = %d, want 165", data.RssKb)
+	}
+	if data.OomScoreAdj == nil || *data.OomScoreAdj != 300 {
+		t.Errorf("OomScoreAdj = %v", data.OomScoreAdj)
+	}
+}

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -2688,6 +2688,99 @@ components:
         truncated:
           type: boolean
           description: True if the data field was truncated due to size limits.
+    BrowserSystemOomKillEventData:
+      type: object
+      description: Per-kill payload for `system_oom_kill` events.
+      additionalProperties: false
+      required: [process_name, pid, rss_kb]
+      properties:
+        process_name:
+          type: string
+          description: Comm of the killed process as reported by the kernel (max 15 chars, truncated by the kernel).
+        pid:
+          type: integer
+          description: PID of the killed process.
+        total_vm_kb:
+          type: integer
+          description: Total virtual memory of the killed process in KiB.
+        rss_kb:
+          type: integer
+          description: Resident set size of the killed process in KiB (sum of anon-rss, file-rss, and shmem-rss).
+        oom_score_adj:
+          type: integer
+          description: oom_score_adj of the killed process at the time of kill.
+    BrowserSystemOomKillEvent:
+      type: object
+      description: >
+        The Linux kernel OOM-killer terminated a process inside the VM. Sourced from
+        `/dev/kmsg`. Fires for any process killed by the kernel due to memory
+        exhaustion, including Chrome renderer subprocesses that are not supervised.
+      required: [ts, type, source]
+      properties:
+        ts:
+          type: integer
+          format: int64
+          description: Event timestamp in Unix microseconds.
+        type:
+          type: string
+          const: system_oom_kill
+        source:
+          $ref: "#/components/schemas/BrowserEventSource"
+        data:
+          $ref: "#/components/schemas/BrowserSystemOomKillEventData"
+        truncated:
+          type: boolean
+          description: True if the data field was truncated due to size limits.
+    BrowserServiceCrashedEventData:
+      type: object
+      description: >
+        Per-crash payload for `service_crashed` events. Fields are derived
+        from the supervisord eventlistener wire protocol, which exposes the
+        process name, the state the process exited from, and (for EXITED but
+        not FATAL transitions) the PID. Exit code and signal are not surfaced
+        by supervisord on this channel.
+      additionalProperties: false
+      required: [service_name, from_state]
+      properties:
+        service_name:
+          type: string
+          description: Supervisord program name (e.g. `chromium`, `mutter`, `kernel-images-api`).
+        pid:
+          type: integer
+          description: PID of the crashed process. Absent for PROCESS_STATE_FATAL transitions, which fire after all start attempts are exhausted.
+        from_state:
+          type: string
+          description: >
+            Supervisord state the process was in before the unexpected exit.
+            `RUNNING` means a healthy process died; `STARTING` means it died
+            during startup; `BACKOFF` is paired with FATAL and means
+            supervisord gave up restarting it.
+          enum:
+            - RUNNING
+            - STARTING
+            - BACKOFF
+    BrowserServiceCrashedEvent:
+      type: object
+      description: >
+        A supervisord-managed service exited unexpectedly. Only fires when supervisord
+        reports the exit as unexpected (`expected=0`); intentional stops via
+        `supervisorctl stop` do not produce this event.
+      required: [ts, type, source]
+      properties:
+        ts:
+          type: integer
+          format: int64
+          description: Event timestamp in Unix microseconds.
+        type:
+          type: string
+          const: service_crashed
+        source:
+          $ref: "#/components/schemas/BrowserEventSource"
+        data:
+          $ref: "#/components/schemas/BrowserServiceCrashedEventData"
+        truncated:
+          type: boolean
+          description: True if the data field was truncated due to size limits.
     KnownBrowserTelemetryEvent:
       description: >
         Discriminated union of browser telemetry events emitted by the Kernel
@@ -2726,6 +2819,8 @@ components:
         - $ref: "#/components/schemas/BrowserLiveViewConnectEvent"
         - $ref: "#/components/schemas/BrowserLiveViewDisconnectEvent"
         - $ref: "#/components/schemas/BrowserCaptchaSolveResultEvent"
+        - $ref: "#/components/schemas/BrowserSystemOomKillEvent"
+        - $ref: "#/components/schemas/BrowserServiceCrashedEvent"
       discriminator:
         propertyName: type
         mapping:
@@ -2757,6 +2852,8 @@ components:
           live_view_connect: "#/components/schemas/BrowserLiveViewConnectEvent"
           live_view_disconnect: "#/components/schemas/BrowserLiveViewDisconnectEvent"
           captcha_solve_result: "#/components/schemas/BrowserCaptchaSolveResultEvent"
+          system_oom_kill: "#/components/schemas/BrowserSystemOomKillEvent"
+          service_crashed: "#/components/schemas/BrowserServiceCrashedEvent"
     TelemetryState:
       type: object
       description: Current telemetry configuration.


### PR DESCRIPTION
## Summary

Adds two new telemetry event types so customers see when the VM kills processes or supervised services crash:

- **`system_oom_kill`** — fires whenever the Linux OOM-killer terminates a process inside the VM. Sourced from `/dev/kmsg` by an in-process goroutine in `kernel-images-api`. Catches Chrome renderer subprocesses that aren't supervised.
- **`service_crashed`** — fires whenever supervisord reports a `PROCESS_STATE_EXITED` with `expected=0` (or `PROCESS_STATE_FATAL`). Sourced from a tiny shim binary (`kernel-images-supervisord-shim`) that supervisord launches as an eventlistener; the shim POSTs to the existing local `/telemetry/events` endpoint.

Both event categories are `system`, which is always-on regardless of caller telemetry config. Events flow through the existing `EventStream`, so the SSE stream (`GET /telemetry/stream`) and the S2 storage sink inherit them for free.

### Why two sources

Coverage matrix:

| Failure mode | kmsg | supervisord |
|---|---|---|
| Chrome renderer OOM | ✓ | ✗ (not supervised) |
| Chromium parent OOM | ✓ | ✓ |
| Chromium segfault / V8 abort | ✗ | ✓ |
| kernel-images-api panic | ✗ | ✓ (on respawn) |
| mutter/envoy crash | only OOM | ✓ |

No de-dup — if both fire for the same kill, that's the signal (RAM exhaustion, not a bug).

### Design notes

- Dispatch is decentralized. `lib/sysmon` only owns the kmsg goroutine and publishes directly to `EventStream`. The supervisord shim handles its own schema mapping and uses the existing telemetry HTTP endpoint, so this PR doesn't introduce a new unix socket or a central event-dispatcher abstraction (vs. the earlier sketch).
- The shim always ACKs supervisord with `OK` even if the HTTP POST fails, so supervisord doesn't quarantine the listener when kernel-images-api is briefly down.
- Shim logs to stderr only — stdout is reserved for the supervisord eventlistener wire protocol.
- Both Dockerfiles (headful and headless) build and install the shim binary, and both ship the new `supervisord-shim.conf` eventlistener entry.

### Out of scope (per the original spec)

- Setting kernel-images-api's own `oom_score_adj`
- On-startup kmsg backlog read
- PSI / cgroup-attributed memory events (kernel doesn't expose them in this VM)

## Test plan

- [x] Unit tests for kmsg parser: canonical line, negative `oom_score_adj`, comm with internal space, non-OOM lines (preamble), malformed lines
- [x] Unit tests for the supervisord shim: `parseFields`, `readEvent`, `mapEvent` for unexpected exits, expected exits (skipped), FATAL transitions, unrelated event types (skipped)
- [x] Round-trip test in `lib/sysmon`: pipe an OOM-kill line through a FIFO and verify the event lands in `EventStream` with the right schema
- [x] `go vet ./...` clean
- [x] `go test -race ./...` (excluding e2e) passes
- [ ] E2E inside a real VM:
  - [ ] `echo f > /proc/sysrq-trigger` produces `system_oom_kill` on `/telemetry/stream`
  - [ ] `supervisorctl stop mutter` does NOT fire `service_crashed` (expected=1)
  - [ ] `kill -SEGV $(pgrep mutter)` fires `service_crashed`
  - [ ] Forced chromium parent OOM fires BOTH events

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new always-on system telemetry sources (reading `/dev/kmsg` and a supervisord eventlistener that POSTs into the API), which could increase event volume and affect runtime behavior if parsing/IO misbehaves or the local telemetry endpoint is unavailable.
> 
> **Overview**
> Adds **VM-internal failure telemetry** by introducing two new event types: `system_oom_kill` (emitted by a new `sysmon` monitor that tails `/dev/kmsg` inside `kernel-images-api`) and `service_crashed` (emitted by a new lightweight `supervisord-shim` eventlistener that converts supervisord PROCESS_STATE_* crash transitions into POSTs to `/telemetry/events`).
> 
> Updates the OpenAPI spec and generated `oapi` union types to include these events, wires `sysmon` startup into `server/cmd/api/main.go`, and updates both headful/headless Chromium images to build/install the shim plus enable it via new `supervisord-shim.conf` (with a larger event buffer). Includes unit/round-trip tests for the kmsg parser and shim event mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ecdc0d4b06163fcefd8671b583c3b2ee9b0d0c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->