### PR TITLE
neko update + telemetry enable

### DIFF
--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -152,7 +152,7 @@ RUN --mount=type=cache,target=/tmp/cache/ffmpeg,sharing=locked,id=$CACHEIDPREFIX
     rm -rf /tmp/ffmpeg*
 EOT
 
-FROM ghcr.io/kernel/neko/base:3.0.8-v1.5.0 AS neko
+FROM ghcr.io/kernel/neko/base:3.0.8-v1.6.0 AS neko
 FROM node:22-bullseye-slim AS node-22
 FROM docker.io/ubuntu:22.04
 

--- a/images/chromium-headful/neko.yaml
+++ b/images/chromium-headful/neko.yaml
@@ -53,3 +53,6 @@ filetransfer:
 
 scaletozero:
   enabled: true
+
+telemetry:
+  enabled: true


### PR DESCRIPTION
Yoinks in https://github.com/kernel/neko/pull/13

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small dependency tag bump and an opt-in telemetry flag in Neko config; no auth or application logic changes in this diff.
> 
> **Overview**
> Bumps the **Neko** base image in the chromium-headful Dockerfile from `ghcr.io/kernel/neko/base:3.0.8-v1.5.0` to `3.0.8-v1.6.0`, so built images pick up the newer Neko runtime layer.
> 
> Turns on **Neko telemetry** in `neko.yaml` (`telemetry.enabled: true`) alongside the existing `scaletozero` settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b512186186e4911ab63394ac62a63cfb763367f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->