### PR TITLE
server: document category const on Browser*Event schemas

### DIFF
--- a/server/lib/oapi/oapi.go
+++ b/server/lib/oapi/oapi.go
@@ -26,6 +26,21 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
+// Defines values for BrowserApiCallEventCategory.
+const (
+	BrowserApiCallEventCategoryApi BrowserApiCallEventCategory = "api"
+)
+
+// Valid indicates whether the value is a known member of the BrowserApiCallEventCategory enum.
+func (e BrowserApiCallEventCategory) Valid() bool {
+	switch e {
+	case BrowserApiCallEventCategoryApi:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserApiCallEventType.
 const (
 	ApiCall BrowserApiCallEventType = "api_call"
@@ -110,6 +125,21 @@ func (e BrowserCaptchaSolveResultEventDataStatus) Valid() bool {
 	}
 }
 
+// Defines values for BrowserCdpConnectEventCategory.
+const (
+	BrowserCdpConnectEventCategorySystem BrowserCdpConnectEventCategory = "system"
+)
+
+// Valid indicates whether the value is a known member of the BrowserCdpConnectEventCategory enum.
+func (e BrowserCdpConnectEventCategory) Valid() bool {
+	switch e {
+	case BrowserCdpConnectEventCategorySystem:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserCdpConnectEventType.
 const (
 	CdpConnect BrowserCdpConnectEventType = "cdp_connect"
@@ -119,6 +149,21 @@ const (
 func (e BrowserCdpConnectEventType) Valid() bool {
 	switch e {
 	case CdpConnect:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserCdpDisconnectEventCategory.
+const (
+	BrowserCdpDisconnectEventCategorySystem BrowserCdpDisconnectEventCategory = "system"
+)
+
+// Valid indicates whether the value is a known member of the BrowserCdpDisconnectEventCategory enum.
+func (e BrowserCdpDisconnectEventCategory) Valid() bool {
+	switch e {
+	case BrowserCdpDisconnectEventCategorySystem:
 		return true
 	default:
 		return false
@@ -164,6 +209,21 @@ func (e BrowserCdpDisconnectEventDataReason) Valid() bool {
 	}
 }
 
+// Defines values for BrowserConsoleErrorEventCategory.
+const (
+	BrowserConsoleErrorEventCategoryConsole BrowserConsoleErrorEventCategory = "console"
+)
+
+// Valid indicates whether the value is a known member of the BrowserConsoleErrorEventCategory enum.
+func (e BrowserConsoleErrorEventCategory) Valid() bool {
+	switch e {
+	case BrowserConsoleErrorEventCategoryConsole:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserConsoleErrorEventType.
 const (
 	ConsoleError BrowserConsoleErrorEventType = "console_error"
@@ -173,6 +233,21 @@ const (
 func (e BrowserConsoleErrorEventType) Valid() bool {
 	switch e {
 	case ConsoleError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserConsoleLogEventCategory.
+const (
+	BrowserConsoleLogEventCategoryConsole BrowserConsoleLogEventCategory = "console"
+)
+
+// Valid indicates whether the value is a known member of the BrowserConsoleLogEventCategory enum.
+func (e BrowserConsoleLogEventCategory) Valid() bool {
+	switch e {
+	case BrowserConsoleLogEventCategoryConsole:
 		return true
 	default:
 		return false
@@ -218,6 +293,21 @@ func (e BrowserEventSourceKind) Valid() bool {
 	}
 }
 
+// Defines values for BrowserInteractionClickEventCategory.
+const (
+	BrowserInteractionClickEventCategoryInteraction BrowserInteractionClickEventCategory = "interaction"
+)
+
+// Valid indicates whether the value is a known member of the BrowserInteractionClickEventCategory enum.
+func (e BrowserInteractionClickEventCategory) Valid() bool {
+	switch e {
+	case BrowserInteractionClickEventCategoryInteraction:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserInteractionClickEventType.
 const (
 	InteractionClick BrowserInteractionClickEventType = "interaction_click"
@@ -233,6 +323,21 @@ func (e BrowserInteractionClickEventType) Valid() bool {
 	}
 }
 
+// Defines values for BrowserInteractionKeyEventCategory.
+const (
+	BrowserInteractionKeyEventCategoryInteraction BrowserInteractionKeyEventCategory = "interaction"
+)
+
+// Valid indicates whether the value is a known member of the BrowserInteractionKeyEventCategory enum.
+func (e BrowserInteractionKeyEventCategory) Valid() bool {
+	switch e {
+	case BrowserInteractionKeyEventCategoryInteraction:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserInteractionKeyEventType.
 const (
 	InteractionKey BrowserInteractionKeyEventType = "interaction_key"
@@ -242,6 +347,21 @@ const (
 func (e BrowserInteractionKeyEventType) Valid() bool {
 	switch e {
 	case InteractionKey:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserInteractionScrollSettledEventCategory.
+const (
+	BrowserInteractionScrollSettledEventCategoryInteraction BrowserInteractionScrollSettledEventCategory = "interaction"
+)
+
+// Valid indicates whether the value is a known member of the BrowserInteractionScrollSettledEventCategory enum.
+func (e BrowserInteractionScrollSettledEventCategory) Valid() bool {
+	switch e {
+	case BrowserInteractionScrollSettledEventCategoryInteraction:
 		return true
 	default:
 		return false
@@ -293,6 +413,21 @@ func (e BrowserLiveViewDisconnectEventType) Valid() bool {
 	}
 }
 
+// Defines values for BrowserMonitorDisconnectedEventCategory.
+const (
+	BrowserMonitorDisconnectedEventCategorySystem BrowserMonitorDisconnectedEventCategory = "system"
+)
+
+// Valid indicates whether the value is a known member of the BrowserMonitorDisconnectedEventCategory enum.
+func (e BrowserMonitorDisconnectedEventCategory) Valid() bool {
+	switch e {
+	case BrowserMonitorDisconnectedEventCategorySystem:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserMonitorDisconnectedEventType.
 const (
 	MonitorDisconnected BrowserMonitorDisconnectedEventType = "monitor_disconnected"
@@ -323,6 +458,21 @@ func (e BrowserMonitorDisconnectedEventDataReason) Valid() bool {
 	}
 }
 
+// Defines values for BrowserMonitorInitFailedEventCategory.
+const (
+	BrowserMonitorInitFailedEventCategorySystem BrowserMonitorInitFailedEventCategory = "system"
+)
+
+// Valid indicates whether the value is a known member of the BrowserMonitorInitFailedEventCategory enum.
+func (e BrowserMonitorInitFailedEventCategory) Valid() bool {
+	switch e {
+	case BrowserMonitorInitFailedEventCategorySystem:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserMonitorInitFailedEventType.
 const (
 	MonitorInitFailed BrowserMonitorInitFailedEventType = "monitor_init_failed"
@@ -332,6 +482,21 @@ const (
 func (e BrowserMonitorInitFailedEventType) Valid() bool {
 	switch e {
 	case MonitorInitFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserMonitorReconnectFailedEventCategory.
+const (
+	BrowserMonitorReconnectFailedEventCategorySystem BrowserMonitorReconnectFailedEventCategory = "system"
+)
+
+// Valid indicates whether the value is a known member of the BrowserMonitorReconnectFailedEventCategory enum.
+func (e BrowserMonitorReconnectFailedEventCategory) Valid() bool {
+	switch e {
+	case BrowserMonitorReconnectFailedEventCategorySystem:
 		return true
 	default:
 		return false
@@ -368,6 +533,21 @@ func (e BrowserMonitorReconnectFailedEventDataReason) Valid() bool {
 	}
 }
 
+// Defines values for BrowserMonitorReconnectedEventCategory.
+const (
+	BrowserMonitorReconnectedEventCategorySystem BrowserMonitorReconnectedEventCategory = "system"
+)
+
+// Valid indicates whether the value is a known member of the BrowserMonitorReconnectedEventCategory enum.
+func (e BrowserMonitorReconnectedEventCategory) Valid() bool {
+	switch e {
+	case BrowserMonitorReconnectedEventCategorySystem:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserMonitorReconnectedEventType.
 const (
 	MonitorReconnected BrowserMonitorReconnectedEventType = "monitor_reconnected"
@@ -377,6 +557,21 @@ const (
 func (e BrowserMonitorReconnectedEventType) Valid() bool {
 	switch e {
 	case MonitorReconnected:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserMonitorScreenshotEventCategory.
+const (
+	BrowserMonitorScreenshotEventCategorySystem BrowserMonitorScreenshotEventCategory = "system"
+)
+
+// Valid indicates whether the value is a known member of the BrowserMonitorScreenshotEventCategory enum.
+func (e BrowserMonitorScreenshotEventCategory) Valid() bool {
+	switch e {
+	case BrowserMonitorScreenshotEventCategorySystem:
 		return true
 	default:
 		return false
@@ -398,6 +593,21 @@ func (e BrowserMonitorScreenshotEventType) Valid() bool {
 	}
 }
 
+// Defines values for BrowserNetworkIdleEventCategory.
+const (
+	BrowserNetworkIdleEventCategoryNetwork BrowserNetworkIdleEventCategory = "network"
+)
+
+// Valid indicates whether the value is a known member of the BrowserNetworkIdleEventCategory enum.
+func (e BrowserNetworkIdleEventCategory) Valid() bool {
+	switch e {
+	case BrowserNetworkIdleEventCategoryNetwork:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserNetworkIdleEventType.
 const (
 	NetworkIdle BrowserNetworkIdleEventType = "network_idle"
@@ -407,6 +617,21 @@ const (
 func (e BrowserNetworkIdleEventType) Valid() bool {
 	switch e {
 	case NetworkIdle:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserNetworkLoadingFailedEventCategory.
+const (
+	BrowserNetworkLoadingFailedEventCategoryNetwork BrowserNetworkLoadingFailedEventCategory = "network"
+)
+
+// Valid indicates whether the value is a known member of the BrowserNetworkLoadingFailedEventCategory enum.
+func (e BrowserNetworkLoadingFailedEventCategory) Valid() bool {
+	switch e {
+	case BrowserNetworkLoadingFailedEventCategoryNetwork:
 		return true
 	default:
 		return false
@@ -428,6 +653,21 @@ func (e BrowserNetworkLoadingFailedEventType) Valid() bool {
 	}
 }
 
+// Defines values for BrowserNetworkRequestEventCategory.
+const (
+	BrowserNetworkRequestEventCategoryNetwork BrowserNetworkRequestEventCategory = "network"
+)
+
+// Valid indicates whether the value is a known member of the BrowserNetworkRequestEventCategory enum.
+func (e BrowserNetworkRequestEventCategory) Valid() bool {
+	switch e {
+	case BrowserNetworkRequestEventCategoryNetwork:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserNetworkRequestEventType.
 const (
 	NetworkRequest BrowserNetworkRequestEventType = "network_request"
@@ -437,6 +677,21 @@ const (
 func (e BrowserNetworkRequestEventType) Valid() bool {
 	switch e {
 	case NetworkRequest:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserNetworkResponseEventCategory.
+const (
+	BrowserNetworkResponseEventCategoryNetwork BrowserNetworkResponseEventCategory = "network"
+)
+
+// Valid indicates whether the value is a known member of the BrowserNetworkResponseEventCategory enum.
+func (e BrowserNetworkResponseEventCategory) Valid() bool {
+	switch e {
+	case BrowserNetworkResponseEventCategoryNetwork:
 		return true
 	default:
 		return false
@@ -458,6 +713,21 @@ func (e BrowserNetworkResponseEventType) Valid() bool {
 	}
 }
 
+// Defines values for BrowserPageDomContentLoadedEventCategory.
+const (
+	BrowserPageDomContentLoadedEventCategoryPage BrowserPageDomContentLoadedEventCategory = "page"
+)
+
+// Valid indicates whether the value is a known member of the BrowserPageDomContentLoadedEventCategory enum.
+func (e BrowserPageDomContentLoadedEventCategory) Valid() bool {
+	switch e {
+	case BrowserPageDomContentLoadedEventCategoryPage:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserPageDomContentLoadedEventType.
 const (
 	PageDomContentLoaded BrowserPageDomContentLoadedEventType = "page_dom_content_loaded"
@@ -467,6 +737,21 @@ const (
 func (e BrowserPageDomContentLoadedEventType) Valid() bool {
 	switch e {
 	case PageDomContentLoaded:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserPageLayoutSettledEventCategory.
+const (
+	BrowserPageLayoutSettledEventCategoryPage BrowserPageLayoutSettledEventCategory = "page"
+)
+
+// Valid indicates whether the value is a known member of the BrowserPageLayoutSettledEventCategory enum.
+func (e BrowserPageLayoutSettledEventCategory) Valid() bool {
+	switch e {
+	case BrowserPageLayoutSettledEventCategoryPage:
 		return true
 	default:
 		return false
@@ -488,6 +773,21 @@ func (e BrowserPageLayoutSettledEventType) Valid() bool {
 	}
 }
 
+// Defines values for BrowserPageLayoutShiftEventCategory.
+const (
+	BrowserPageLayoutShiftEventCategoryPage BrowserPageLayoutShiftEventCategory = "page"
+)
+
+// Valid indicates whether the value is a known member of the BrowserPageLayoutShiftEventCategory enum.
+func (e BrowserPageLayoutShiftEventCategory) Valid() bool {
+	switch e {
+	case BrowserPageLayoutShiftEventCategoryPage:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserPageLayoutShiftEventType.
 const (
 	PageLayoutShift BrowserPageLayoutShiftEventType = "page_layout_shift"
@@ -497,6 +797,21 @@ const (
 func (e BrowserPageLayoutShiftEventType) Valid() bool {
 	switch e {
 	case PageLayoutShift:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserPageLcpEventCategory.
+const (
+	BrowserPageLcpEventCategoryPage BrowserPageLcpEventCategory = "page"
+)
+
+// Valid indicates whether the value is a known member of the BrowserPageLcpEventCategory enum.
+func (e BrowserPageLcpEventCategory) Valid() bool {
+	switch e {
+	case BrowserPageLcpEventCategoryPage:
 		return true
 	default:
 		return false
@@ -518,6 +833,21 @@ func (e BrowserPageLcpEventType) Valid() bool {
 	}
 }
 
+// Defines values for BrowserPageLoadEventCategory.
+const (
+	BrowserPageLoadEventCategoryPage BrowserPageLoadEventCategory = "page"
+)
+
+// Valid indicates whether the value is a known member of the BrowserPageLoadEventCategory enum.
+func (e BrowserPageLoadEventCategory) Valid() bool {
+	switch e {
+	case BrowserPageLoadEventCategoryPage:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserPageLoadEventType.
 const (
 	PageLoad BrowserPageLoadEventType = "page_load"
@@ -527,6 +857,21 @@ const (
 func (e BrowserPageLoadEventType) Valid() bool {
 	switch e {
 	case PageLoad:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserPageNavigationEventCategory.
+const (
+	BrowserPageNavigationEventCategoryPage BrowserPageNavigationEventCategory = "page"
+)
+
+// Valid indicates whether the value is a known member of the BrowserPageNavigationEventCategory enum.
+func (e BrowserPageNavigationEventCategory) Valid() bool {
+	switch e {
+	case BrowserPageNavigationEventCategoryPage:
 		return true
 	default:
 		return false
@@ -548,6 +893,21 @@ func (e BrowserPageNavigationEventType) Valid() bool {
 	}
 }
 
+// Defines values for BrowserPageNavigationSettledEventCategory.
+const (
+	BrowserPageNavigationSettledEventCategoryPage BrowserPageNavigationSettledEventCategory = "page"
+)
+
+// Valid indicates whether the value is a known member of the BrowserPageNavigationSettledEventCategory enum.
+func (e BrowserPageNavigationSettledEventCategory) Valid() bool {
+	switch e {
+	case BrowserPageNavigationSettledEventCategoryPage:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserPageNavigationSettledEventType.
 const (
 	PageNavigationSettled BrowserPageNavigationSettledEventType = "page_navigation_settled"
@@ -563,6 +923,21 @@ func (e BrowserPageNavigationSettledEventType) Valid() bool {
 	}
 }
 
+// Defines values for BrowserPageTabOpenedEventCategory.
+const (
+	BrowserPageTabOpenedEventCategoryPage BrowserPageTabOpenedEventCategory = "page"
+)
+
+// Valid indicates whether the value is a known member of the BrowserPageTabOpenedEventCategory enum.
+func (e BrowserPageTabOpenedEventCategory) Valid() bool {
+	switch e {
+	case BrowserPageTabOpenedEventCategoryPage:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BrowserPageTabOpenedEventType.
 const (
 	PageTabOpened BrowserPageTabOpenedEventType = "page_tab_opened"
@@ -572,6 +947,21 @@ const (
 func (e BrowserPageTabOpenedEventType) Valid() bool {
 	switch e {
 	case PageTabOpened:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserServiceCrashedEventCategory.
+const (
+	BrowserServiceCrashedEventCategorySystem BrowserServiceCrashedEventCategory = "system"
+)
+
+// Valid indicates whether the value is a known member of the BrowserServiceCrashedEventCategory enum.
+func (e BrowserServiceCrashedEventCategory) Valid() bool {
+	switch e {
+	case BrowserServiceCrashedEventCategorySystem:
 		return true
 	default:
 		return false
@@ -608,6 +998,21 @@ func (e BrowserServiceCrashedEventDataPhase) Valid() bool {
 	case BrowserServiceCrashedEventDataPhaseRunning:
 		return true
 	case BrowserServiceCrashedEventDataPhaseStartup:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BrowserSystemOomKillEventCategory.
+const (
+	System BrowserSystemOomKillEventCategory = "system"
+)
+
+// Valid indicates whether the value is a known member of the BrowserSystemOomKillEventCategory enum.
+func (e BrowserSystemOomKillEventCategory) Valid() bool {
+	switch e {
+	case System:
 		return true
 	default:
 		return false
@@ -1069,6 +1474,8 @@ type BatchComputerActionRequest struct {
 
 // BrowserApiCallEvent An HTTP call handled by the kernel-images-api server.
 type BrowserApiCallEvent struct {
+	Category BrowserApiCallEventCategory `json:"category"`
+
 	// Data Per-call payload for `api_call` events.
 	Data *BrowserApiCallEventData `json:"data,omitempty"`
 
@@ -1082,6 +1489,9 @@ type BrowserApiCallEvent struct {
 	Ts   int64                   `json:"ts"`
 	Type BrowserApiCallEventType `json:"type"`
 }
+
+// BrowserApiCallEventCategory defines model for BrowserApiCallEvent.Category.
+type BrowserApiCallEventCategory string
 
 // BrowserApiCallEventType defines model for BrowserApiCallEvent.Type.
 type BrowserApiCallEventType string
@@ -1179,6 +1589,8 @@ type BrowserCaptchaSolveResultEventDataStatus string
 
 // BrowserCdpConnectEvent An external client (e.g. customer SDK, Playwright, Puppeteer) connected to the CDP WebSocket proxy on this VM.
 type BrowserCdpConnectEvent struct {
+	Category BrowserCdpConnectEventCategory `json:"category"`
+
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
 
@@ -1190,11 +1602,16 @@ type BrowserCdpConnectEvent struct {
 	Type BrowserCdpConnectEventType `json:"type"`
 }
 
+// BrowserCdpConnectEventCategory defines model for BrowserCdpConnectEvent.Category.
+type BrowserCdpConnectEventCategory string
+
 // BrowserCdpConnectEventType defines model for BrowserCdpConnectEvent.Type.
 type BrowserCdpConnectEventType string
 
 // BrowserCdpDisconnectEvent An external client disconnected from the CDP WebSocket proxy on this VM. Pair with the immediately preceding `cdp_connect` on the same stream.
 type BrowserCdpDisconnectEvent struct {
+	Category BrowserCdpDisconnectEventCategory `json:"category"`
+
 	// Data Per-disconnect payload for `cdp_disconnect` events.
 	Data *BrowserCdpDisconnectEventData `json:"data,omitempty"`
 
@@ -1208,6 +1625,9 @@ type BrowserCdpDisconnectEvent struct {
 	Ts   int64                         `json:"ts"`
 	Type BrowserCdpDisconnectEventType `json:"type"`
 }
+
+// BrowserCdpDisconnectEventCategory defines model for BrowserCdpDisconnectEvent.Category.
+type BrowserCdpDisconnectEventCategory string
 
 // BrowserCdpDisconnectEventType defines model for BrowserCdpDisconnectEvent.Type.
 type BrowserCdpDisconnectEventType string
@@ -1229,7 +1649,8 @@ type BrowserCdpDisconnectEventDataReason string
 
 // BrowserConsoleErrorEvent A browser console error or uncaught JavaScript exception event. Emitted from two distinct CDP sources with different data shapes. Runtime.consoleAPICalled (console.error calls) produces level, text, args, and stack_trace. Runtime.exceptionThrown (uncaught exceptions) produces text, line, column, source_url, and stack_trace. Fields not applicable to the source are absent.
 type BrowserConsoleErrorEvent struct {
-	Data *BrowserConsoleErrorEventData `json:"data,omitempty"`
+	Category BrowserConsoleErrorEventCategory `json:"category"`
+	Data     *BrowserConsoleErrorEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1241,6 +1662,9 @@ type BrowserConsoleErrorEvent struct {
 	Ts   int64                        `json:"ts"`
 	Type BrowserConsoleErrorEventType `json:"type"`
 }
+
+// BrowserConsoleErrorEventCategory defines model for BrowserConsoleErrorEvent.Category.
+type BrowserConsoleErrorEventCategory string
 
 // BrowserConsoleErrorEventType defines model for BrowserConsoleErrorEvent.Type.
 type BrowserConsoleErrorEventType string
@@ -1292,7 +1716,8 @@ type BrowserConsoleErrorEventData struct {
 
 // BrowserConsoleLogEvent A browser console log event (console.log, console.info, console.warn, etc.).
 type BrowserConsoleLogEvent struct {
-	Data *BrowserConsoleLogEventData `json:"data,omitempty"`
+	Category BrowserConsoleLogEventCategory `json:"category"`
+	Data     *BrowserConsoleLogEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1304,6 +1729,9 @@ type BrowserConsoleLogEvent struct {
 	Ts   int64                      `json:"ts"`
 	Type BrowserConsoleLogEventType `json:"type"`
 }
+
+// BrowserConsoleLogEventCategory defines model for BrowserConsoleLogEvent.Category.
+type BrowserConsoleLogEventCategory string
 
 // BrowserConsoleLogEventType defines model for BrowserConsoleLogEvent.Type.
 type BrowserConsoleLogEventType string
@@ -1388,7 +1816,8 @@ type BrowserHttpHeaders map[string]interface{}
 
 // BrowserInteractionClickEvent A browser user click event captured via injected page script.
 type BrowserInteractionClickEvent struct {
-	Data *BrowserInteractionClickEventData `json:"data,omitempty"`
+	Category BrowserInteractionClickEventCategory `json:"category"`
+	Data     *BrowserInteractionClickEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1400,6 +1829,9 @@ type BrowserInteractionClickEvent struct {
 	Ts   int64                            `json:"ts"`
 	Type BrowserInteractionClickEventType `json:"type"`
 }
+
+// BrowserInteractionClickEventCategory defines model for BrowserInteractionClickEvent.Category.
+type BrowserInteractionClickEventCategory string
 
 // BrowserInteractionClickEventType defines model for BrowserInteractionClickEvent.Type.
 type BrowserInteractionClickEventType string
@@ -1445,7 +1877,8 @@ type BrowserInteractionClickEventData struct {
 
 // BrowserInteractionKeyEvent A browser keyboard event captured via injected page script.
 type BrowserInteractionKeyEvent struct {
-	Data *BrowserInteractionKeyEventData `json:"data,omitempty"`
+	Category BrowserInteractionKeyEventCategory `json:"category"`
+	Data     *BrowserInteractionKeyEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1457,6 +1890,9 @@ type BrowserInteractionKeyEvent struct {
 	Ts   int64                          `json:"ts"`
 	Type BrowserInteractionKeyEventType `json:"type"`
 }
+
+// BrowserInteractionKeyEventCategory defines model for BrowserInteractionKeyEvent.Category.
+type BrowserInteractionKeyEventCategory string
 
 // BrowserInteractionKeyEventType defines model for BrowserInteractionKeyEvent.Type.
 type BrowserInteractionKeyEventType string
@@ -1496,7 +1932,8 @@ type BrowserInteractionKeyEventData struct {
 
 // BrowserInteractionScrollSettledEvent A browser scroll settled event emitted after scroll position stops changing, captured via injected page script.
 type BrowserInteractionScrollSettledEvent struct {
-	Data *BrowserInteractionScrollSettledEventData `json:"data,omitempty"`
+	Category BrowserInteractionScrollSettledEventCategory `json:"category"`
+	Data     *BrowserInteractionScrollSettledEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1508,6 +1945,9 @@ type BrowserInteractionScrollSettledEvent struct {
 	Ts   int64                                    `json:"ts"`
 	Type BrowserInteractionScrollSettledEventType `json:"type"`
 }
+
+// BrowserInteractionScrollSettledEventCategory defines model for BrowserInteractionScrollSettledEvent.Category.
+type BrowserInteractionScrollSettledEventCategory string
 
 // BrowserInteractionScrollSettledEventType defines model for BrowserInteractionScrollSettledEvent.Type.
 type BrowserInteractionScrollSettledEventType string
@@ -1606,7 +2046,8 @@ type BrowserLiveViewDisconnectEventData struct {
 
 // BrowserMonitorDisconnectedEvent The CDP connection to Chrome was lost. Telemetry events may be dropped until monitor_reconnected arrives. Treat any in-progress computed state (network_idle, page_layout_settled) as unreliable until then.
 type BrowserMonitorDisconnectedEvent struct {
-	Data *BrowserMonitorDisconnectedEventData `json:"data,omitempty"`
+	Category BrowserMonitorDisconnectedEventCategory `json:"category"`
+	Data     *BrowserMonitorDisconnectedEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1618,6 +2059,9 @@ type BrowserMonitorDisconnectedEvent struct {
 	Ts   int64                               `json:"ts"`
 	Type BrowserMonitorDisconnectedEventType `json:"type"`
 }
+
+// BrowserMonitorDisconnectedEventCategory defines model for BrowserMonitorDisconnectedEvent.Category.
+type BrowserMonitorDisconnectedEventCategory string
 
 // BrowserMonitorDisconnectedEventType defines model for BrowserMonitorDisconnectedEvent.Type.
 type BrowserMonitorDisconnectedEventType string
@@ -1633,7 +2077,8 @@ type BrowserMonitorDisconnectedEventDataReason string
 
 // BrowserMonitorInitFailedEvent The CDP session could not be initialized.
 type BrowserMonitorInitFailedEvent struct {
-	Data *BrowserMonitorInitFailedEventData `json:"data,omitempty"`
+	Category BrowserMonitorInitFailedEventCategory `json:"category"`
+	Data     *BrowserMonitorInitFailedEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1646,6 +2091,9 @@ type BrowserMonitorInitFailedEvent struct {
 	Type BrowserMonitorInitFailedEventType `json:"type"`
 }
 
+// BrowserMonitorInitFailedEventCategory defines model for BrowserMonitorInitFailedEvent.Category.
+type BrowserMonitorInitFailedEventCategory string
+
 // BrowserMonitorInitFailedEventType defines model for BrowserMonitorInitFailedEvent.Type.
 type BrowserMonitorInitFailedEventType string
 
@@ -1657,7 +2105,8 @@ type BrowserMonitorInitFailedEventData struct {
 
 // BrowserMonitorReconnectFailedEvent The CDP connection to Chrome could not be re-established after exhausting all reconnection attempts. No further telemetry events will arrive on this session.
 type BrowserMonitorReconnectFailedEvent struct {
-	Data *BrowserMonitorReconnectFailedEventData `json:"data,omitempty"`
+	Category BrowserMonitorReconnectFailedEventCategory `json:"category"`
+	Data     *BrowserMonitorReconnectFailedEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1669,6 +2118,9 @@ type BrowserMonitorReconnectFailedEvent struct {
 	Ts   int64                                  `json:"ts"`
 	Type BrowserMonitorReconnectFailedEventType `json:"type"`
 }
+
+// BrowserMonitorReconnectFailedEventCategory defines model for BrowserMonitorReconnectFailedEvent.Category.
+type BrowserMonitorReconnectFailedEventCategory string
 
 // BrowserMonitorReconnectFailedEventType defines model for BrowserMonitorReconnectFailedEvent.Type.
 type BrowserMonitorReconnectFailedEventType string
@@ -1684,7 +2136,8 @@ type BrowserMonitorReconnectFailedEventDataReason string
 
 // BrowserMonitorReconnectedEvent The CDP connection to Chrome was successfully re-established after a disconnection. Events emitted during the gap are lost. Computed state is reset, so navigation and network tracking restart fresh from this point.
 type BrowserMonitorReconnectedEvent struct {
-	Data *BrowserMonitorReconnectedEventData `json:"data,omitempty"`
+	Category BrowserMonitorReconnectedEventCategory `json:"category"`
+	Data     *BrowserMonitorReconnectedEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1697,6 +2150,9 @@ type BrowserMonitorReconnectedEvent struct {
 	Type BrowserMonitorReconnectedEventType `json:"type"`
 }
 
+// BrowserMonitorReconnectedEventCategory defines model for BrowserMonitorReconnectedEvent.Category.
+type BrowserMonitorReconnectedEventCategory string
+
 // BrowserMonitorReconnectedEventType defines model for BrowserMonitorReconnectedEvent.Type.
 type BrowserMonitorReconnectedEventType string
 
@@ -1708,7 +2164,8 @@ type BrowserMonitorReconnectedEventData struct {
 
 // BrowserMonitorScreenshotEvent A periodic screenshot of the browser viewport.
 type BrowserMonitorScreenshotEvent struct {
-	Data *BrowserMonitorScreenshotEventData `json:"data,omitempty"`
+	Category BrowserMonitorScreenshotEventCategory `json:"category"`
+	Data     *BrowserMonitorScreenshotEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1721,6 +2178,9 @@ type BrowserMonitorScreenshotEvent struct {
 	Type BrowserMonitorScreenshotEventType `json:"type"`
 }
 
+// BrowserMonitorScreenshotEventCategory defines model for BrowserMonitorScreenshotEvent.Category.
+type BrowserMonitorScreenshotEventCategory string
+
 // BrowserMonitorScreenshotEventType defines model for BrowserMonitorScreenshotEvent.Type.
 type BrowserMonitorScreenshotEventType string
 
@@ -1732,6 +2192,8 @@ type BrowserMonitorScreenshotEventData struct {
 
 // BrowserNetworkIdleEvent A browser network idle event emitted after a 500ms quiet period with no in-flight HTTP requests.
 type BrowserNetworkIdleEvent struct {
+	Category BrowserNetworkIdleEventCategory `json:"category"`
+
 	// Data Browser event context stamped by the browser monitor onto all CDP-sourced events. Identifies the target, frame, and navigation epoch in which the event occurred.
 	Data *BrowserEventContext `json:"data,omitempty"`
 
@@ -1746,12 +2208,16 @@ type BrowserNetworkIdleEvent struct {
 	Type BrowserNetworkIdleEventType `json:"type"`
 }
 
+// BrowserNetworkIdleEventCategory defines model for BrowserNetworkIdleEvent.Category.
+type BrowserNetworkIdleEventCategory string
+
 // BrowserNetworkIdleEventType defines model for BrowserNetworkIdleEvent.Type.
 type BrowserNetworkIdleEventType string
 
 // BrowserNetworkLoadingFailedEvent A browser network loading failed event. If the request was already in flight when CDP attached (no prior `network_request` was emitted for it), `url`, `frame_id`, `loader_id`, and `resource_type` are absent; `BrowserEventContext` is partially populated in that case.
 type BrowserNetworkLoadingFailedEvent struct {
-	Data *BrowserNetworkLoadingFailedEventData `json:"data,omitempty"`
+	Category BrowserNetworkLoadingFailedEventCategory `json:"category"`
+	Data     *BrowserNetworkLoadingFailedEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1763,6 +2229,9 @@ type BrowserNetworkLoadingFailedEvent struct {
 	Ts   int64                                `json:"ts"`
 	Type BrowserNetworkLoadingFailedEventType `json:"type"`
 }
+
+// BrowserNetworkLoadingFailedEventCategory defines model for BrowserNetworkLoadingFailedEvent.Category.
+type BrowserNetworkLoadingFailedEventCategory string
 
 // BrowserNetworkLoadingFailedEventType defines model for BrowserNetworkLoadingFailedEvent.Type.
 type BrowserNetworkLoadingFailedEventType string
@@ -1805,7 +2274,8 @@ type BrowserNetworkLoadingFailedEventData struct {
 
 // BrowserNetworkRequestEvent A browser network request sent event.
 type BrowserNetworkRequestEvent struct {
-	Data *BrowserNetworkRequestEventData `json:"data,omitempty"`
+	Category BrowserNetworkRequestEventCategory `json:"category"`
+	Data     *BrowserNetworkRequestEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1817,6 +2287,9 @@ type BrowserNetworkRequestEvent struct {
 	Ts   int64                          `json:"ts"`
 	Type BrowserNetworkRequestEventType `json:"type"`
 }
+
+// BrowserNetworkRequestEventCategory defines model for BrowserNetworkRequestEvent.Category.
+type BrowserNetworkRequestEventCategory string
 
 // BrowserNetworkRequestEventType defines model for BrowserNetworkRequestEvent.Type.
 type BrowserNetworkRequestEventType string
@@ -1874,7 +2347,8 @@ type BrowserNetworkRequestEventData struct {
 
 // BrowserNetworkResponseEvent A browser network response received event. Fired after the response body is fully received, not when headers arrive.
 type BrowserNetworkResponseEvent struct {
-	Data *BrowserNetworkResponseEventData `json:"data,omitempty"`
+	Category BrowserNetworkResponseEventCategory `json:"category"`
+	Data     *BrowserNetworkResponseEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1886,6 +2360,9 @@ type BrowserNetworkResponseEvent struct {
 	Ts   int64                           `json:"ts"`
 	Type BrowserNetworkResponseEventType `json:"type"`
 }
+
+// BrowserNetworkResponseEventCategory defines model for BrowserNetworkResponseEvent.Category.
+type BrowserNetworkResponseEventCategory string
 
 // BrowserNetworkResponseEventType defines model for BrowserNetworkResponseEvent.Type.
 type BrowserNetworkResponseEventType string
@@ -1940,7 +2417,8 @@ type BrowserNetworkResponseEventData struct {
 
 // BrowserPageDomContentLoadedEvent A browser DOMContentLoaded event (CDP Page.domContentEventFired).
 type BrowserPageDomContentLoadedEvent struct {
-	Data *BrowserPageDomContentLoadedEventData `json:"data,omitempty"`
+	Category BrowserPageDomContentLoadedEventCategory `json:"category"`
+	Data     *BrowserPageDomContentLoadedEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -1952,6 +2430,9 @@ type BrowserPageDomContentLoadedEvent struct {
 	Ts   int64                                `json:"ts"`
 	Type BrowserPageDomContentLoadedEventType `json:"type"`
 }
+
+// BrowserPageDomContentLoadedEventCategory defines model for BrowserPageDomContentLoadedEvent.Category.
+type BrowserPageDomContentLoadedEventCategory string
 
 // BrowserPageDomContentLoadedEventType defines model for BrowserPageDomContentLoadedEvent.Type.
 type BrowserPageDomContentLoadedEventType string
@@ -1985,6 +2466,8 @@ type BrowserPageDomContentLoadedEventData struct {
 
 // BrowserPageLayoutSettledEvent A browser layout settled event emitted 1 second after page load with no intervening layout shifts, indicating visual stability. Each layout shift resets the 1-second timer.
 type BrowserPageLayoutSettledEvent struct {
+	Category BrowserPageLayoutSettledEventCategory `json:"category"`
+
 	// Data Browser event context stamped by the browser monitor onto all CDP-sourced events. Identifies the target, frame, and navigation epoch in which the event occurred.
 	Data *BrowserEventContext `json:"data,omitempty"`
 
@@ -1999,12 +2482,16 @@ type BrowserPageLayoutSettledEvent struct {
 	Type BrowserPageLayoutSettledEventType `json:"type"`
 }
 
+// BrowserPageLayoutSettledEventCategory defines model for BrowserPageLayoutSettledEvent.Category.
+type BrowserPageLayoutSettledEventCategory string
+
 // BrowserPageLayoutSettledEventType defines model for BrowserPageLayoutSettledEvent.Type.
 type BrowserPageLayoutSettledEventType string
 
 // BrowserPageLayoutShiftEvent A browser cumulative layout shift (CLS) event from the Performance Timeline API.
 type BrowserPageLayoutShiftEvent struct {
-	Data *BrowserPageLayoutShiftEventData `json:"data,omitempty"`
+	Category BrowserPageLayoutShiftEventCategory `json:"category"`
+	Data     *BrowserPageLayoutShiftEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -2016,6 +2503,9 @@ type BrowserPageLayoutShiftEvent struct {
 	Ts   int64                           `json:"ts"`
 	Type BrowserPageLayoutShiftEventType `json:"type"`
 }
+
+// BrowserPageLayoutShiftEventCategory defines model for BrowserPageLayoutShiftEvent.Category.
+type BrowserPageLayoutShiftEventCategory string
 
 // BrowserPageLayoutShiftEventType defines model for BrowserPageLayoutShiftEvent.Type.
 type BrowserPageLayoutShiftEventType string
@@ -2064,7 +2554,8 @@ type BrowserPageLayoutShiftEventData struct {
 
 // BrowserPageLcpEvent A browser Largest Contentful Paint (LCP) event from the Performance Timeline API.
 type BrowserPageLcpEvent struct {
-	Data *BrowserPageLcpEventData `json:"data,omitempty"`
+	Category BrowserPageLcpEventCategory `json:"category"`
+	Data     *BrowserPageLcpEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -2076,6 +2567,9 @@ type BrowserPageLcpEvent struct {
 	Ts   int64                   `json:"ts"`
 	Type BrowserPageLcpEventType `json:"type"`
 }
+
+// BrowserPageLcpEventCategory defines model for BrowserPageLcpEvent.Category.
+type BrowserPageLcpEventCategory string
 
 // BrowserPageLcpEventType defines model for BrowserPageLcpEvent.Type.
 type BrowserPageLcpEventType string
@@ -2133,7 +2627,8 @@ type BrowserPageLcpEventData struct {
 
 // BrowserPageLoadEvent A browser page load event (CDP Page.loadEventFired).
 type BrowserPageLoadEvent struct {
-	Data *BrowserPageLoadEventData `json:"data,omitempty"`
+	Category BrowserPageLoadEventCategory `json:"category"`
+	Data     *BrowserPageLoadEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -2145,6 +2640,9 @@ type BrowserPageLoadEvent struct {
 	Ts   int64                    `json:"ts"`
 	Type BrowserPageLoadEventType `json:"type"`
 }
+
+// BrowserPageLoadEventCategory defines model for BrowserPageLoadEvent.Category.
+type BrowserPageLoadEventCategory string
 
 // BrowserPageLoadEventType defines model for BrowserPageLoadEvent.Type.
 type BrowserPageLoadEventType string
@@ -2178,7 +2676,8 @@ type BrowserPageLoadEventData struct {
 
 // BrowserPageNavigationEvent A browser page navigation started event (CDP Page.frameNavigated). Carries nav context fields inline but not nav_seq, as this event resets the navigation epoch.
 type BrowserPageNavigationEvent struct {
-	Data *BrowserPageNavigationEventData `json:"data,omitempty"`
+	Category BrowserPageNavigationEventCategory `json:"category"`
+	Data     *BrowserPageNavigationEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -2190,6 +2689,9 @@ type BrowserPageNavigationEvent struct {
 	Ts   int64                          `json:"ts"`
 	Type BrowserPageNavigationEventType `json:"type"`
 }
+
+// BrowserPageNavigationEventCategory defines model for BrowserPageNavigationEvent.Category.
+type BrowserPageNavigationEventCategory string
 
 // BrowserPageNavigationEventType defines model for BrowserPageNavigationEvent.Type.
 type BrowserPageNavigationEventType string
@@ -2220,6 +2722,8 @@ type BrowserPageNavigationEventData struct {
 
 // BrowserPageNavigationSettledEvent Emitted when page_dom_content_loaded and page_layout_settled have both fired for the same navigation, indicating the page is loaded and visually stable. Independent of network_idle; a single pending request does not block it.
 type BrowserPageNavigationSettledEvent struct {
+	Category BrowserPageNavigationSettledEventCategory `json:"category"`
+
 	// Data Browser event context stamped by the browser monitor onto all CDP-sourced events. Identifies the target, frame, and navigation epoch in which the event occurred.
 	Data *BrowserEventContext `json:"data,omitempty"`
 
@@ -2234,12 +2738,16 @@ type BrowserPageNavigationSettledEvent struct {
 	Type BrowserPageNavigationSettledEventType `json:"type"`
 }
 
+// BrowserPageNavigationSettledEventCategory defines model for BrowserPageNavigationSettledEvent.Category.
+type BrowserPageNavigationSettledEventCategory string
+
 // BrowserPageNavigationSettledEventType defines model for BrowserPageNavigationSettledEvent.Type.
 type BrowserPageNavigationSettledEventType string
 
 // BrowserPageTabOpenedEvent A new browser tab or target was opened (CDP Target.attachedToTarget for page targets). Fires before a CDP session is attached to the new target, so `session_id`, `frame_id`, `loader_id`, and `nav_seq` are absent; this event does not compose `BrowserEventContext`. Consumers reading context fields generically should treat it as a special case.
 type BrowserPageTabOpenedEvent struct {
-	Data *BrowserPageTabOpenedEventData `json:"data,omitempty"`
+	Category BrowserPageTabOpenedEventCategory `json:"category"`
+	Data     *BrowserPageTabOpenedEventData    `json:"data,omitempty"`
 
 	// Source Provenance metadata identifying which producer emitted the event.
 	Source BrowserEventSource `json:"source"`
@@ -2251,6 +2759,9 @@ type BrowserPageTabOpenedEvent struct {
 	Ts   int64                         `json:"ts"`
 	Type BrowserPageTabOpenedEventType `json:"type"`
 }
+
+// BrowserPageTabOpenedEventCategory defines model for BrowserPageTabOpenedEvent.Category.
+type BrowserPageTabOpenedEventCategory string
 
 // BrowserPageTabOpenedEventType defines model for BrowserPageTabOpenedEvent.Type.
 type BrowserPageTabOpenedEventType string
@@ -2275,6 +2786,8 @@ type BrowserPageTabOpenedEventData struct {
 
 // BrowserServiceCrashedEvent A managed service exited unexpectedly. Intentional stops (e.g. operator-initiated shutdown) do not produce this event — only unexpected exits and terminal restart-give-up transitions do.
 type BrowserServiceCrashedEvent struct {
+	Category BrowserServiceCrashedEventCategory `json:"category"`
+
 	// Data Per-crash payload for `service_crashed` events. Exit code and signal are not exposed by the underlying process manager on this channel, so only the service identity, the lifecycle phase the crash occurred in, and (when available) the PID are reported.
 	Data *BrowserServiceCrashedEventData `json:"data,omitempty"`
 
@@ -2288,6 +2801,9 @@ type BrowserServiceCrashedEvent struct {
 	Ts   int64                          `json:"ts"`
 	Type BrowserServiceCrashedEventType `json:"type"`
 }
+
+// BrowserServiceCrashedEventCategory defines model for BrowserServiceCrashedEvent.Category.
+type BrowserServiceCrashedEventCategory string
 
 // BrowserServiceCrashedEventType defines model for BrowserServiceCrashedEvent.Type.
 type BrowserServiceCrashedEventType string
@@ -2309,6 +2825,8 @@ type BrowserServiceCrashedEventDataPhase string
 
 // BrowserSystemOomKillEvent The Linux kernel OOM-killer terminated a process inside the VM. Sourced from `/dev/kmsg`. Fires for any process killed by the kernel due to memory exhaustion, including Chrome renderer subprocesses that are not supervised.
 type BrowserSystemOomKillEvent struct {
+	Category BrowserSystemOomKillEventCategory `json:"category"`
+
 	// Data Per-kill payload for `system_oom_kill` events.
 	Data *BrowserSystemOomKillEventData `json:"data,omitempty"`
 
@@ -2322,6 +2840,9 @@ type BrowserSystemOomKillEvent struct {
 	Ts   int64                         `json:"ts"`
 	Type BrowserSystemOomKillEventType `json:"type"`
 }
+
+// BrowserSystemOomKillEventCategory defines model for BrowserSystemOomKillEvent.Category.
+type BrowserSystemOomKillEventCategory string
 
 // BrowserSystemOomKillEventType defines model for BrowserSystemOomKillEvent.Type.
 type BrowserSystemOomKillEventType string
@@ -18156,353 +18677,355 @@ func (sh *strictHandler) StreamTelemetryEvents(w http.ResponseWriter, r *http.Re
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+z9+XIjN5YojL8Kgr+JsDRDUiq73HO7Ku4fsqRqa1yLfpLKnumWPxLKPCTRygTSAJIS",
-	"7agb9yHuE94n+QLnALmQSC5aXPZ8FTExXRYT29lxcJbfeonKCyVBWtN79VtPgymUNID/8R1PL+CXEow9",
-	"1Vpp96dESQvSun/yoshEwq1Q8uCfRkn3N5PMIOfuX/+iYdJ71fv/HdTzH9Cv5oBm+/TpU7+Xgkm0KNwk",
-	"vVduQeZX7H3q946VnGQi+b1WD8u5pc+kBS159jstHZZjl6DnoJn/sN97r+wbVcr0d9rHe2UZrtdzv/nP",
-	"iRRsMjtWeVFa0EeJ+zwgyu0kTYX7E8/OtSpAW+EIaMIzA8srHLEbNxVTE5b46RjH+QyzisE9JKUFZtzk",
-	"0gqeZYthr98rGvP+1vMD3D/bs3/QKWhIWSaMdUuszjxkp/gPoSQzVhWGKcnsDNhEaGMZOMi4BYWF3GyC",
-	"YxsgDl+5kGc08kW/ZxcF9F71uNZ8gQDV8EspNKS9V/+ozvBz9Z26+ScQ9X2n1Z0BfVSIY55lp3OP8CVI",
-	"Svb91dU5S3iWsRmXaQYpu1ngYW5BS8gGIudTMANeCGaQsFZBmXK7kVwi2zlxwxyJqFInsOUEOPKSRnzq",
-	"96wuZcKtA8fy2a50CUxM8Cxuh2wiIEvZHTesGsXSEhxijfgVWCZyYY07ngfmjVIZcMSJjRAKboVZkYOx",
-	"PC+YkOyjFPcsF4lWBhIlU5xtonTObe9VT0j7l5f19EJamAKyKP3ltx7IMkfEFmLkcNLArLFayOkKCVgT",
-	"JqwAuSU1nHis7cB456AHSCoFX2SKp2yiNBuHzY4ZuHlNhEBKjSJmlEfA+BPPskGSqeSWhe8c2zm0EUVq",
-	"B9lcZJloANWfUJb5DYHQrUeLiAgxfChAHp2fseqrszQskjtZAinTygmNPRhOh2xcaJWAMY7Px302tvwW",
-	"LhMNIM1M2fF+YwcBL4QWMDa6voOc/52J1EmliQDNJlrlHcwWvs5FmmZwxzVEFzWW2zICVWTroIkZfcUS",
-	"lTZnqQhwiaYaB1mCa7Vev4XTNRTnyO3S8uR2dYvHJ+fsopSOgYb4yZXmCTANhQbjQCSnCJv/4HN+ieNI",
-	"Thn3LeMWf3SjUUpLor4he+PY3LDSAHMrSJ67iRIl3c8oyTW3M9DMzrhkRvJbGCXcoBxAWsB5j2da5cBO",
-	"YH6lVGbYuVZWJSpjd0IDI5YeXssVUnc7fKN5DltoFjzNBD/uM0d9OlfGkhZp6Y+lJVRW5vI9Uf7KIn8H",
-	"rQY33EDK6ENGPMLuhJ0J0lOZkFE66PcmpUSd8p7nsDp3AxPhQwdf6DOlGeSFXTCiTBQMXCq5yFVpqo9N",
-	"lITdbrY4jfsschb6On4a+u0sjdMe/XeDHaO7K3W2OvzjxVt3ZHf2IEb8bBORxRh1icNaYG7sk5ZrgaTf",
-	"xneM1do2wpLQXpWEJOxZxm8gQ0Th9pGpLHIgyUBuFjJhCS8NxOVdwXWwIrPsw6T36h9bafBaInz6eUXB",
-	"4JStzSAl4Vbwr2a4AswGy60VRIVNZvxSZXO4AFNmtssmYgl9yoz7lnFrHWkzDRz1BGeOUYUDoSptonJ4",
-	"lEXUsa8vxlGnceTRM0L0jDTC7KkNpXVY2d1mCiTUMptix+g2ocLXARhL4sxT7BxkqjSb8Fxki6FTWmmZ",
-	"gDZMOjBnDpGFVnORgh6YAhIxEQmz3NyiKDNMSKuYnQnDDNhXDNyVstDCAJtzLbi0xok7DYFDEpVlvDAQ",
-	"BoLQbA7aOMVwUya3YNne/Gt2wObf7PcZlynjcuFE95RJZVmi5qgQSeA44J4op03eWX+gPisyLiT7cHyx",
-	"z4RxtoHSjjS5YWPltPiYlHCgjZnfWc8hP8Bs/nX7P79xlFBqaazIHDlMAay7hfZ7OGWElvq7m7Bo2pEE",
-	"MZZr6zgpJjhWDFm8Po6cqba6ENJjA3X4LZp17go64SIrdWXDnl5cfLgYHR+dXx1/fzT6+P7yw9sfj757",
-	"ezreH7KjG2dhuUGmTJylu5NxebV8Djb204xf0Zk10+BAjPKyNPwmA/cD3pmHbOx3Gvta+kPtGQA2roHh",
-	"dj128kSVth6XihQpicY37QKnFUB/ZdgdF5bdlOkU7JCN+Q2XqZKQjl/5T1jCZQKZu/l6XVjwKTDJ52KK",
-	"YpDf8YUzwwe4Zpve/LGdIKMjOTDSJnv9XrVYlKQc30UvCx7L3BgxdTBpWCjsQ8F/KaHvzNtJSerblIXj",
-	"CuYEqxlomIAGmUAcpXdwY4SF0UyZiO77XpFlWkHhbgYaPDyJ5Z2KQECka+cvuJ1FrkHczrafn/3/S9CV",
-	"SQn3SVam0WVXDIKGrHzAlSUtjpWUkNhurwnce2dbkgnHSMRySWmsykGzy5Mf+uw844s7LaYz22fnZVGA",
-	"BdD77ibi5oaUkcjEW8pPcHOpUF4WWt0vyKEkDPvx3aoq+GISrJoEaTHycH1ySyAtToRJdiWItBoDaX3N",
-	"34Bqds4FXW7wa5HnkApuIVuwQkMCqeODceOw4+B5NO4mYqwGnj/OGl057RdDdC3V1Xh+fsJ7oPVZb3HJ",
-	"AG1t/+m9d35i95dtHHg5GMOnMEpUGeMxuv+6uR0T+Y+dRZjxhVPSqP0i64JAZ08qNP0t7inQwE3stvzT",
-	"bLE8J0inhNiYGH2UZMo4Qwa/It4XUliBhEt/VMZZSGVB/DlKZlxO0QBBJ5Moc6YBbURIyc4Agxa0s5dR",
-	"U6KcsEoDS9WdZEY1V0tUmaXOJvc45lMupCHvmIQ7FtZtbgHNqvGr6jeWCmfN6QBXVpR5QYYYnVVJC/d2",
-	"VJlK/sDBSel/R7atzak9uyiEM7IW/umAmVlp3RH221ZUE5S9fm8ZUs0/4Z7QKbK0o83s16TjZXKrKGAd",
-	"QyppVAb48NXpO7ihbx1E3MfemFWaOVlWTme26c6E+wQKIiryXZ7mwtYK4045NWKFTCwSPckMQwoiFRM0",
-	"9CyJTTPjBZhh5VD16x+dnx1zQob/y9DfGXiWmX1HWu6GaFgGc8j6zMG0z7ieGrquoc9lhJ6Yeu5q21cz",
-	"7ehxrzpb9UtzapozExL63iXZ90cZlTqLrOM9uM6u9++T7vrgrSUaybgGxvESE/PC7qLxlrH6ReF1KzyC",
-	"lWfCp9Z3UUTs6l3EkcckHHqf+su+c0fZEbbNsophuZ6WuZuZJQp0QmY6HdAM2Tk9TTAls4W7vEhPj55l",
-	"u7iv5c1fvQgu+W+JSSJenpY/v+X/blykaqGCNIUsuvXGl1g7rixRVsR96gGKbhCb88xdVXl2xxeGXZNn",
-	"47r3KChGXw9W9/K28Vjw+QBVS7mOJ4SVpwNmZ/iwpeGuvccn2FjLrxOk7dZe6spp3+8hb63KHdQrwYBw",
-	"39R7FpLdKDsLwrvgdmY23+NxnVWJ8fOKzHirplsr5ExNSdvWGjFT0374fSjkRNX/dce17DOwyXB/+ARa",
-	"Jmz0i47ZqGMyNX0mDdNCwh9Lv+ykJtaI4U4r0M3RZwU3Bm8nWpXTGSvlRGQWPfEoSujte+i9r2N0vKvS",
-	"e6xaNoC/MzJ34QCevmY8yxg60dmyNjDOlgOumZO/Q3YJ5A0xBSTVI+SkzDLmCIFsut9Hbr3BoK1l9Kxi",
-	"Z7O8IoT0t5BbLSpa2ZH/yIupcLdCTqvDs4Jcy5UU1l0xpFUI/uOT80HQDP5Kz86CB5luyJbrKdg+xR6Q",
-	"Ae7d3XgXKVQycyx9NxM+GoJ2opKk1O5CGLG4caqoN9thGX9tBr40HPW0mbhuVzwF3TlrqhLCFX3XmL/v",
-	"btSA7xvAk1njdNF1JJ+PDPyyuso7JZVV0l9ihUzcLRFfr2pwUZhhEsyNPn3m9gVptQGrigGSR3NkFAhb",
-	"iEzvH+iES/AfNAONPIfROg13RhQe9FV0/kCbfqLGEnvG4j3Ne2Lqc5pwUM4sv9lft2JQBltw9hWOuHID",
-	"1kVpaMhgziU9v82EIVJ+Ta8P7oMJxnFUOHG8gL8R6/QrF0f1Ldg7pW8b3rL1QqGBrCZg20euSXCN+mrq",
-	"/x29gFrNQXJHpDlYjiaBx9zCUTMxur+wawbeC1Fx/qrpA3FzKzw4N14oUXJgoIx/luzSTWMEb1N6VT4U",
-	"BHWccG6FTLvsk3CgIfo6g78tFtTl1Vjlp/fCdcjGFJg34oUYv2I/4H+wo/Oz4NDac3JGz4FcqvTHwRQk",
-	"aLSxws7ZGO4tSEcI41dMyH/Su4DfT/XbkI0zlfBs5MMPx6+YWRgLOfN/YLqU0mGMZ0pOjUihtd22Uy0t",
-	"ev1evX/3U1io52RrY6Ho+2QglW5iixgpm+ghaDMiBietiA8OPJ8ckKo4O2nhO/DCEm8h8tdwzPfWFt+D",
-	"0w2m+xBWlysMg9GTMxrJcl447N5xnWLkwUB4SnG7d6JNlbYKsCAlw350V1+DXqqGE5SsPHZTWpbzBbsB",
-	"xuWC/cflh/doIrWsnpXDYHw/RXwfZyK53XjjKfHa4z4NlgQvbOmsvLngNRGitKuj6B58xYnu78tFp/Oi",
-	"I2p4jRBLT33d6UbIE196DGSQWBUJ3zy+vGThV7z1By8uHtgJyAwtpQ6bYBqLa373llk+bcVeLs3msFQW",
-	"BWgM6yVJ893Hq6sP7/vsqM9Ozn7sMEKi1viPwgj0Pzux5VNnOhbuM6vx0TY6/X1sbrjD2I37QaKUToXk",
-	"tn0qdxYHxULcQ2bibqbFmokXD594ifjue26lfo1twtDae06DBH+AxUaJdQuLG8V1+nvLq7C3L9JqK2l1",
-	"C4tnlFUtZDyxpHI7X4HaD7AgV3Vt//3gCZEAShLk1G2xz77jya0peOLuzXEx8gBxGAQXen9n+ECflIa8",
-	"vJQeskAyKTQY0yFetheXOPl6cXn2/vzjVZ9dnf7n1dHFabfQXDbI4BES4jLRKssuwdoM0o2ywuDXzNDn",
-	"XmKEmwuf2PqTQhnRyNXDR2Uhp/3fT76snuyLpNlK0hAGRx7Jzyh0OjD0xOLHyZdRxAyg1dn9oCJVn91E",
-	"kcP1M5H7agrGUe02hgGut+hcb/HU63mXxgMEIK21ySBUMeC9wUhkswpClAFu8nCCICu2OYmKwa211OJJ",
-	"llpODCIKqVDnD+03tArhtbL1rZiDMwQ3RLOyTMyBzQXc1SFFSyGq7io8KbMgfL8y7Ce4ubg6rtwg7+FW",
-	"7Q/Z9/47JbPFawzgCBJ5ojTOkoExjNIcHyVdY2f7IlQ7hapD8cih+LnCZDvxsXu8YnBft4IVVw7QHa+4",
-	"zj3+tiL1VSf5kF22PNhVSJ3pM6MYZ1ZzaZBBghP4JhMFS7hEMseALe9JrGJ4MTB3XG9pvJPHeAuAbw5O",
-	"XuXveHDytkxeBynHsHKzWDnuo5n8S0jy7nz+fIHJ67Dy5Nz+BwpQfqhcee1LDIToZE1p+RTM3yXXdnxY",
-	"2jK15R09Fp80+L9Dalz5bIUGjKwKDxaOFTJl7JBdob1m9SIIPu/XTrUqCkhZKa3Iwhv1qJKo7oqmtZiD",
-	"GbIrDdyiI1zIQaHV1N1xQ2EXjAy1wPa8xB2JNMMAhimMMr5QpQ2Xg33GDSulhkygEKeV7Qzko0RQF8S+",
-	"yKBOGRSw3dQyTy2D1qJlkxBqE0NX6P8F/r16Oa9Pgw88CXLCqArcrx4Xq5e68Muw+Sa3NGozWDaHpXtQ",
-	"nElh33CRbeToIKAob8DZ6DfgUxYy8Svt97HssrSZL8yykVkcAkYTBNkz8UoMJ7txirFQdNNVDnamMIe2",
-	"IiYfIGOhIM8mnc+7GCmAY2jAHpVWHVnLk9kWLkbcxObTXgRVsxVPRLVci0E0DAADXISZVQ5GuJ/x0lh6",
-	"kM/qCwN5VDDn3wzZe8UmpaaSM8vq8k5kmVeFVSKgZ9Cn4MMYFL4w40ZmrBD5vBzZiZ1nUWAt6vTZ6sP6",
-	"ryNPzE6VETE7Mg1UzO5AA8NXg7Kogh589vukzLIFKjylQ9GmNlc1dWBkxSdUgxfwaMt26VQRvufL1sAp",
-	"cXNwdqVlBYcpLzAKhMzl47ZVixUtDFj0LywFoQUXg9U8uXWzeaOBTTSYWbi1C8MKJaR9UmHxRVDsLCie",
-	"X0Y8Rj4Ehtv2ooxF1ZauxMzyW0BWaaSaVn7vNj9sA9QVBo9tcjN86qp8ne6vArRQqUiYqb4NHoDwmDj3",
-	"4RJPwUZLO/rCRRu5qMbLMzFRDCW78VAhI4/r33EDf3k5AJmoFFJ2/v5vW5JYBaubhYWNFq9be80Z35Oi",
-	"OEsz2PhoHpSKSENY7dKTOWffHh7mhv1SCrCec8jXKxUTcjDJxHRmma8uiZHRj3vHWXox/cImq2zSdH09",
-	"NYN44nmreCrkdO1daZWKMhoVrnU+h/1s0ioN4EDMMw08XTigeALCyBZnhXG897lLoVSs0EJpNg4H9lOM",
-	"cY7mQ6Kw+302LnU27rNxyDxx/64SRsaU1TLW4HMwHQDGjazx12wcoUDMdSq4pqLRrFBFmSFpYJoGtyzh",
-	"Bh6ZcN4J8i+aYiMLeIp7pmvZesw8cSwIFa7YhKgmF4URyxlgGEoxjVRCbeCL6qjFA1zfh4wWzOhr/OYd",
-	"NRLsq1enFxej4w/v358eX519eD+6OH3z8fL0ZPdCyI7nI4WQ8YUk3JmUFlMhOfpVlmRB5+OIW7XB6vGF",
-	"/UmHF/7Tq0UBjfsxrrCSHdkM+PeJkT9IdScpZtAwIbEuGTvx2Wh99gZsMuuz//z+os+o0kefXdpFBmYG",
-	"7rJ3lvMp9Nk7SAXvszfKjbmCe3vlrnp91mDpfl0tqs/ecSkmuMNzDRNa44OdgSZZlyu9ReXZVm3nBlX0",
-	"a4JcG1PiQRh6OmyrKgL6MBu8I6dodxna3MUX6blRenokPJPYXEHGEwvMkO25sZxClRaKGrtdjMmDICpA",
-	"Zo1MoV323cwyWi1p7MESsomGbiW/J8d7nbLqLHwzxFoaQqbYpwOz9dAQKU37TA8WXMaLqIJr44RJocHp",
-	"WZIqmMwdBZcwIw1UVmsdu6CPy8t74/dryoxaa7AwQ5xP6Emho7i9f2/ghoVSpm5yLM9Oeutvp1d9dv7h",
-	"8qqjfLUydhRkThxnNypdoH5wsxycf7yq7jx9dzg+5yLjNxl06CM6WpxeP5COyzCv9AYmyhclCaMQDXgw",
-	"NJUbwEYw6hKeSPX2WSnFLyW0aqrXLxBf1Ozj1awn435bhNUCZ0UgbKeBqbfDDirYN4PQkICY1xe2N27T",
-	"DV9e9SGSv0OK94TTsD4+iSFVhgxJesB6Go3eONUXlb6FSid4PZtOX0bHEyt1R2JRzHjwt2ixlolYAwkl",
-	"Ctxb9u7s3SnVGPld9brfWVOxb6OwvJWiggJYZ5LkIu8StNWhw4QVqEj7OcgczGye9dlyk68vt7Y/vDp5",
-	"osY+YZqOm390rkZ6/ocf+qxq57b/UK1X1d8OjLhWvZ3zKZyo/JgSbd8qnm7hkTz58K41IFT4cuTjJhym",
-	"1Yw4F6q8x1X06tznF63VqbUwbDNV+cinUaM/7+n9eOtR89R+vLQYVcCKCDCKK8hDISFGL6yUbyokC6+r",
-	"3PoqLCukPHFA6GOhYyvmiNdA9iHWkAID9pxdhqjCCk77Q/bRABtbQ5VV7trvu5EQ5+Uy+q2TbWTatxiO",
-	"u236JgXvdqRvvvBg8UYpejcxOLx+ibKg54ClUMJMMzHBe1l9UZ4LU3LsF3YjMmEXQ3bKk1lrAMVf0L30",
-	"xcCv6g6tv7xq/Q6yoB3C/RxywFOlw/XmEpFlXnoma9HI3vHby31PolW2zDloPLVMgF2JHLA92dH52aOV",
-	"yvKOv+iT7WjIAez3oKBn8W36mJdV6J0s5ay0CBOk1YuVQJ09X3D3EMV+SzyyAjSWXNyPZrg0QTlKwXKR",
-	"md1TegJbNADHuLVa3JQWzAYOwiOt8tCMpyMNibMZhCxKu56OW0DydRMSSOnpDMsi4STB5YUhD33fYMYp",
-	"DuH5/PjtZZzOUX1HsoCa65pE6XBPEcbjas9ZPgiJEHf49nI/ropXaNJflHastBhqPuDf6+LHLRBVhR2j",
-	"Wdci1goyiryayWPUujnHajnUe+nAfi91ttMWRklSbBT7b7meukuqN7smZcbOuXDXh7fH57+j3Pdb/SLv",
-	"N8j7pHgWMd8E/xOL9ywpHihOPW3WpEmU+Vhx6qssRKWISOvpAx+/PT6va1yJSfDDdRZtHcWFhrvRVB17",
-	"l+bdKgVTqrRb9J18eMfcBxHp11inq/+LTEF3bPsCf9x246+94qV2bOQV8xUPqsD5K5ELOR0cZZm6G9BT",
-	"UDzlVPwK3RXJuAbesSEqOMHMLyVvy/V67k3PqM0ZMejKHYEpzeYiBRV+6qiA+rzKq7k1J7gIe8+gv3Ch",
-	"mJH1YOW1WWMpvvn2XN+Ilx1dWRj+RC6uajtf1NIGtaT481xgWwj4gzuv0OaryfLP4rp6X6XebMd5zerf",
-	"vm/XMh8i378PPUT3h+yYay0A62JXRXAn1OhISJQ+N1hG1jJfCrrPsCtJKFnd9FQtF2t/NJcvAeALr6/n",
-	"9Rr+z8HxMWTslq3wMC1bd7zFL3atyP8e7tj6qvys6mhb3Yo3FOanFvNrrAbfMH7lSNQX94b+3ihF/9qH",
-	"f9MOIkX5Oxoh71xx/8nq6v++5fJrGrDqyWrbU7RLwxKqqWhrVlj/rhD65mFUSscrU1Xaf8nrzGZ8DtSe",
-	"CPVV9bRs2rTTelqoGhgLwxrT04sDlvrGuDB2JlMonHVKNYObqRyvGWdGyGkGzH1BKZ70XJ4qoPZ3N6jz",
-	"xGN73H15jthVrj/nk8QVv/lQgFzzSCbhrjI4LL/BvuQkFxwsFQ4mW8MXUQhZNFeK/oA0jPRJ48w+hXmZ",
-	"EGrIW6VAhKnzcHzFP7eF0CbGqFZJr005N95+aWfbNAyZirqR5pydF8vEGbJjJU2Zg3b3O0o0WrKbsM9C",
-	"qK0/w2oNFosJCetsJ46ebsGzp8jaWUXcFyNpPTNZfjMiUn1+JnqAjYRbi1syVyu9bbyF5HgRg8o9CyJR",
-	"KwkUDSwXuyr9uv1FrFePhLtsUS3Fb57FErDCZhH3CEWfZ16GuG8qKxEFQ3wzUbMiTNVwLXXPsUwXa22K",
-	"NSRyCXouEjjW3MzWCNqcSz6FFCscigQY3AuLVcvgvsCc+2zhdLizIpCqfAlpio5y1MSt0oM6xaDqb8xS",
-	"hSLOt6Bpir//+7//D8Uv1qvguob6PYPOfVggXi0HUzGHQVn44pPUTylVj5RmEfB8EWed4sxTxyghcD21",
-	"OOtCxu61FHGD7UqKS3uviiiy03thMW6Q+i+LqSM6p7Gxau+9U8xVpmEpU9AZtooKfhviHF0VLUpmXErI",
-	"0FhA6qY8AmIrEm520ScHkZhAskic3Tvjhjy6tPPwDsmEJFtiDw36Ks9inx46zk5woxoKhQXWIryAM8fK",
-	"NG6x9JCNkfXKYsxy4NKEJux48FQ4uJAVJTCyVTv7BG0nzmbAMztbVH2asM7LkI39f4cJOSs0zIUqTbao",
-	"xrRWaIug8ZTPYRTfUMBEVU2HOVkSqsVUBXyoyzZVZbTa4fI1k3Vlqi5CoQpV7mJUX9oDWqnEolE52Fmj",
-	"Qo2pLiwVAxE4e/2eh0Ov3/MninaeKqJX/bOTqnAn7TGAYMiObupUmRhs3GKsLFbLdkXBJJx5yjIl3dCq",
-	"/g6nOrrnZycdkbYegJJH3xu0mmqet9vW+GMEePoGaVgkUJS5M67z0lrQ7l/UyGtAD0kDXojxNsXSmnvq",
-	"e65YJ4qw29gHlf8gsmxN/aS3Qpb3jLbEPnx4N7gVWYb1zVB7YT2JCglCVo3Kfnw3ZJfNrsXjgxTmB7e5",
-	"mY7DDcWRGZc1O+DUlSjya3pNkUOu9KJCKF3SQxSH9177xyH0B/k5sRQrt5W4M2XhAGXismQXvboCvy9q",
-	"tVutIrBGSuUjh+MnV6txXOyuVd3mlpRqe+fdlYkTJY3VXMT46KdZm6IhESndvwNDDdlYKglB6E8zdcOz",
-	"VZp/zcY55ElDuSRTrcoifIkoR5KYCfuajZOiNGDH7ADHKb0YFSoTyYIu7O8/vjs6oD8MUi3mIJEDayGr",
-	"pN+yYSrDd/EZl+zb4aF/A0pFWlX+900ldJlQo5WxUjke7dWYZUJCW024w2LiQJ44DUH7pD/Uu+xoVZiP",
-	"JhpgdHsT6dqgAUIfRQ8SIdkP4rvQ9aL5sO8212cpaMyQq4Irxm72V+/Hnr+EbKDuK8PeQT44kxPF0jIv",
-	"huzImDIHh4mXuA6VZxC/wpCdBOdHSEDRkGRc5FizOHFmRKg2b3KeZf6tDeOeOcvcFQixNrLK8mx0ezPG",
-	"isvGOhp16CeI02Edyt1SaL6xGdcpNRDCwn8em152BCJs4o5TRjDurDqg8SW+mq0KGzze3FpEWrlfHo2K",
-	"9whPwy6O3hEVPQIdzwOFTfaLV2nBfInPQT92mBPHKs/jszGMhyDLeElp7uX8nr341tnq2vQbCqL1WUd2",
-	"mDFRlF6AQeueGbCkYeK78mjeMyXum0slB9qYPpuIDOhfaKHOcsjdf+4P2ZWzNX3OeDFbGJHU0q9p5Dky",
-	"L7ErcwcRdbV4KUaWm1sTo9OC1abCDda2xFMODNgBntIvlau80Q6QKNYQ7N2U5NdfsnlapDq+cluge8KY",
-	"+VeD07ywi3VE6Z1R7ttjjiY9t+xbDFXBHt+K3agSnztIayGxI7FW7eV3tWbcPpHD+f0ZzfHtakt6q8V0",
-	"Cnq0iQH8d40L5Tas6DsUydRJsvHx+cdX7L2zx93/OIZ4NfbJmA3dEsF72OPWDFYR2kwZYDzLFCVTVu81",
-	"jWIMft9WMSHn6pbM3tpCHrIPE+svKfi+xA0bN3cyZnuNaTwTNRIdQe9joEDCJUvFZAK62SUOByW0Tf+z",
-	"g+lcJFbkQ/ZuG/6P9t5fLknXhB3Ju0pEbGuSIUHtZo0dVQ9mHiMUm7WJq1ALrNhm2+P9MXJzEyes1QHb",
-	"C922Fl2VSlu0niIkeoxuxmXDjbzOr93MUCZnsrt4ebfoUovx5vNBr9+74cmtM2RlOvJ/CdfZO6VvQbs/",
-	"zLiGtP5vrFYStRDDrkMB7mNuYaqctDxWciKmD/G20RSLRlVv31EQ09qw1bO7LoSXvK5LAi/EznFdy+dY",
-	"+FOs5qn/0PAbDDK+AM14YsVc2AXhAj0RpbEqB83Q4jevmJCkQI7Oz1jCs8yEd8EVN0ToDuS0d9VffJBD",
-	"Sh5xB5FkxplR2RwaRdEdiRRa3S9wYLbSPqV2Eno/FMcWdBPNq+tEPdLbf5T3MlAy3NDGLODICbVP/Z7v",
-	"KP+M4D72PetVaYvSsr1MTfvsjmvZp/pq+7hrJ0DK6cwyuE+g8HEnWBio6kj4jHv8SBkw1VIBxHvYGNj0",
-	"2S0sUnUn3U0Ee93t4+Z88MIzbqxZVvSgyksPfeiHFBE0fU70nWNg7TLt7TWjQKg20lLW6dvjcwekT2vk",
-	"ZccedpM7NCjkhKGrLOjEphTyRL8a9y+d0ZjGnBFADQrQlx8EG/6beqQO2Zlk7QpIKhfWB8MI4y/GKUx4",
-	"mVkSF7oEtldN5tfep5mOro6/3zDXntLM+MgYbLHmjGKCKxv/9mm8j3ELTKqBKl6TGAtrabBcSIOecPTr",
-	"O11Jrvgr5XfClGapMNTxrR46F5x212cLVbK8pKp1KW7hvshEIiwbu7ON3QxjRNO4ZTRVLrWtyOEhZFC3",
-	"XUoiBOEVzpC1tNSybhqyD3S/rb5AeNuAqFeEQKuqkcIO2WXzA9yb+4JS5+iLD8FUb3T1doaa0JAtmtPx",
-	"LAtrCzA0NcfHhjk0fsD5V1ZMMuD0TG7jsIh5cv2Otn0o77QVoog99m77wKJw6uT9joh9Q30ZyKS9wbZh",
-	"KQsPAtUBAR+RvQfJeL8bvWhRZdRVzs/BGC86V23U+GNZtdqIps55Yaj+O76ZHLibO+lZ7y88qPT/QaGV",
-	"+/kgFabI+II5xfG6ii70E2JpOMeoPujOoYJb4ZP1m22T2jtBM7U5U9Tii3er+VD4l/walsv9aYatlytV",
-	"jAL8qZaJts0/+I5OCAAH6n6vAoL7D3/+8KEo89Ek41ND+HEg2uz2DmcOKIwZ5cdOc79TpQFfu27HaJib",
-	"0tpY+jFOyehXutSS1YAeyQacMphYd20Q0xl6bEWaZsGGp9eBO67TKJ7Q6Ogo/3Plbw/4DfOGUb2qM1J6",
-	"/R6+LOIn0QVmKktHt7AwseOlFHPjfnbnc98223fQrA23yWoAzpILRJb5iOwoWg71Ye/Vi2VOf4+ZC3g1",
-	"Ejl4xiogGOR+3dU7YaQD8n+yRCmd4sNb9baIEAsdiqMzRQpv/ddDZloi1/uem7qDSAtsq+/TGXek0XgN",
-	"o2Ov3pMwORUw8rG/myOM3KTRzVKrFn1UW+MPcFT4Noba0y7pSkhKi56fwnfb5iTqh+xqBmxMpcrJBqJG",
-	"z17EX8t6loLy18hrutpXkkY7IKAdhLcjGltwzXOwoM3wWp7e88RmC6Zk9TuNbFX2wjs8GkI36LCYizT+",
-	"UkqsnDuZsUnHrgqsT/1eqvl0u+Enmk+XR+dqDtuNfqfmsDwaX0acmNg0+Nx9+AMsGmPplrRpIHVdbw4D",
-	"O0pKbdRGi+QS7DF+2BydASm4tQPdR56EG0+wqy/6wU+zQmEtPdzAbwveNHOoJF2DsgJNC7etk4eDxCR3",
-	"PemGYzo9cQX3tgLPMpfHq2r2e8cauIUTLKyq9OJhyjNXKayxNNIwO3Mfsj2V4CsYnrLPMObj37/9dn/I",
-	"ThqXp3//9ls04ri1oN10/88/Dgf//vNv3/RffvqXeKqMnUVCHG+Mypy0qTcR2u4nePSlRQ6G/7rZ+etW",
-	"igHzBDKwcM7t7GFw3HCEsPEUl3n6jV9Agrpv+rDdxxy9ZyshxDos0jgJO8qKGZdlDlok7hY2WxShb20D",
-	"/3zw69Hg74eDvw5+/rd/2S7r+oTMzy3vmEslVwCNuU6FG0x7+q5OOu/Ir8e2ZSPNLWye0n/NNDZJk+z7",
-	"X9mebywsyyxjYoKPQilYSPAZbD+66J1IYwS1vBp+tnb/UdAua6DnMbid2Owwtisjm6zumABNwV0+mnbo",
-	"4bKpcuI+WakhdAP2DkCGjThD20cQcm099Tr5z3imqnQoi4mouZAidxs9jOFkbQsyH3iPAQR1t+7lvYX4",
-	"ePIpEITcXvIqBNDkStnZ/8Qq2eSPQMdIaVXOrUicxe3OcMMNpBjBiguifMlATv05+D2d48Xh4eFh41zf",
-	"Rg/2mFuGO8JOl4y4pPygsQoCy4RBs/If9322+Llp0hdcaFPhLtRKvZuJjDYxxdfqd87U87Yj45ZlwI1l",
-	"X1OnQXzAqHa6vOVmKEj1UPw1Aq/+j+XTrP2RcNmiYYfXiE+bzcqcy0EmboF9B78KrOim51BTM2L4ji/o",
-	"IExIY4FjRd5MSODeKV6ojDxI7Cd8WXWroZPAjArQIwNTpDRiByhGyGSj3D9RTKVqV6JoBNi1Pm8d6dsd",
-	"+bJKqcd9rWDwjHaxyg0b+XPlnO1b7GH3NbbaEtIW7QvLjXl4+UcaFBPdG2TvaHvsRWuvLzY/X3Yp98oN",
-	"t61DbGnidW6XU7rLnWd8cYdSeFtlEO830Lgd1lNikH4ksjDt8JdQ7eKD/+BzTv+kKP96brpm4h9n3DCO",
-	"3U7d718VfApf9dlXPs/uK7pdfuXdpl+xOdfYXN9fHfMig1fsusfvuLD4ujucKqv2vppZW5hXBwdA3wwT",
-	"lX+1/5ppsKWWrPE5Zhbt7b++7sWCDqhkCqXqJi06/MsKHb4jae3PiFcY38QyBKkG85oJw/5y2JLw37Tk",
-	"+2ZaQ+BvSQ8GN7wjOYQGGUtUUJ9u9WUnUPlS+C72dPIk7OymGj6+h1a8Jrff9Oo9keIRCZN1BARubo+S",
-	"4PZJjKSgI/u5DOE71GyqitxoHiziyU1VrORfNZl/bN1yNmrvu+4NDJrQhrTVETj+zNMKuvcLxAjkjcjg",
-	"TE7UqjwSZpQKvX5XqL/w0au6znU0TlGdJbicKs/RIPFBTKGiShXBnXILA19pbzXSNip33LHodnsjrM+P",
-	"67PrXqrv7vXA/d91z11srnsDfTfQA/d/1714xEw8Luc7bqCVPDER4QlvFRJb34qDzbpKJOJXGN0sLETo",
-	"5NIH3ODPQ1/tK2xDgNki1ibETXG06xuL9QMdNHDogd5FThRU1ZGs8aZ6o8EMrSl0Nd/ahvz4ZELpilvT",
-	"4UNxWS31UKTuRiVxt5hPfVgU0PSBHV+cHl2d9vq9ny7O8H9PTt+e4j8uTt8fvTvdIo2BMhg6DRbsU7D8",
-	"BtmB3xPh/ivk3JTSV4qtigdUb6PQ7lDu5TYFB1Fptzrgllch+zxjlt8rqfLFK0zKoRRW32upnt1YDTz3",
-	"AZLjlFs+xgc2pXO0LJSscI02hNvKDWTqju2Rh5u2RK5v/64/7obDuM80TLlOM2e5qIlbmBVlaNIu7JAd",
-	"8ywDPaj/6AGAz/sfLq/YQbX7g0aEEZUl8EkboRqCMATZ18wAsPHSXqr7KLaeMjNewJD9yDORVoV7E9xM",
-	"iMY1jE+5u3vQ1AHAIdQ58WUPvjKhNUN4EUUbKa0xTgo/50UhqD0xL8TIrbXhYfuoEA48RFL9ng/RGmGI",
-	"1igo/7UzHNOQSzeCrJVqsrQY+U7em+ZIi2P6sDm2biS+efhJ9W01A0Vfjbw1tH4C+hYtpOXxmZpuN/qt",
-	"moaxjYAqegDcMMNZ/T0+hsTmweeIbWf5ARaxOcgDXxU02Xo6eq5o1d3p9zIxh9FcwN2WSH4r5vCjgLsl",
-	"TNfTbI3vMNMq0kMb8Xqqjcf0fcFPGiOWZxNS2NBndqvJzqSwzQbK9VR1b/td5qs6/2+YdOf5VudqNGB/",
-	"SIv7Xr/do3qrTl91v/J+V3vfB/ZRbkwYOl7u3E20NYdvsbV7A7Nev7PlyQOby4QZlxonbN1VoM3Nq/Xz",
-	"d29PUE2TFDsUua5GKZ7uUoU0jGtU4Nu5uuHqHDvAsaMiWX+l5s2u5YQa4e2hzsTONTzcHEtJtbvmK/vU",
-	"M3czWLxH650M1E/9npKwfcjtsn781N9lWEMpbzkwxsO7Dm1y7m5jI0JotwlqabjluBhd7zA0Llx2mKDm",
-	"yB0GLVH8LsstS51dxgaZs/t6TRZ/EGIeMkPcMNx9cGUP7j40YvttOUmHhbDb6FW7bLfxK6bOA4c/gJ87",
-	"jMEtR7duZtuKzKV71PbDlk3pLUdGbfodxz5w6a5755bDo+ruoQWzqIr0W2EsOtkiDimt+cJd/1fdW0KS",
-	"txWTbyhpd7htcm7lQo68C1fqNlLrLFPT5XzJRmPQtRHjy10cptWLgoV721l1v6Oq+JXIfQ+aakfUo4dy",
-	"Arf1RXc80zWXjnnXMMDi3EezXlS2/bI7ftsw2xDE9vDw2q4Ztg6rXYlm3C0S5QkjMjC875GxGKkwlssE",
-	"Wg903z53BIbb804RGI8PS/Be9DoGwf2TS7sExbhjfRN51iEegcKYVQ8i021n2olcHx4jmIKxo02xjmAs",
-	"diJWsnrh2RQq2O8ZnWyamIoObT3n8rtgWKDfOEUMQh9um3Jph4fjv1FBXPbhh6qr76pcV7cbqfaMCl2D",
-	"CS+fw82vnuo2epZzbpOZD0N8GMa74hBPuuMPK0Hx9cvD3aMRTzqjEIfsbEKpipD2WUl1xIDNxHQGxtZ1",
-	"CmlI3aIayccrWf+O9JfD/jeH/a+/7b84/Dm+RQStd6htwtfERylpmJSUH6cB6wKgCK6zq5WuA1APNOAx",
-	"haGEcIhLGp/tVec8rQa51qtTMb2QCefL7dXnD2+QmNFnKKWQ8ZQXFPMs4S5USapDNSjjz8FyBjydlFmf",
-	"8hLDX7IO8uwM/zzpDPusyOabrw+3CwJdzgV4mObdEKAZtG5QW5SGvzAUlbncmKhBog7dh336lmtgFkvF",
-	"bI4BW6NIq6D2fJNGvYUFVZtixgHHa/TtFWx8/bc+tNHNbhb5jaLKBLiQb+/rlgjlwG+A8ca3zJRFXRnp",
-	"PlVWqexa7hkA9p8vXuBZFjlLYYIlfZU0+0PmA53qlvHXvQsMf7nu9dl1D30S9M9jqzP611Hm//Tm2+ve",
-	"8JrCGykCThiKz0xwgzwzyu0yUfmNV1nG5wTQfP9mQ+QE/heu9m9X/Aan3QGgS9IaoRuV11SP5PQekieL",
-	"ZePueDnGSy6kkyMSC59GKmHoaTss8h+R+go0E9fTsuo/tj1VcTPSSrWDGuPHKNuVRLECmxvKCi3mIoMp",
-	"dIgdbkalTzJeP2Vo7+O+dlPJMkPtEWT8aqYknT0SqYCADkntZgZZVoHc6YIy3l0luYtVAlAay53Wl9U9",
-	"3oys2Pcz+rdqWoTa1y0fYLPNBXLeTV6/xeLZPc5++7SMsFM5F1pJvHhUcYpY9tK3Q4hX26kpfyXWcLfw",
-	"wm4EdkcREjo3suGjQgh5k+kqhFXniLSOWncfPK3O33UZjFcygnthR/GY1fNQyykUpO4or4sRhaObv7yM",
-	"BxT95eUApBueMvqU3ZSTSUf/HIoo3HYyVdruyT51Y+8HUaf77Ya+SyrHjdQrq54cDepto4yqd7eEWu/q",
-	"9OJdb/28zbAm//kPZ2/f9vq9s/dXvX7v+4/nm6OZ/NpriPgCTdGHahOqtsfOr/5rcMOT23bZxOWY6MzE",
-	"+1JVVfUTlZU5NXlaF+/b72l1t2ku98mOQeo4a582ugZilwW/k02AbVXsJqK6Vzv++ep1MLJ2sVkLHvmv",
-	"GWeFgTJVg+r0e+dX/7W/LFjrWh11faE5kEbqUJdxpIWmEcuIowtN8xAYNrWc2rADSldWcp89fJlP0V6D",
-	"bbw+QJ6fNRzG/MYJJM6Mm20dP0Rrz324rJDVVck8VPeLDb/Eal+DqpNbpG9JYz+VH7csRRoXxNg+ccRt",
-	"3E9MRadX6rr7YTu4ijtZzXJb7tqV+bhRUqg0pGW7pVJRjook1rTMWJFj3Obx+UdWoj+9AJ2AtHwK0Z69",
-	"a9Ro3c9BtKsXzrjxfU22sVGohG9H5HO941AQNdRjpd1XQdEdGjzqbjmvcWpbkbZ1rwDaflwXdSM2FfJh",
-	"SueEW+4k2Z0W5ABdIj1KOhCyKG288+ZWhkXaXGVzKf9q3p83nvlR9qLbjk/wNG661RO6LyzILiKpM8Lw",
-	"A+Y/H/a2dan4o2jgdVT7LrbT5WlV91aD71TebF3is0WUXin09lhsVg9rNbG4U0RNUIi/071tb2kl/Nyx",
-	"QjTVdyvRUAlSmlwYdo0Dr3tdLOv2H9EC5Aj3Yd+q0X8gmZXytl1BCZN3qpSgLZmY4rYR/4/zQ9yodEHt",
-	"8GjKUE2OACA9dy+HskfEuK+S1rayKdxqxc6m1IFmHb5GKSusQFmXU+yHeqfN4o99rAoawrniud2+m0FX",
-	"ZTg6oeeE4aN7UGxIkVjfsXTbchxUggF0PEVqIiTG8m9jLdR1FsKoLltho9uFzKDVP5uqYETj91a279a2",
-	"Tb1bP+iBm12CM9pczX3GYF6H6lzAdJtSR9s9z3xPzzJV2Yup9xWsKRLR4bD/CR31u0y05eM9zfWV8Y2A",
-	"J05IagmPes7fYc7oi2mAQj8AdhPKHvLwoCtEb6hX1CaMqKRuVzXa9TE3s3x0v/7943ulxa9KYs0cXIvx",
-	"XJXSDhlFcbj7Jf7dMMyU7TMJU976u8NDXMHRDjaUyPjR7TjZYv1U3cnI8mURX/wxAQtVXaXtfd+buKLu",
-	"4l8Vf2ovtTtT7Dzl1lEEKxWxdpRaIk1BbsgBpmiH+inJD9r4FO6/69j2G5HBOehcYKFr87D9Y4OfuH+K",
-	"ev9QeqVmf2td8nfN442UqvrLy5f7u1WmUncy9hzi9oo/4QNI2O/Hjv1uk/NJ6YdFDVt69aQHNnx5Th9a",
-	"NWpNDm6zxNqOReR5aaCZkU/lnAtIHO+nlYt9Rx9988EYa6vFXPTN2get2KrDjUzZXDwKEGfCvDE/cZs8",
-	"aSGwqkob3pqxYGK8eoFjXDGHze7Nitv9fKwamy22CHnpDOBBCDyynBi22I4HqFzUtm34yKF4UjiOnYPW",
-	"IgUT6vJ7COw3cf714SZfadRzGN7+Iz6/hgFLBfyfqKgZbjoQ9Jm8JALufp+r99F8nwpxiuuhsxYgOb/H",
-	"ZHvxK5zJd9917wCDfUNPjnffbYmR5RpTL7YMQLm0qngsoSmdgJtnM7+c5b6vQ7bAXqL4Kq5Ky6aaJzAp",
-	"s6oBsk8mzzGMCl1LQmIcgNZlYSFlc5GCQmDFnwV2qaZHHOw29Iyl9OqsbzmHTBW7xuZdYcUyGsoq97nF",
-	"Tm+N8iJsKWM9UsM/OI7WFsRs1w3AYqO/dPpeB7mSyiopkipYh5HTud4pT7Qypmrg2+yxRXQ9ZB+N71T3",
-	"lhs7wJUHZyc+Gq30Qd+Xl6fBb+TdZcJQZTEKaFlpJLnD85o7Y/Cs/bwWh11B8ksFE6hU0p3QMMhgDpl3",
-	"qmCSPxZOKhrFFDzmGMgUz0MtUUIollw6/ZAd6RthNdeh7oG3s6gHrS+iUJcM0MB4SpMN2ZuVtjLrKjv0",
-	"YyUZcMegB+i8IbJhqUowqAaqDodj7w36V1/r4GDpLyc4byNgqs9WCzpESwW33Gl/DN9ZjZD/uPzwvnKd",
-	"xaCdCeOhtL5MBVXtIWf0MvTbFZtjcCW0+N41z9RB9hJsoBmvnyoncWdDWeskt+/HVjWV3b6nLDaQbbWU",
-	"bXWTbdXB9RcxHbrQ0u58gOOOjWef13dZ4f4yvHM94EWxq5lFpGlUkYkO5+JPPMsGSaaSWwJZfQtvALPd",
-	"OMTh109JWRo2FOerdyRMKI9CjRPS7atGJVUB2p36bvhuGw9WXl4/ZdzYFb1ad2LVYMAG/dYGC90a4w2O",
-	"d7gx+ePTOaK0s1S/emc32uOqvN7CwlitbsFEKzNGYx/i1SMflBUTwvXqfYSsoEZ2jJNE99hWM+OL4bU8",
-	"Wek0FPop5iEf6iANNXr3qbuMk1shnPxa+vhfJwLcWtRjVzIVrjmN9VqQYnv4t/956ODik3b2h9eyUS0U",
-	"WxA4qC0K0hJ3SqfYODSlFzIfUFqdXEir+cB9RQuaa+msAMmpCBOqN/q54KVxeHKGCe3NtyQ2ofZoFHXR",
-	"/kT9jp4KjhQRrlgUnpTBTGHQMrUz6CiipUaOYRJYT4vYlWjGnbp2lvuiUEzIf1JHXcyceM1yYSy/BTJ7",
-	"UE+iRYEwu+HJrSl4AjURsMMh+yCzhRdhJgYBtmdEBtJmixacrmX9GdLGPoGqupkdDl9EqT4EZWzbT+In",
-	"LSxUHTAexujrsdUKVwhF38KCD22E8Qm70tFrHFbrrFoKsjPsAciOzs96/d4ctKHtHA5fDA/R71eAxN6G",
-	"vW+Gh8NvfMkzPMhByCY5oG445PNJIk6fd6CngJkh+CWRANwLg0/6SoLps7JwyoctTRrJR5kLXvX6Vzrt",
-	"E5NhOdJSWpEh5KqvT2B+pVRm2HUPzT0p5PS6h1mr1HXaMHWDNlPKbmCidKiLiW4QnziFxORwSB6MFN1+",
-	"NpmFVd74bkC+Us13Kl34xvFVh5Q6Sffgn4acjKQxIy+kAZpL1kU4EsHQKpYjWH2dxn9c9waDW6HMLSUt",
-	"DAa+L9pgWpTXvZ/3H55nQBuKk1X9neNPSjXCnDVc5+vDw4h/GvdP+E7xnlQdzSN7uVrnp37vJc0Uszyq",
-	"FQ++44EnqV7wp37v223GYdEEyTM/CuuL5jl3F5veR6LLaosZL2Uy80hwm/d7xmE19Va9pDZxRWlAD0I/",
-	"lnoZwCLWWhhg1JeL1S6oKuDhhlc/Dx1V9a/lRnZhu3PLtdyVXY5BY93xAAWWc8mndJ30DY6X2oAiFbPT",
-	"0Hbr0ve3619LbDA6wMLUkFYz0jmq+QMZoi/z+OT8IOQmK7mP+ufGWdKQXkv0VwRYbuTs87ol2EOZO64a",
-	"YhbVNsgfsh9CJpj/SfIczLXc8/lGXpseK3UrwHg4XveoZSkW/vUvKrNqBvrr8FpeArBQ9pl6otU7GU6V",
-	"mmZQEfYBvXRU2ZLh7wRSXzTanf87bkRyVNrZhzno760tTkP/SoJBdMPoKHIfm4/FVPMUTDXKK9V3/N7X",
-	"rhBKmnPQ545Oeq+++brfO1dFWZijLFN3kL5R+qPODL7prZa07v386ankWqCVP61oWyY7d5ZuCVcWmeLp",
-	"oO6UN+AyHYRvndhTJmLofMRhVExUs9xJkGoK9qsoGNfJTMwdh8O9xTZ1dgY5K2UKmh3MVA4HJELqToXm",
-	"4Lo8PPwmcayA/4L+tXT3Qe1kXN5cgeS2kA8wNCrJeS1/R0OD4FUJRnMk0wsP43UyKS8zKwrs8Kh0Pgi+",
-	"si6bo9HvsDNds/7GGR+EfoQJJghw26q9sE2b9jcqczjFV2OrWJHxBHzp74Cu3bC+9EBwNPg7H/x6OPjr",
-	"cDT4+bcX/a+//Tb+uP2rKEbYxnFli3+vCTI00/Cxh6UsKJOlZp9q13vYZy2kmuZcigkYiyp6v+mFuBHS",
-	"ceImq77anq/FHLuZrDXgGth9mBX3IhaPWlEDkQKk/Yi0I66pmAO7hfL0c8u9FRFUYbNB5HvcOIFk9ptC",
-	"sDqil4b+Ln1wE2y8uNQ7DVm0kqmlBi9L3QUNPbL51oOhdfuQHflfUfNTFI4zZ8hbZgXPsoXvIDJTWdVu",
-	"+T7JSuOI15k/fWYUk4phg30KfWeVsDEs4ZJ8FBnwOWB3iBDUYKwqTHAiTIQ21tf+D40Lqz7foqo6Qd7K",
-	"0JCQmrJey1CeujT41IgdY2eeq1Kg/B13L6z9gJiaQeVU3Gq3sKAOkR5c1zK8XxZ84WbxzwpMq1KmA6tF",
-	"wZzpKBOKIAZML5epmIu05JmfJiZ5v0NDsN1B8uFm4Fqf6epKdRO8hxkjOGVH84PPyXsVI1C3zCgDNGl6",
-	"ic2WmlMGZmsjrm5L+Uz4ivS9fCCaqFNY6OoZ2PqzYuhS5GVG6YLEdc2+vXFH4gqOyF114ER9N5ougKfH",
-	"DddWDFpPha52y1rE1tLdq+o865dEPbXCN4+Grjs0eZarPJMVL18XONE32A3PtnPymUg/7gF9KPmj19Pn",
-	"FlFD+ICFP4zA+okcssGZvgW+qmawcTRVQa/PhKHVNrNbI+dJ1m8UvorxGcXjzkVoiFDdlv8wGP9epL4E",
-	"h7prVvdro7nd5jhu9WFlIbRaMPI7CFTqx9ivHqmc5cZDTT23rLb0KoShB3K5R+NUzEMbPDJMM+AG0LZq",
-	"dhfa0EAwZvFU7TCfiTRXGz4/UG64if4g6hK3UtdNJDRxxMMSxUzBEsGMqj7snULib2BbNS6fUz3Gi2nG",
-	"eRejDuik1SGeAop/A9sKbPCWBwmLsNI2xke7f3gcuFWtzWci89XO5I+yDj0U3Mk+L6m/CyUkW9gJWrGK",
-	"eK8ljdkGY62e7WvkqK/TV6+Dz/goMxvv/VW4PfnJ67yPRrGxaxkrIUYhYljmqtAwA0n35tVaZX1mAK6l",
-	"20y83hjjtnajT4UdTjRACubWqmKo9PTg3v2/QiurDu5fvKB/FBkX8oAmS2EynJE89+FcMyWVNs3ADx/L",
-	"GM7rbtQ+mDzxoMC0AeNdaIQFlUZfPHwBvGdih5Ve+w/kBkQoUssfyVogHd/0JSFdbkH4zYYtXaLqit9C",
-	"ncL3XBbjSibiJ4+jtRoHw1IPCsqcrVfa7N1cUSz1BijW9bMi9JgX+CLJWY2gEIS2AZ0qy7qFGOVYsrnP",
-	"Q8wWzno7UI63Q26k+5tt2HgNSdq2Flt+vlYVR28GtpIcfVNjyTI1xRRIK5Jbw/aksj4Bl1ycDQpiNzDj",
-	"c+FImi/YnOvFa2ZL9NL5Hu6BgUPM1I2ys8ZR6Lkx5Fxihqb3Xfqn7n4zWjWE/OBLT8uluVfNgaZwvcA+",
-	"xX2gF4mChUJkdxCF4xAbRg6MwUBDAdyy92wwoKCrQ0YvCGSQ0xvCOCYhL0Oq4zOxXyP59qHS0ZPXH8SH",
-	"RJupbQVCD7fOMt7BmgtBvx3C0QdcPhNeluM5H+XkoCDCP4zWcmcjp8Y6LPgY4W6ZVleSDc+NzP0/CkNe",
-	"LIcno9SqnoiM5c5As6ooMLUiAbZHAQn9a+nfZOvXmL4THJiW5Z/j+g2bzxcDNuJXIaf7/tZcLSSqUlMM",
-	"7nlis8W1xOVaL1MaeCqk0+Xu9uzu4xhFHdYYUwHlUmdjXM+LHc5uwNgBTCZK22tZd6OqyiaHWcMrhZsZ",
-	"DTV3seFTYJSe8J2TjQ4JoYWlznmGoaZWXctxMCfHvvw+lwuENFuokqUKQ6AluB0fhVb/ziTxtiDGZ7iv",
-	"8V3yBpgvqDO8xncGDJxp44o6v+tSVvVu8dnqVSP+pokbj4E+Pa/30TiWyxgbRlGiZLYg7HvVBzKlwNgq",
-	"BYdi1q+l1VyaYN6+YmLCOD7t6Dr8x+0bH5vcBrnOnFqsmY4ZkQIDbEsb8tpyLqSjB1ybAoET8LTq/iSV",
-	"HHx9f+/fuwqtCj51Cnl4Lc81TNC0duCZY5f8gmMi57iOLvjXMaUCHXgYjfE9z0e3EttkEF4XB1aL6RSc",
-	"nXQtCQfESUIiPn1eZh2+H1NWAcrHFf8+YaAAhQWNmuFtS/EdV28G/8Pn3rRjl1jOC/Z///f/YRjjbSDn",
-	"0ooES+ieH10df89Wo+fiFW/9V6OOQMnGDuiNm41/u6Ygxuveq2ac5M+fxltuCEdHd+PRus02cic00DKJ",
-	"35NWq+yP2R5WEjmgOiIHYJPh/pChwUXVpkNA9SoBUUi56Yf3WcxmrRJElqWxqEVxK2ypxaltJo0WxFoT",
-	"R3LaDPMx6IUMu0+cxkpKLLhRTzHEyBA6Rp0ZsDbuaH+4OQjl0SEizx+/gTHjbsjIy85VaFquh78aG4tO",
-	"wbQvMAjecSt2BoNNfVKiF85eFJgh8+IsxF/5SgxYLtu3N6oDB/1g9//MQaNtOlrwBjI3fg+f2ynUjo19",
-	"mN8BrYIP++N9SjcdO7gVo5olxqQVUEQSun08QzisnfEqvsY4fYcf3GleFLDSxn0junyVJ6fcI2x88bZ6",
-	"/fHqHbxyr6XwWvVd+YL6LAM5Jf98wonXLPv68OX/oCp7/Zr1HAITDPalMAqUER4BtIubDDqqIrdhucZo",
-	"qxOsAgTx9aAeSxnZWhT0WLlEkxVV7DkdWRXM8ZlEWBkd7okjN6Zm/6GeqFqWkJeXr2tzs6ICN3MGy29X",
-	"w8cY9i8P/7p5nNtgJpKV68DTPJYvWw/h+tAJJ0CDy/0vyvIqpjtlxYwjiJs3jyO0Z+janlYGDV7lfXZu",
-	"2xItstKswD4UsjpoaN8qyj4Szu216nM5OCPtcX5nivarh2TLVWR99K+s4a7UAvJno9hHxy53HMeRxsQc",
-	"JBq4hVHVBQHJpIxFDOGHVW2a5wobaq+yE6m8WFdKh875B3Iv0EkZx5yvGvwBLyk4sbkFXk7ww+fGC63S",
-	"bGf24HfpCiV0xPRxnPVy87j3yr5RpUyf8EEbd854N96CHbwGZW/I3P1jYwsLpf03QBTio8KRupPOYnbc",
-	"NfpVYEGgKdhYASpbamkYZ38/O2fVXaBxhwhXg6pETF3ULJDGcDWGxK9/IvTfRYER+ZrnYEEbbH7Q1e6v",
-	"4hy0Qa2qbH1nGoRD4e3OjfulBBQHdKcL5d3aNNBvOjE2lYv7eSfl7OH6qEcvB/VwxqoSEhJWE8B/Rrr0",
-	"yGqKEHcbIEILF9o4vRqbbkGw4e67Z7luXIDz8DiMdqiba38tXV/LNYTN/m5sytRkAtowI6ZSTETCMfV8",
-	"wg1d/2hBb79eyxSaf3L/5ppugL+KwjtceDITMMdmqWCXZ0E2ikdmNbjKwejPwlb931Zbf1XHxQiGIfte",
-	"TGeg6b+qDsLM5DzLmu6Im9Iyy2+BZUpOQQ+v5YAwYewr9r8ctmkK9qLPfOK/QyykbO9/fXN4OPj28JC9",
-	"++7A7LuBvrBBe+A3fXbDMy4TZ0q5kQeIAbb3v1582xhLiGsP/fd+wGcY8u3h4H+0Bq1s80Uf/1qN+Ppw",
-	"8LIa0YGRBrWMcJpeEx11SfPwr7rukgdVr9/4jbaM/zCxgvS7SkXPvY8Si1dLfq3/j4jGJXdeJR7R4RJq",
-	"N3ix2BYNVSvxbWUCSgIP1pWu5n8UDbubTVi3U18lKLTyGr3a/4Rk8zewrW7zoXnQCvYqssmEsWinm066",
-	"qZveP0yZ/DkppT51hFTq61tGtUn+hLSC2bqIeUokXKUNbJPedX0Ljb2fMTT2Ka5uGIpauzv+hHjCE2Ar",
-	"Z3zlWsfMGnhaXbqjvHwBPPVX7u1YGRcLJqGb/4/CzSqxYAd1y5pH2RIo+qN5XH8yYsGssdZzXUUcBkjQ",
-	"jxol0zu5e7Vy/fMlIXWUyH9wdY1GRXifMvQnROQl2FVGb1a7P8Bq+mYmigrD9ALaHYSFdU5M46HU544r",
-	"XceXkELwofoacuVlAOWyDTuqTgTz4MmiRyqLpOOJPgVjRxu6BLhvfJftSoL5qmneoN2mP0C/99DXfP+S",
-	"X29153IMBIUnq8SAWKqKMPzZRV2kOMPE22tNdgiuzbVFZjg6XigGDfslUz0ZYU3t21xJX1mmry7mIO/m",
-	"k7HGrqSfNhspNCrl1DESajs+eKLIlnX88EDC/rsoarJuIPC/DZHzZsGjJRJdoXfvXNlA8Lu6Rrv44lpu",
-	"ZozNLtKWR/RaLrlEu8sdeR/nkzFXZxTV1QyWXS+VCtkibuizMW08yqerWOv77QN9fHcqvzcsZoTlfR05",
-	"DQb4zaAetz/crYZywMOziIsjD8P/5iJjmVw7xMbdckGipZtAo7/Pc90BIi2EtsftA4un4rGjTa8/SvFL",
-	"CbG+NzVX3nlwbBWvtlyv3SYz9tQ1/j4TsdFhmk5qX6hJThuWGELr4LcA8k++jDlQkZJlelNFTW5LTgp0",
-	"PHhPg/c7VHhc53vY7Gp4GSusT4iiYOc/OaIusYFPiCuPefuWkXRAOXKdriTq2fzGnNJnvyOult1CFu4t",
-	"7TbqD9r0HnCJV1vfOieSc1q3sFGTxl3Y5xBi706e4ql/6/3n4PLydODLBw2uoq0o3kEquK+2PsEeMdh6",
-	"w6ck7i0Lsf3Wy114pVsRdZFHuU9/RjKlXkHLUPYlT0jsVhTrLvPrg4ywKM82Ds+ThvHFV5yfv+O794e6",
-	"IUHoztjZmLHVO+UvL192bRO7GXZsa207R2K+bTT+I92xD/RmVCWh/uxqFN1STnOGeMg6VCtTU3NQAzb+",
-	"RKemvod+hxxeIgjfXWgd5QZB40m8rm8b7ekeX2aiskzdxSMPWh2tGz0Xl9GMCR5V2p6YMNo7E4b5ra1h",
-	"zG6tsss6jbPHV6s/GBXUpqb32TTaWzXdUpU5wvpDa6+YZnCbphzKy8tTYpAi44s7TWlvVDRyi/KqVfOv",
-	"82o0S5ywxbfQiQYza/RqRdTcW8anXEhDN/GQhaBLiSWcpZIsUwnPZsrYV3/9+uuvKTsVZ51xgx3kDIrq",
-	"rwo+ha/67Cs/71eU0POVn/KrqlNMqNLguyr6WAycsd4clsq1pZZ1I7dAXjHHiQdBfe5j0g7PcbNbWesz",
-	"ZT1E9uEAGk9WqYD7RyyHWh8Byw5c4s6JIiLE6RmEZBJyR/dF3zfYcgs9W32faoXPRAetHXRRQF3NWPtv",
-	"/hBlcBOV505KmIVMZlpJVZpQ9TYg2BT8Tm7E8CV+9awoxiU+L479FrqQjD9/5uInq7jla5D7m/8H3s1v",
-	"RbuCUBTRPwgsRbP5Xl7PvNYkrCz5shTpYy4LD0KoO80fslLphx/+lPEFTpSIqbtpWsWC2dpNcVQYYCPN",
-	"XdBn/22ojs7zhe6eLkAJ60twdn71X4MbaqWwmfiM5bbsdkUGkU9f/d6098x6jA4VU2H+lz9llLJHADPh",
-	"eN2oT8UWNg1+9d9G6uBxPrP9RFvosp++W2DrDnK//Wk9brXmY0Rna+lQlXaTI64GnirtWo/cZ5JHj/As",
-	"VWdzw7b0MQXoqtIWJfXIz8QEkkWSwZcHlOd7QGlQtSrtksNMQ4LlQqcH9SNsXLpS5vBF+P5ZE7WrVTbX",
-	"ll1O9/QDP1+K9meqbVEldhca5gLvjIyQCymbixRU4x2hgXWfXNYpxUL2WRPxa1/Pqkcrv7puNtmnKmS+",
-	"iX+rmmsZanX7V4FqeNdDFgq9+DMWH/x6NPj74eCvg5//7V8eJBoRYAd58fLR6QQ1RfqYx5aAq34dvBES",
-	"m9QPjmKNnkUOxvK8cEKOmvOjZ7eemgYP2d9Krrm0QPFyN8Au3hx/8803fx2ufwFpbeWS4lEetBMfy/LQ",
-	"jbitfH349TrGxuJyIsuYwGKRUw3G9FmB/SyY1QvyfVKNxza4L8DqxeBo4n5YLYVbTqeUK4ptNbADpJCs",
-	"bpgfui/qBTFBfYgqlu1FJJbt05844ZRK8RrkRWqgvoVEyQRpj878wQvP2Oax/SmqfIB1CiWsRpmeK0H2",
-	"K/waGlfqapdPlmDHs6w5bRtsKx1QI6F3z61824us1b0v1rGoFwJ/wgpRCIGqinst14bsA5Wcbcq6AjQ7",
-	"O8EWiFjbfCqMxS6NWLLaSZDhKpZVsQ7Jqnh+HDfWeLh55UPhPm/BcKuKtvohcJuEZ2DVr6DVge9nv7ZN",
-	"CN0V3EQ/vqOihW4GLPyhmJul75DLdZrh9WXCvr+6OmdW88lEJExJJuyQHfMsC7VCjs7PqES2MG7KO6et",
-	"7vgtMGHZDSS8NMA+SnGr+cTSr6HzeOIbO92Cb1KyCEUMQs7Jj++ipT7omJfu5Ffq76BVb5uwRvx+YNXA",
-	"nZJ5WKVPgpyzFPJCWVIbfmaEKwSoNkA0XEUcyPV4uwBjlQbjy2bS1NVRqk4E9Rp9J3/VHZoQCM32Zshq",
-	"QItGpBkQQmlsZeb8+I5J5UuJYOVs422bGWQp4w5t0Vd2+XjcgHwm1NDEmzBjIYPc2T4bC+00GzJVo9ql",
-	"9oYsfPzy8CUTk8Z3VLW7LpIabT3zN7BX1X6e0ftVLXJpuY263a/iB3yo7bba3ap7/qpy5ZI449o3waB8",
-	"V0JIJyJQqyXcwpQq8cK9A5ZwhGGwfkSzjgq7UekCq8lSUHf6OtzkmlNosJzGCV1RgqEO/WYn1DPf1x8N",
-	"pwnmJNXL2IonXjHs7s+SDLg2oVhT45Sx7kUOem0ieoYOvRR4US3TLLT5+/lwH0zFnytjOlaycx0jlLG+",
-	"OWA3UH6gw68PX7Tp8I4TITb8KDVNvvbhVW7coRsnrBvwVKT6msSu+79KRnv1s5uIPC/t56PuPzw175ot",
-	"9DwbMvB5w4ku1ymYltJvpH/EjbEz+U/sjsEled6ZCJmg9QL0ENBnU+5b6GEKY4Llv5e30WTPQ0o/xa+N",
-	"EVMJKQM5h0wVUJtmflnDeBqci18fvoz8PhEZXdL2pArLh4LSPrULv/3KBBZGlgu28X7fffXy8NDZSHOe",
-	"iZRXveo7WmuclzeZMLW2oeeSZ3ozpLVwic/0Zlif0yMpGleH6Chot06sVhhNuA49AWp8h7b+Q+LeiLVM",
-	"E/IkgQLJq7Q1ptfT2muS9mErj6jE3m7xRxNuwRLLzLbyrLjsXwdJrXrnwNovbPXMxLBDdsqTGZtonlPY",
-	"MRa7UDpnY5G+Yr8Z+OXT9bVMueWv2G8BBQOHb/f362s5dpqNYO8r/1cN2RIwZpArqaySIsHnvAK0QUdX",
-	"opUxS+LOJwK+Zpy95cYOEGODsxO6cWNvIq9x3UAJSQhoRi7D67AGU+bhkk3HHrITrQraFIUwEcKnvDDB",
-	"fB2LdEwdQbD/j/cYgJhDSr8JQzUj7IxL9oLxGfA0BFhnbq8GQOKn/fCyeAfaCQqBWcJVV/abcjIBPWTH",
-	"mcCvfCdRq3lyG5nNWQYpWEgs7nfI3mCseX186gDlLp1tkKGDrV62trI9qhwyMInBAGA57UAPVzNgd8LB",
-	"asYLTGjAxoEgQYuEjdsyakzdTUNwuz85eJPfc9UP2CSEWjCyPff5ApsVOUqhlnqcpSopc5Bu1NguChhT",
-	"u61K0I6pu4ijF6XzqrxG3frG2xr/its6wY9J3PSZgQwSvx+aPNqLD4mlfbyNNewuHLmFvh1omJk2L/i+",
-	"WkozAzJlh5QRH0VNaGC3LT/1mVFtppjzrKTo/xwci2gNCVZNoKW4W0Nge67wYEZPH/WLWYuGPl9WylYK",
-	"4u0W0u1Pl7CyfALGDbvE58/BpSMST5Zu9P8bAAD//xM0cORbsQEA",
+	"H4sIAAAAAAAC/+z9+XIjN5YojL8Kgr+JsDRDUqpyued2Vdw/ZEnV1rgW/SSVPdMtfySYeUiilQTSAJIS",
+	"7agb9yHuE94n+QLnALmQSC5aapmvIiamy2JiOxsOzvpnJ1GzXEmQ1nRe/tnRYHIlDeB//MjTC/i9AGNP",
+	"tVba/SlR0oK07p88zzORcCuUPPinUdL9zSRTmHH3r3/RMO687Pz/Dqr5D+hXc0Czffz4sdtJwSRa5G6S",
+	"zku3IPMrdj52O8dKjjORfKrVw3Ju6TNpQUuefaKlw3LsEvQcNPMfdjvvlH2tCpl+on28U5bheh33m/+c",
+	"SMEm02M1ywsL+ihxnwdEuZ2kqXB/4tm5VjloKxwBjXlmYHmFIzZyUzE1ZomfjnGczzCrGNxBUlhgxk0u",
+	"reBZtuh3up28Nu+fHT/A/bM5+3udgoaUZcJYt8TqzH12iv8QSjJjVW6YksxOgY2FNpaBg4xbUFiYmU1w",
+	"bALE4Wsm5BmNfNbt2EUOnZcdrjVfIEA1/F4IDWnn5T/KM/xWfqdG/wSivh+1ujWgj3JxzLPsdO4RvgRJ",
+	"yX66ujpnCc8yNuUyzSBlowUe5ga0hKwnZnwCpsdzwQwS1iooE25hovTC/RtkMcOt5aK2LWO1kBO3rZTb",
+	"jaQV2fqJG+bISRU6gS0nwJGXNOJjt2N1Id1W01U4XOkCmBjjud0O2VhAlrJbblg5iqUFOCIw4g9gmZgJ",
+	"axwo/AlHSmXAEX82QlS4FWbFDIzls5wJyT5IccdmItHKQKJkirONlZ5x23nZEdL+5UU1vZAWJoDsTH9p",
+	"QHrg8BcB9xK5WBMm7FY4K2G6JRGdeATuwK/noHtIYTlfZIqnbKw0G4Z9Dxm4ec0qXaWFRsk0mEUg+ivP",
+	"sl6SqeSGhe8ctzoMEiFrB+SZyDJRg68/oSxmI4KmW48WERG6eJ+DPDo/Y+VXZ2lYZOZEEKRMKydr9qA/",
+	"6bNhrlUCxjjxMOyyoeU3cJloAGmmyg73azuoOEKTDIyu7yDnf2cidcJsLECzsVazFh4NX89EmmZwyzVE",
+	"FzWW2yICVZQG4QJn9BVLVFqfpaTFJfKqHWQJruV63QZO11CcI7dLy5Ob1S0en5yzi0I6XurjJ1eaJ8A0",
+	"5BqMA5GcIGz+g8/5JY4j8Wbct4xb/NGNRuEuifr67LXjeMMKA8ytIPnMTZQo6X7GC0BzOwXN7JRLZiS/",
+	"gUHCDYoEpAWc93iq1QzYCcyvlMoMO9fKqkRl7FZoYMTd/WsZEaFZ9lrzGWxxIeFpxvhxlznq0zNlLF0+",
+	"jWtnaQmVFTP5jih/ZZG/g1a9ETeQMvqQEY+wW2Gngq63TMgoHXQ740LiVfSOz2B17homwocOvtBlSjOY",
+	"5XbBiDJRMHCp5GKmClN+bKIk7HazxWncZ5Gz0Nfx09BvZ2mc9ui/a+wY3V2hs9XhHy7euCO7swcx4mcb",
+	"iyzGqEsc1gBzbZ+0XAMk3Sa+Y6zWVC2WhPaqJCRhzzI+ggwRhdtHprLIgSQDuVnIhCW8MBCXdznXQfnM",
+	"svfjzst/bHWZVxLh428rFwxO2dgMUhJuBf9q+ivArLHcWkGU22TKL1U2hwswRWbbVCmW0KfMuG8Zt9aR",
+	"NtPA8Z7gzDGqcCBUhU3UDCIX3vbKUcu+vulJrXqSR88A0TPQCLPddKbNitI6rOyuMwUSaqhNsWO0q1Dh",
+	"6wCMJXHmKXYOMlWajflMZIu+u7TSIgFtmHRgzhwic63mIgXdMzkkYiwSZrm5QVFmmJBWMTsVhhmwLxm4",
+	"l2iuhQE251pwaY0TdxoChyQqy3huIAwEodkctHEXw6hIbsCyvflzdsDm3+93GZcp43LhRPeESWVZouZ4",
+	"IZLAccA9Ue42eWv9gbosz7iQ7P3xxT4TxukGSjvS5IYNlbvFh3QJB9qY+p11HPIDzObPm//5vaOEQktj",
+	"RebIYQJg3eO128Ep48+dXVVYVO1IghjLtXWcFBMcK4osvjoHTlVbXQjpsYY6/BbVOvdyHXORFbrUYU8v",
+	"Lt5fDI6Pzq+OfzoafHh3+f7NL0c/vjkd7vfZ0chpWG6QKRKn6e6kXF4tn4MN/TTDl3RmzTQ4EKO8LAwf",
+	"ZeB+wKd2nw39TmNfS3+oPQPAhhUw3K6HTp6owlbjUpEiJdH4ul7gbgXQ3xl2y4VloyKdgO2zIR9xmSoJ",
+	"6fCl/4QlXCaQuQezvwtzPgEm+VxMUAzyW75wangP12zSmz+2E2R0JAdG2mSn2ykXi5KU47voY8FjmRsj",
+	"Jg4mNQ2Fvc/57wV0nXo7Luj6NkXuuII5wWp6GsagQSYQR+ktjIywMJgqE7n7flKkmZZQuJ2CBg9PYnl3",
+	"RSAg0rXz59xOI88gbqfbz8/+/wXoUqWEuyQr0uiyKwpBTVbe48mS5sdKSkhsu7EF7ryNLsmEYyRiuaQw",
+	"Vs1As8uTn7vsPOOLWy0mU9tl50WegwXQ++4l4uaGlJHIxFfKrzC6VCgvc63uFmSHEob98nY7K41ZGAuz",
+	"KJl90yBWNYg0H3g0PKGx5TjNT4RJdiWltBwDaWUg2EAk7JwLehbh12I2g1RwC9mC5RoSSB0HDWvnHgZT",
+	"p3FvGGM18NmDSW0XtXcFON803rX0WpHFJyXZe2q81W6XlN7GSR7fYugndn/Zxmg4A2P4BAaJKmLcSW9u",
+	"N7djP/+x00IzvnCKAd64kXVBoIEpFZr+FrdOaOAm9kL/dbpYnhOku/jYkETEIMmUccoTfkVSQ0hhBdIw",
+	"/VEZp5UVOXH2IJlyOUGlBw1bopgxDaiXQkq6DRjU2p2OjrczShirNLBU3UpmVH21RBVZ6t4BHsd8woU0",
+	"ZJGTcMvCuvUtoCo3fFn+xlLhNEgd4MryYpaT8kdnVdLCnR2U6pk/cDCM+t+RgysVbs8ucuEUu4X3cjAz",
+	"Law7wn5Tc6uDstPtLEOq/ifcExpilna0mRPrdLxMbiUFrGNIJY3KAH10rfaKEX3rIOI+9gq00syJtWIy",
+	"tXUTKtwlkBNRkb30dCZsddXcKncBWSETi0RPMsPQ1ZKKMSqXliSomfIcTL804vr1j87Pjjkhw/+l798p",
+	"PMvMviMt9yo1LIM5ZF3mYNplXE8MPRHRzjNA6081d7ntq6l29LhXnq38pT41zZkJCV1vBu36owwKnUXW",
+	"8VZj95bwrlT3ZPEaGo1kXAPj+HCKW35X70p//gdflstU8O2ubL8rCVaeaZ/wqoziZFdjKI48JrnS+dhd",
+	"NvU7pohwfJaVvM71pJi5mVmiQCf0qqCzmj47J08KUzJbuLeW9KTsub2NcRvOh9V365K5mfgrYpRquB8a",
+	"5vrau6+SR0heyN1bb3xJKsTvWRQzcRdAgKIbxOY8cy9rnt3yhWHXZIi57jwIilFnx+pe3tR8G58PUJWA",
+	"bPF4rHg6mJ2iH07DbXOPj7CxhhkqCOqtjeqlj6HbQd5aFUF4JQXdw31T7VlINlJ2GuR+zu3UbDY74Dqr",
+	"EuO3FZnxRk22vsszNaGLurpMMzXpht/7Qo5V9V+3XMsuA5v09/uf4YIKB/t2PW28njI1efrLqYGPL+tq",
+	"2umGWSPBW3VPN0eX5dwYfBNpVUymrJBjkVn0OaAUIi9/39uZh+hiUIW3zTU0Cf9SZe6ZAzx9xXiWMXQX",
+	"sOWLxDgNErhmTnT32SWQ9cbkkJTu1nGRZczRBGmSn0bkvcaotmX0rGJns6gjhHS3EHkNKlrZkf/IS7jw",
+	"okOmq+LXgkicKSmse9hIqxD8xyfnvXCpeEMCOwu2cnqXW64nYLsUZUFqvzfs4wsoV8nUcfftVPi4D9qJ",
+	"SpJCu2doRM/HqaJ2e4dl/LUe4lNzSdBm4mqB4ino1llTlRCu6Lva/F33jgf05ABPprXTRdeRfD4w8Pvq",
+	"Km+VVFZJ/3QWMnFvU/TTVeCiOMwkaCpd+sztC9JyA1blPSSP+sgoELaQnt4q0QqXYLWoh1R5DqN1akaU",
+	"KDzoq+j8gTb9RLUl9ozF16G3/1TnNOGgnFk+2l+3YrgXtuDsKxxx5Qasi0fRkMGcS3I0ToUhUn5Ffhb3",
+	"wRgjVkqcOF7A34h1uqVhpfwW7K3SNzUb3XqhUENWHbDNI1ckuOb6qqsCO9oetZqD5I5IZ2A5agcecwtH",
+	"zcTo3kygGXjbR8n5q1oTxDW14Fqv+WJRcmBIkHfAtt1NQwRvXXqVlhsEdZxwboRM21SVcKA+WliDlS8W",
+	"vuavsdKv4IVrnw0pBHHAczF8yX7G/2BH52fBjLbn5IyeAxly6Y+9CUjQqG6FnbMh3FmQjhCGL5mQ/yQ/",
+	"ht9P+VufDTOV8GzgAy2HLxn5FZj/A9OFlA5jPFNyYkQKje02TXlp3ul2qv27n8JCHSdbawtFNd1AKu3E",
+	"FlFSNtFDuM2IGJy0Ij448HxyQFfF2UkD34EXlngLkb+GY36yNv8J3N1g2g9hdbHCMBgnOqWRbMZzh91b",
+	"rlOMsegJTylu9060qcKWoSR0ybBf3KvZoG2sZnolLY+NCstmfMFGwLhcsP+4fP8OVaSG1rNyGEyAoJD4",
+	"40wkNxsfSwW+mNynQZPguS2cljcXvCJClHZVvODm15GoNvLQF1L0TN/eSa3vpBroB4jZJ3wttePmkd9M",
+	"BjJIrIrEuR5fXrLwK9obgukZz+7ka4aKVotKMYkFgL99wyyfNIJUl2ZzCCvyHDTGP5Og+vHD1dX7d112",
+	"1GUnZ7+06DBRZf4XYQQazZ3U86lJLQt3mdXoo45OfxebG24xyOWulyilUyG5bZ7KncVBMRd3kJm4gWux",
+	"ZuLF/SdeosO7jlupW2GbMLT2mVQjwZ9hsVHg3cBipLhOvwZxF87zTdhtJexuYPFpRF0DL48s6NwhVgD4",
+	"MyzIxl5pnz97OibYkgA6dVvssh95cmNynrhXe1wK3UOaBrmHZuspBiUkhSHzNKXhLJBicg3GtEin7aUt",
+	"Tr5e2p69O/9w1WVXp/95dXRx2i5zl9VBeICAuUy0yrJLsDaDdKOoMfg1M/S5Fzjh3cTHtvokV0bUUinR",
+	"kS7kpPtli6dVaHwTVFsJKsL6wBPGp5FZLch6ZOnlxNMgooTQ6uyuV1K6T0KjAO/KPea+moBxRL+NWoLr",
+	"LVrXWzz2et4ecw/5SWttUkdVDHivMWDcrIIQRYibPJwgiJptTqJicGsstXiUpZbzt4hCStT5Q/sNrUJ4",
+	"rWh+I+bg1NANQccsE3NgcwG3VRTWUiSxe8ePiyzI7u8M+xVGF1fHpQ3nHdyo/T77yX+nZLZ4hTEvQaCP",
+	"lcZZMjCGUTbqg7KbYmf7Jl9b5atD8cCh+H7hyZtlaSs+dg/xDLb3RnznygHaQzzX2fbflKS+auHvs8uG",
+	"+b2MQjRdZhTjzGouDTJIsGCPMpGzhEskc4xx82bQMmAao6CH1ZaGO5m7twD45kjwVf6OR4Jvy+RVRHgM",
+	"K6PFynEfzOTfArp35/P7hnVvz+qPE9C9gdu/oJju+8qVV74SRAjo1lQ9gTIn2uTajl6xLTOQ3pKn+6TG",
+	"/y1S48qnhtRgZFXwtjhWyJSxfXaF+prViyD4vFE+1SrPIWWFtCILDvZBKVHdC09rMQfTZ1cauEUrvpC9",
+	"XKuJeyKHsj0YTGuB7XmJOxBphtEXExhkfKEKG94J+4wbVkgNmUAhTivbKchPmX3SBuBvIqtVZAXiqF9K",
+	"T/joW4uhTeKrSUZteRYX+PcyYKA6GPq1EuShQZklUfpUSwdl+KVfd0UujdoMoc05AB4UZ1LY11xkG2VB",
+	"EG2UpOG0+xH4/JBM/EH7/cSMtrT3b2y2kc0cvgZjBNnTc1kMPbvxmLGQt1PkDOxUYXp1SYY+oshCTsZY",
+	"Oqq3ilLES9+APSqsOrKWJ9MtrKK4ic2nvQjX21bcFL1ZG6yloQcYESTMtLSJwt2UF8ZSBENWPVLIioPl",
+	"IEyfvVNsXGiqRrR8Rd+KLPPXb5np6Vn7M3BwDGjf2HgjG5d4/2S83IqoJ7k0G3TtSyD0q78OPBu465PY",
+	"wBF4oH92CxoYukiKvIwv8SUVxkWWLfCSVTpUAmvyY/3ejaz4iFfvBTxYD186VURi8GUN5JTkQDDNpUUJ",
+	"hwnPMeCGlPvjpg6OZVIMWLSGLMX7BYOI1Ty5cbN5RYWNNZhpsDEIw3IlpP2cYuabiNlZxHxS6fIQyRJY",
+	"dVuDANb4W3r6M8tvAJmsloVc2vebnLQNfFdEQ2yTm+FTFYlsNfPloIVKRcJM+W2wdASf69wHpXwGBlw6",
+	"wDf+28h/FRqfnv1i2NmN+3IZiV74kRv4y4seyESlkLLzd3/bkjhLsI0WFjbq527tNWd8R5fTWZrBxqiE",
+	"cJGJNERNL8UkcPbD4eHMsN8LAdbzHFnDpWJC9saZmEwt82VSMfDdbMdufumH8tuSD/obh61yWN2Y+IS8",
+	"5enujeKpkJO1j8JVAsxoVHi/+poKZ+NGqQoHbZ5p4OnCwcfTHkYdOaWR4wPXvX6lYrkWSrNhOLufYohz",
+	"1L20wu532bDQ2bDLhiEnyf27TCUaUr7TUINP7HUAGNaqGLxiwwgxYhZczjXVW2e5yosMqQQTeLhlCTew",
+	"bQGER2KWVhR9u582co+n0Kd/gK5H0iPH6FANlk04qzNgGLGcVoghLpNIIeEa6qgMYTzs+V1Ik8I00dpv",
+	"3pglwb58eXpxMTh+/+7d6fHV2ft3g4vT1x8uT092ryPuxEWkjjh6rsLrUGkxEZKj7WlJjLQ6rdyqNSkR",
+	"X9iftH/hP71a5FCzBOAKKym39SwSn237s1S3kkJBDRMSy/qxE5/i2GWvwSbTLvvPny66jIrWdNmlXWRg",
+	"puCetWczPoEuewup4F32WrkxV3Bnr9yjtstq3N2tSqZ12VsuxRh3eK5hTGu8t1PQJCZnSm9RuLlRGr1G",
+	"Fd2KINfG+ngQhk4q294yAX1YnaAlUe3pxW99198E70bB65H29BJ3BS+PLGtD9vHGyiBlmjLqCc2SZB4a",
+	"UdkzrWWu7bLvetbbajFxD5aQ3dZ3K/k9ObZtFXNn4Zs+loURMsXGOpg9iupPYZpnurfMM1665VwbJ4dy",
+	"De62JoGExQWi4BJmoIGKy63jHDQE+qvC+P2aIqNeOCzMEGcZ8ti0tJXw7hxuWCgi7CbHxgh05f3t9KrL",
+	"zt9fXrUUjlfGDoL4ieNspNIFXi1uloPzD1flI63rDsfnXGR8lEHLVUZHi9Pre7oeM8xzHsFY+fo6YRSi",
+	"AQ+GCnoN2AhGXcAj3dpdVkjxewGNbgaVg+fbDf3wG9qTcbcpwiqBsyIQtru8qavKDre3b8OiIQExr56J",
+	"r92ma2bL8kMkf4cU7y6gYV30OCJVhoxd8g9+HmWgBoVv2sAW2gDB61OoA8uYeWR9wFFnFEkeEw0yrsQp",
+	"VgJDYQR3lr09e3tK5XI+qUrgd1bXCba567yCo8LdsU6bmYlZm4wuDx0mLEFFF6eDzMHUzrIuW27o9+2t",
+	"+MXfRI/UjStM02JviM5VqzTx/ucuK1s37t/3wiyL5gdGXHsznvMJnKjZMSV9v1E83cKEevL+bWNAqHPn",
+	"yMdN2E/LGXEuvC23rGuX88mDi9q1Hurbbdd622HEb6pmA5//j9bHJ7U6rsfSY1sd03xQwi0i+CjeYxZq",
+	"aTHyX1PSs5As+K659YWIVlhg7ODRxQrjVswRxYFdQtwpBWzsOVUQsYZFzPb77IMBNrSGigvdNr3nkUD5",
+	"5Z4ZjZNtZPY3GNS9bQ4xhYC35BA/82DxejDaYjHFoPLWWdBzwGpAYaapGONTsHqbz4UpODYHHIlM2EWf",
+	"nfJk2hhAcTH0FH7W86u6Q+tPJ1S+uf22kyHNrIEnlh+emh2NbC7MWswKz5wN2to7fnO570m7zNU6B40A",
+	"kAmwKzED7GF4dH72aS+x5eN9u7+2oz0HsE9MeU9ivvURTKuAPFnKtGoQNEirFythV3u+PPYhXjMNccxy",
+	"0FjldD+al1WH6iAFy0Vmdk9EC+xUAxzj1moxKiyYDZyHR1rlvSlPBxoSp64ImRd2PUk3gOSLhSSQkmMR",
+	"K5HhJMGqh2EoXd+9yl1UwsuH4zeXcZJHdSGSu1Zf1yRKh/eUMB5Xe07pQkiE+NM3l/vxq3+FJv2Dbsfi",
+	"pqHQCf69KlXeAFFZSzVaK0DE+sxGkVfxe4xaN2cGLicLLB3Y76XK0dtCCUryjdfFG64n7jHt1bxxkbFz",
+	"Ltwz583x+Zd6X/hzfbsnNtwTSf7U10MdE498LWRJfk8x7Gm6Immi6IeKYV9TJCp9RFpNH/j/zfF5VU9O",
+	"jIOdsbW+8iAubNzLq2wjvjTvVgnHUqXtIvPk/VvmPohIzdo6bQ2iZAq6ZdsX+OO2G3/lL2zqEUlWP1/f",
+	"o0y8uBIzISe9oyxTtz3yksUTrMUf0F79j2vgLRui8irM/F7w5n1Qzb3Jw1yfEaPg3BGY0mwuUlDhp5Zi",
+	"xU976dW35mQYYe8J7j1cKKac3fvS23zTKb75lV+93JcNeVkY/jlMeOXev11nG64zxZ/8od3AxRdunEMd",
+	"syLnr8U0965M+dqOY+sF/n1DwGX+RXnxLjRE3u+zY661ACx9X9a5HlMHNSFRao2wUrRlvtp7l2HPolCV",
+	"vm6JW+7H8GmlwxK0vsmI9TKiQtYTS4oYXnbLdLnfrV61/cYvdm3W8Q5u2fqGHaxs612+3jf07Mi5dmpx",
+	"+3nO8YPVI1Fz8BH9vdal4pWP/6cdRPp1tHSD37kZx6O13Pi0nTQqGrDq0dpeUOBRTfOqqGhrVljvbwmN",
+	"PDFAqMURV3b9WDKwsymfAzU9w3uudNWbJu00XC5lF3dhWG168sRgFwAM0WNnMoXcacNUD7ye1vOKcWaE",
+	"nGTA3BeUkkzhB6kC6sc5wrtSbN1085ub5nPcB5/IVXPFR+9zkGucjhJuSwXH8pF7HHp54sCqcDDpNr7M",
+	"SEi/ulL0B6R9pGsaZ/YpUs+EaFHeKLMjTJXA5etwui2EzlNGNQrtbUrW8vpSM02rpjiVXIHk5/TKWApX",
+	"nx0raYoZaPcOpQy1JT0NW7eEdh1TrGdiscSXsE5X42jJFzzbKd3rsbSyJpa/KWXrmdDy0YDo+pMy3z10",
+	"MtxlXHO6Wmmz5TUyx8OYT+BZF5lBSaBAcLnYVcmoOvHE2oZJuM0W5VJ89CSahxU2i5h/KPEg87LHfVNq",
+	"pShQ4puJqjFhqprprH2OZRJZq8OsIZFL0HORwLHmZrpGQM+45BNIsV6pSIDBnbBYgxDucqwskS2czuC0",
+	"FqQqX0+eotscNXGrdK/KLikbvLNUoWj03bDqYvP//u//Q/Gn1Sq4rqGG96BnPqwTn8C9iZhDr8h9KVlq",
+	"7ZaqbaXg4xRkiEDzmyBsFYSemAYJgesJBWEbXnavqYp7bVZUXTpGWUyVnd4JixGj1LpeTBy5Oh0Bq3ff",
+	"OVWgzGwtZAo6w353wTJFPKfLQmLJlEsJGaonyBeUfEIMSWLRLrpkAhNjSBaJ09Cn3JCtm3YePLtMSNJe",
+	"9vDpUSbn7JML6OwEN6ohV1guMcJFOHOsXOsWS/fZEJm2yIdsBlySVSkcPBUOLqS3CYxp1k4jQm2Nsynw",
+	"zE4XZbM5rKDUZ0P/32FCznINc6EKky3KMY0VmsJrOOFzGMQ3FDBR1qliTgqFOkxlaSzEsqXqrFY7XL5i",
+	"sqoW10YoVDXOPeEq80JAK5VaNWoGdlqr/WTKp1XJSwTOTrfj4dDpdvyJokItjxolzk7KAr60xwCCPjsa",
+	"VflVMdi4xViRr5bSi4JJOIWYZUq6oWVlK071tM/PTlpirD0AJY96YrSaaD5rNs/yxwjw9F0eseSnKGZO",
+	"nZ8V1oJ2/6JuhD1ysfV4LobbFDCs76nruWKdKMKL5r2a/SyybE1lsjdCFneMtsTev3/buxFZhjUH8d7D",
+	"qiklEoQsuy3+8rbPLutd24cHKcwPbmZmMgxvIkdmXFbsgFOXosiv6S+NGcyUXpQIJXNCiIvx9nnvNkPL",
+	"lZ8TSzJzW4o7U+QOUCYuS57wRl4B97cLuf1CRmANlJoNHEk85YUcR8vu97Hb59J13DxEe23zREljNRcx",
+	"Dvx12uQFSERKtoLAin02lEpCuC4mmRrxbJVbXrHhDGZJ7VpKJloVefgSsY/UMRX2FRsmeWHADtkBjlN6",
+	"MchVJpIFGRfefXh7dEB/6KVazEEi71biWUm/ZcNUhrEGUy7ZD/1D7x9LRVr2DvFtaXSRUKenoVIzPNrL",
+	"IcuEhOYF4w6LySazxN0ttE/6Q7XLlk6ts8FYAwxuRpG+LxogtJH1IBGS/Sx+DH1z6sESbnNdloLGhMwy",
+	"YGXoZn/5buhZTcga6r4z7C3MemdyrFhazPI+OzKmmIHDxAtchwqJiD+gz06CoSYkLWlIMi5mWPU8cQpI",
+	"6FdhZjzLvB8SY945y9yzC7E2sMrybHAzGmLNdmMdjTr0E8TpsA7lbilU/NiU65Q6mGExTo9NL0YCEdZx",
+	"xykBHXdWHtD44nn1Tq01dq9vLSK43C8PRsU7hKdhF0dviYoegI6ngcImzcdfhkHxic9BP7YoIsdqNovP",
+	"xjDGhHTqpet2b8bv2LMfnJavTbd2VzQ+a8koNCaK0gsw+C5gBixdNvFdeTTvmQL3zaWSPW1Ml41FBvQv",
+	"1G2nM5i5/9zvsyunpfoSBfl0YURSSb+6eujIvMCm9C1E1NYkKh9Ybm5MjE5zVikZI6w3i6fsGbA9PKVf",
+	"aqZmtXamRLGGYO+mJN/FkrbUINXhldsCvTCGzHtGTme5XawjSm8Ac98ec3wMcMt+wPAf4dQixUaqQJcO",
+	"3VpI7EiswgKV1dxVsXH7RA7nd2c0xw8lVLnWfEFKi5hMQA82MYD/rvYU3YYVfY8zmTpJNjw+//CSvXOa",
+	"vPsfxxAvhz6Bt3a3RPAe9rg1g5WENlUGGM8yRQm4pU+qVvvD79sqJuRc3ZDCXOnWffZ+bP3zBn1o3LBh",
+	"fSdDtlebxjNRLTkW9D4GUSRcslSMx6DrbSpxUELb9D87mM5FYsWsz95uw/8NuLWVbKzDjuRdKSK2VcmQ",
+	"oHbTxo5Kp6DHCMW7beIqvAVWdLPt8f4QubmJE9beAdsL3eYtuiqVtmheR0j0GN2My5rpep0tvZ7VTgZs",
+	"92Tzplii7DKhvOEu6nZGPLlxiqxMB/4v4SF8q/QNaPeHKdeQVv+NxXGiGmLYdSinf0xPCQHmWMmxmNzH",
+	"TudfI7Ua/b6lKaY0Yqd791wIXse2RwLPxc4xb8vnWPhTrNY2+LlmcehlfAGa8cSKubALwgXaMApj1Qw0",
+	"Q43fvGRC0gVydH7GEp5lJvgwVwwYob+Yu73hzoI0QsneDFKywjuIJFPOjMrmUGtx4Egk1+pugQOzlQZM",
+	"lXnRW7A4NrEca14+J6qRXv+jHKSekuGFNmQBR06ofezie0yRj+WJwH1MKzBV2LywbC9Tky675Vp2qRLg",
+	"Pu7aCZBiMrUM7hLIfWwN1qGqetk+3R4/UDZSuVQA8R42NjdddgOLVN1K9xLBbpn7uLlQKObpNlYvu3tQ",
+	"1jKYgeUpt7xPUU+Tp0TfOQYrL9PeXj3ShUpxLWUcvzk+d0D6uEZetuxhN7lDg0J+HhrZwp1Yl0Ke6Fdz",
+	"KaRTGtOYMQKo3Qh6AYJgw39Tk+Y+O5OsWXBLzYT1AT/C+IdxCmNeZJbEhS6A7ZWT+bX3aaajq+OfNsy1",
+	"pzQzPvoHmzQ6pZjgyoZ/fhzuY4wFk6qn8lckxsJaGiwX0qANHT0C7q4kI/6V8jthSrNUGOoZWQ2dC067",
+	"67KFKtisoPqKKW7hLs9EIiwburMN3QxDRNOwoTSV1rWtyOE+ZFA1bksiBOEvnD5r3FLLd1Ofvaf3bfkF",
+	"wtsGRL0kBFpVjhS2zy7rH+De3BeUxkhfvA+qerj3bsAh3woN2aI+Hc+ysLYAQ1NzdFPMofYDzr+yYpIB",
+	"J9e8jcMiZgP2O9rWOd+qK0QRe+wN/oFF4dTJ+x0R+5p6pZBKO8LGgykLroTygICOa29BMt7uRr4wKue7",
+	"yvkzMMaLzlUdNe5mK1cb0NQznhvqrIDelgP3cqd71tsLD8r7/yDXyv18kAqTZ3zB3MXxqoyg9BNiJULH",
+	"qD6w0KGCW+ELNdTbpzV3gmpqfaaoxhfvPfU+99EDFSyXu031Gz4vlQ8C/Kn+jbb1P/jObggAB+pupwSC",
+	"+w9//vChKGaDccYnhvDjQLTZAh7OHFAYU8qP3c39VhUGfKnEHSNwRoW1sVRwnJLRr/SoJa0BLZI1OGUw",
+	"tu7ZICZTtNiKNM2CDk+Ogluu0yieUOloKRl15V8P+A3zilG1qlNSOt0O+iTxk+gCU5WlgxtYmNjxUorz",
+	"cT+787lv6y11aNaa2WQ16GfJBCKL2YD0KFoO78POy2fLnP4OszrwaSRm4Bkrh6CQ+3VX34SRHur/yRKl",
+	"dIouu9IriRALPc6jM0WKtf3XfWZaIte7jpu6hUjzkeI69SmiO9JovO7Vsb/ekzA5Fb3y8c2bo5rcpNHN",
+	"UvskfVRp4/cwVPhGqNrTLt2VkBQWLT+579fPSdT32dUU2JDq8ZMORK3ivYi/ltUsOeUEktV0tTMtjXZA",
+	"QD0IX0c0Nueaz8CCNv1reXrHE5stmJLl7zSyUQ0O3/CoCI3QYDEXaYuPFVl55mTGpjt2VWB97HZSzSfb",
+	"DT/RfLI8eqbmsN3ot2oOy6PRM+LExKbB5+7Dn2FRG0uvpE0DL/Gr+jCwg6TQRm3USC7BHuOH9dEZ0AW3",
+	"dqD7yJNwzRu7GgsQ7DQrFNa4h2v4bcCbZg41zytQlqBp4LZx8nCQmOSuJt1wTHdPXMGdLcGzzOXxIq7d",
+	"zrEGbuEE6/gqvbjf5TlTKazRNNIwO3Mfsj2VoBcMT9llGC3y7z/8sN9nJ7XH07//8AMqcdxa0G66/+cf",
+	"h71//+3P77svPv5LPB3ITiNhlSOjMidtqk24D1GDxqMvLXLQ/9fNxl+3UgyYJ5CBhXNup/eD44YjhI2n",
+	"uMzjb/wCErz7JvfbfczQe7YStqzDIrWTsKMsn3JZzECLxL3Cpos8dL6u4Z/3/jjq/f2w99feb//2L9tl",
+	"sp+Q+rnlG3Op/A2gMtd64QbVnr6rEvlbahZgK8GB5hY2T+m/ZhobF0r20x9sz7cml0WWMTFGp1AKFhJ0",
+	"g+1HF70VaYygllfDz9buPwra5RvoaRRuJzZblO1SySatOxrFBO7xUddDD5dVlRP3yUo9pxHYWwAZNuIU",
+	"bR97yLX11OvkP+OZKlO+LCbpzoQUM7fRwxhO1jb388H+GEBQ9ftf3luIySebAkHI7WVWBg+amVJ2+j+x",
+	"KDvZI9AwUlg141YkTuN2ZxhxAynGvuKCKF8ykBN/Dn5H53h2eHh4WDvXD9GDPeSV4Y6w0yMjLinfa6ws",
+	"wTJhUK38x12XLX6rq/Q5F9qUuAv1dW+nIqNNTNBb/dapel53ZNyyDLix7Dl1/0QHRrnT5S3XQ0FKR/Fz",
+	"BF71H8unWfsj4bJBww6vEZs2mxYzLnuZuAH2I/whsCqfnkNFzYjhW76ggzAhjQWOVZwzIYF7o3iuMrIg",
+	"sV/Rs+pWQyOBGeSgBwYmSGnEDpAPkMkGM++imEjVrO5Ri7VrfN440g878mVZbgD3tYLBM9rFKjds5M+V",
+	"czZfsYftz9hyS0hbtC8s/ebh5Z00KCbaN8je0vbYs8Zen212X7Zd7qUZbluD2NLE68wup/SWO8/44hal",
+	"8LaXQby9Re11WE2J4f2RyMK0xV5C9a4P/oPPOf2T8gOquemZiX+ccsM4diB2v3+X8wl812Xf+ZzA7+h1",
+	"+Z03m37H5lwLd936p+Msz+Alu+7wWy4senf7E2XV3ndTa3Pz8uAA6Jt+ombf7b9iGmyhJat9jtlMe/uv",
+	"rjuxoAMqQ0PpyEmDDv+yQodvSVr7M+ITxreHDfGqQb1mwrC/HDYk/PcN+b6Z1hD4W9KDwQ3vSA6hH8sS",
+	"FVSnW/XsBCpfiuTF7mOehJ3eVMHHN36L13H3m159J1I8ImGyioDAze1R4t0+iZEUdGQ/lyF8h9qilZEb",
+	"9YNFLLmpipVfLCfzztYtZ6OW2+t8YFCHNqSNLt1xN08jXN8vECOQ1yKDMzlWq/JImEEq9Ppd4f2FTq/y",
+	"OdfSp0e1ljVzV/kMFRIfxBSqzZTB3Cm30PNVD1cjbaNyxx2LXrcjYX1OXpddd1J9e6d77v+uO+5hc93p",
+	"6due7rn/u+7EI2bicTk/cgONtIuxCC68VUhs/SoOOusqkYg/YDBaWIjQyaUPuMGf+76CWtiGALNFrE2I",
+	"m+Ko19cW6wY6qOHQA72NnCioqiXN43Xpo8Hcrgm0tYnbhvz4eEwpklvT4X1xWS51X6TuRiVxs5jPgljk",
+	"ULeBHV+cHl2ddrqdXy/O8H9PTt+c4j8uTt8dvT3dIqOBkhlaFRbsbbHsg2zB74lw/xWydQrpq/aWhQ5K",
+	"36iPZAjV1b3cpuAgKpdXBdzyMmSfZ8zyOyXVbPES03kobda39qpmN1YDn/kAyWHKLR+ig03pGWoWSpa4",
+	"Rh3CbWUEmbple2Thpi2R6dv79YftcBh2mYYJ12nmNBc1dguzvBhlAjOxhO2zY55loHvVHz0A0L3//vKK",
+	"HZS7P6hFGFEJBZ+0ESo3CEOQfcUMABsu7aV8j2KnMzPlOfTZLzwTaVlEOcHNhGhcw/iEu7cHTR0AHEKd",
+	"E1+i4TsT2nkEjyjqSGmFcbrwZzzPBbXv5rkYuLU2OLaPcuHAQyTV7fgQrQGGaA3C5b92hmMaculGkLZS",
+	"TpbmA98jf9McaX5MH9bHVi36Nw8/Kb8tZ6Doq4HXhtZPQN+ihrQ8PlOT7Ua/UZMwthZQRQ7ADTOcVd+j",
+	"MyQ2D7ojtp3lZ1jE5iALfFmHZevpyF3RqC3U7WRiDoO5gNstkfxGzOEXAbdLmK6m2RrfYaZVpIeO+9VU",
+	"G4/p++af1EYszyaksKE58laTnUlh613Cq6k0+FV2mu8ijNow6c7zrc5VdfXfbqrL8vswU6Mn+1aN4qp+",
+	"/t22ntT3bP5dmzD0Wt25j21jDt+hbff+d51ua+ebe/YYCjMu9cHYutlDk5tX2xrs3jWinCbJd6ghXo5S",
+	"PN2lWGsYVys4uHMxx9U5doBjS9W17krJnV2rGdXC20Oxip0Lgbg5lvJrd01d9qln7mWweIfaOymoH7sd",
+	"JWH7kNvl+/Fjd5dhtUt5y4ExHt51aJ1zdxsbEUK7TVBJwy3Hxeh6h6Fx4bLDBBVH7jBoieJ3WW5Z6uwy",
+	"Nsic3ders/i9EHOfGeKK4e6DS31w96ER3W/LSVo0hN1Gr+plu41fUXXuOfwe/NyiDG45uvEy21ZkLr2j",
+	"th+2rEpvOTKq0+849p5Lt707txweve7uW3WLKmy/EcaikS1ikNKaL9zzf9W8JSRZWzH5hpJ2+9sm55Ym",
+	"5IhfuLxuI/XVMjVZzpesNZNdGzG+3BljUnoULNzZ1k4GLRXXr8TM9wMqd0T9kigncFtbdIubrr50zLqG",
+	"ARbnPpr1otTtl83x24bZhiC2+4fXts2wdVjtSjTjbpEojxiRgeF9D4zFSIWxXCbQcND98NQRGG7PO0Vg",
+	"PDwswVvRqxgE908u7RIU44b1TeRZhXgECmNW3YtMt51pJ3K9f4xgCsYONsU6grHYvVrJ0sOzKVSw2zE6",
+	"2TQxFR3aes5lv2BYoFs7RQxC72/qcmkHx/HfqHgve/9z2Ql6Va6rm41Ue0bFvMEEz2d/s9dT3UTPcs5t",
+	"MvVhiPfDeFsc4kl7/GEpKJ6/ONw9GvGkNQqxz87GlKoIaZcVVIEM2FRMpmBsVeGQhlRtzZF8/CXr/Uh/",
+	"Oex+f9h9/kP32eFv8S0iaL1BbRO+xj5KScO4oPw4DVgXAEVwlV2tdBWAeqABjykMJYRDXNL4bK8q52k1",
+	"yLVancrwhUw4X6ivOn/wQWJGn6GUQsZTnlPMs4TbUCWpCtWgjD8HyynwdFxkXcpLDH/JWsizNfzzpDXs",
+	"sySb758fbhcEupwLcL+bd0OAZrh1w7VFafgLQ1GZy82eaiTq0H3YpW+5BmaxVMzmGLA1F2kZ1D7bdKPe",
+	"wIKqTTHjgONv9O0v2Pj6b3xoo5vdLGYjRZUJcCHf2tktEUqXj4Dx2rfMFHlVGekuVVap7FruGQD2n8+e",
+	"4VkWM5bCGMsIK2n2+8wHOpmyYtd15wLDX647XXbdQZsE/fPY6oz+dZT5P73+4brTv6bwRoqAE4biMxPc",
+	"IM+McrtM1GzkryzjcwJovn+zIXIC/wtX+7crPsJpdwDokrRG6EblNdUjOb2D5NFi2bg73gzjJRfSyRGJ",
+	"JVMjlTD0pBkW+Y9IfQWaietJUfZ0256quBlopZpBjfFjFM0apFiBzQ1luRZzkcEEWsQON4PCJxmvnzK0",
+	"PnJfu6lkkeHtEWT8aqYknT0SqYCADkntZgpZVoLc3QVFvINMchurBKA0FkqtHqt7vB5Zse9n9L5qWoRa",
+	"Ai4fYLPOBXLeTl5/xuLZPc7+/LiMsFM5F1pJfHiUcYpYAdO3bohX26kofyXWcLfwwnYEtkcREjo3suGD",
+	"Qgh5nelKhJXnWGXCte/B0/L8bY/BeCUjuBN2EI9ZPQ+1nEIp65bCvBhROBj95UU8oOgvL3og3fCU0ads",
+	"VIzHLT2CKKJw28lUYdsn+9iOvZ9Fle63G/ouqZA3Uq8s+4fUqLeJMqr73RBqnavTi7ed9fPWw5r85z+f",
+	"vXnT6XbO3l11up2fPpxvjmbya68h4gtURe97m1C1PXZ+9V+9EU9ummUTl2OiMxPvvVVW8k9UVsyokdW6",
+	"eN9uR6vbTXO5T3YMUsdZu7TRNRC7zPmtrANsq2I3kat7tRuir14HA2sXm2/BI/814yw3UKSqV55+7/zq",
+	"v/aXBWtVq6OqLzQHupFarss40kKjimXE0YOmfggMm1pObdgBpSsruc/uv8zHaB/GJl7vIc/PagZjPnIC",
+	"iTPjZlvHD9Hac+8vS2S11UAP1f1iwy+x2lev7FYX6ZVS209pxy0KkcYFMbaWHHAbtxNT/emVivB+2A6m",
+	"4lZWs9wWu3a6Pq6VFCoM3bLtUikvBnkSa8xmrJhh3Obx+QdWoD09B52AtHwC0T7Ia67RqhOEaFYvnHLj",
+	"e6lso6NQCd+WyOdqx6EgaqjHSrsvg6JbbvCoueW8wqltRNpWXQZo+/G7qB2xqZD3u3ROuOVOkt1qQQbQ",
+	"JdKjpAMh8yISSJ1yy7dSLNL6KpubAJTz/rbxzA/SF912fIKncdOtntB9YUG2EUmVEYYfMP95v7OtScUf",
+	"RQOvotp30Z0uT8u6txp89/d60xOfLaL0SqG3h2KzdKxVxOJOEVVBIe6ne9Pc0kr4uWOFaKrvVqKhFKQ0",
+	"uTDsGgded9pY1u0/cguQIdyHfataK4JkWsibZgUlTN4pU4K2ZGKK20b8P8wOMVLpglr30ZShmhwBQHru",
+	"Xg5lX99tuNKyfQeJbjR1oF6Hr1bKCitQVuUUu6Heab34Yxergna36VDRVhmOTug5of/gdhQbUiTWd2Xd",
+	"thwHlWAAHU+RGguJsfzbaAtVnYUwqk1X2Gh2ITVo9c+mLBhR+72R7bu1blPt1g+652aX4Iw6V32fMZhX",
+	"oToXMNmm1NF27pmfyC1Tlr2YeFvBmiIRLQb7X9FQv8tEWzrvaa7vjG92PHZCUkt4kDt/hzmjHtMAhW4A",
+	"7CaU3cfxoEtEb6hX1CSMqKRuVjXa1ZmbWT64W+//+Elp8YeSWDMH12J8pgpp+4yiONz7Ev9uGGbKdpmE",
+	"CW/83eEhfsHRDjaUyPjF7TjZYv1U3crI8kUeX/whAQtlXaXtbd+buIJbX0myKv7UXGp3pth5yq2jCFYq",
+	"Yu0otUSagtyQA0zRDpUryQ/a6Ar337Vs+7XI4Bz0TGCha3O//WODn7h9inr/UHqlZn9rPPJ3zeONlKr6",
+	"y4sX+7tVplK3MuYOcXvFn9ABEvb7oWW/2+R8UvphXsGWvJ7kYEPPc3rfqlFrcnDrJdZ2LCLPCwP1jHwq",
+	"55xD4ng/LU3sO9ro6w5jrK0WM9HXax80YqsONzJlffEoQJwK89r8ym3yqIXAyipt+GrGgonx6gWOccUc",
+	"Nps3S27387FybLbYIuSlNYAHIfDAcmLYDjweoHJR6bbhI4fice44dg5aixRMqMvvIbBfx/nzw0220qjl",
+	"MPj+Iza/mgJLBfwfqagZbjoQ9Jm8JAJu989V+6j7p0Kc4nrorAXIjN9hsr34A87k2x/bd4DBvqEnx9sf",
+	"t8TIco2pZ1sGoFxalT+U0JROwM2zmV/OZr6vQ7bALqToFVeFZRPNExgXWdl02SeTzzCMCk1LQmIcgNZF",
+	"biFlc5GCQmDF3QK7VNMjDnYbesJSelXWt5xDpvJdY/OusGIZDWWl+dxip7daeRG2lLEeqeEfDEdrC2I2",
+	"6wZgsdHfW22vvZmSyiopkjJYh5HRudopT7Qypmz9W++xRXTdZx+M71T3hhvbw5V7Zyc+Gq3wQd+Xl6fB",
+	"buTNZcJQZTEKaFnpKbmDe82dMVjWfluLw7Yg+aWCCVQq6VZo6GUwh8wbVTDJHwsn5bViCh5zDGSK56GW",
+	"KCEUSy6dvs+O9EhYzXWoe+D1LOpe64soVCUDNDCe0mR99nqlrcy6yg7dWEkG3DHoHhpviGxYqhIMqoGy",
+	"w+HQW4P+1dc6OFj6ywnOWwuY6rLVgg6b2rF+KbazCiH/cfn+XWk6i0E7E8ZDaX2ZCqraQ8boZeg3KzbH",
+	"4Epo8b1rnqiZ7CXYQDP+fiqNxK29Za2T3L4fW9lfdvv2sthLttFdttFYtlEH1z/EdGhIS7vzAY479qB9",
+	"WttlifvL4Oe6h0exrZlFpGlUnokW4+KvPMt6SaaSGwJZ9QqvAbPZOMTh109JWRo2FOerdiRMKI9CjRPS",
+	"7atGJWUB2p36bvhuG/e+vPz9lHFjV+7VqhOrBgM23G9NsNCrMd7reIcXkz8+nSNKO0v1q3c2oz2syusN",
+	"LIzV6gZMtDJjNPYhXj3yXlkxIVyv2kfICqplxzhJdIdtNTO+6F/Lk5VOQ6Gf4izkQx2koUbvPnWXcXIr",
+	"hJNfSx//60SAW4t67EqmwjOntl4DUmwP//Y/Dx1cfNLOfv9a1qqFYgsCB7VFTrfErdIpNg5NyUPmA0rL",
+	"kwtpNe+5r2hBcy2dFiA5FWHC641+znlhHJ6cYkJ78y2JTag9GkVdtD9Rt6WngiNFhCsWhafLYKowaJna",
+	"GbQU0VIDxzAJrKdF7Eo05e66dpr7IldMyH9SR13MnHjFZsJYfgOk9uA9iRoFwmzEkxuT8wQqImCHffZe",
+	"ZgsvwkwMAmzPiAykzRYNOF3L6jOkjX0CVfkyO+w/i1J9CMrYtp/Er1pYKDtg3I/R12OrEa4Qir6FBe/b",
+	"COMjdqUjbxxW6yxbCrIz7AHIjs7POt3OHLSh7Rz2n/UP0e6Xg8Tehp3v+4f9733JMzzIQcgmOaBuOGTz",
+	"SSJGn7egJ4CZIfglkQDcCYMufSXBdFmRu8uHLU0ayUeZC/fYykHPhVE67RKTYTnSQlqRIeTKr09gfqVU",
+	"Zth1B9U9KeTkuoNZq9R12jA1Qp0pZSMYKx3qYqIZxCdOITE5HJIFI0Wzn02mYZXXvhuQr1Tzo0oXvnF8",
+	"2SGlStI9+KchIyPdmBEPaYDmknYRjkQwtIrNEKy+TuM/rju93o1Q5oaSFno93xetN8mL685v+/fPM6AN",
+	"xcmq+s7xJ6UaYc4arvP88DBin8b9E75TfCeVR/PIXq7W+bHbeUEzxTSPcsWDH3ngSaoX/LHb+WGbcVg0",
+	"QfLMj8L6orMZdw+bzgeiy3KLGS9kMvVIcJv3e8ZhFfWWvaQ2cUVhQPdCP5ZqGcAi1loYYNSXi1UmqDLg",
+	"YcTLn/uOqrrXciO7sN255Vruyi7HoLHueIACm3HJJ/Sc9A2Ol9qAIhWz09B269L3t+teS2ww2sPC1JCW",
+	"M9I5yvkDGaIt8/jk/CDkJiu5j/fPyGnSkF5LtFcEWG7k7POqJdh9mTt+NcQ0qm2Q32c/h0ww/5PkMzDX",
+	"cs/nG/nb9FipGwHGw/G6Qy1LsfCv96hMyxnor/1reQnAQtln6olW7aQ/UWqSQUnYB+TpKLMlw98JpL5o",
+	"tDv/j9yI5Kiw0/dz0D9Zm5+G/pUEg+iG0VDkPjYf8onmKZhylL9U3/I7X7tCKGnOQZ87Oum8/P55t3Ou",
+	"8iI3R1mmbiF9rfQHnRn06a2WtO789vGx5Fqgla9WtC2TnTtLu4Qr8kzxtFd1yutxmfbCt07sKRNRdD7g",
+	"MComqtnMSZByCvaHyBnXyVTMHYfDncU2dXYKM1bIFDQ7mKoZHJAIqToVmoPr4vDw+8SxAv4LutfSvQe1",
+	"k3Gz+gokt4W8h6JRSs5r+QkVDYJXKRjNkUwvPIzXyaRZkVmRY4dHpWe9YCtr0zlq/Q5b0zWrb5zyQehH",
+	"mGCCALeN2gvbtGl/rTKHU/QaW8XyjCfgS38HdO2G9SUHwVHv77z3x2Hvr/1B77c/n3Wf//BD3Ln9h8gH",
+	"2MZxZYt/rwgyNNPwsYeFzCmTpWKfctd72GctpJrOuBRjMBav6P26FWIkpOPETVp9uT1fizn2MlmrwNWw",
+	"ez8t7lksHrWkBiIFSLsRaUdcUzIHdgvl6eeWeysiqMRmjcj3uHECyezXhWB5RC8N/Vv6YBR0vLjUOw1Z",
+	"tJKppQYvS90FDTnZfOvB0Lq9z478r3jzUxSOU2fIWmYFz7KF7yAyVVnZbvkuyQrjiNepP11mFJOKYYN9",
+	"Cn1npbAxLOGSbBQZ8Dlgd4gQ1GCsyk0wIoyFNtbX/g+NC8s+36KsOkHWytCQkJqyXstQnrow6GrEjrFT",
+	"z1UpUP6OexdWdkBMzaByKm61G1hQh0gPrmsZ/Jc5X7hZvFuBaVXItGe1yJlTHWVCEcSA6eUyFXORFjzz",
+	"08Qk74+oCDY7SN5fDVxrM11dqWqCdz9lBKdsaX7wOXmvZATqlhllgDpNL7HZUnPKwGxNxFVtKZ8IX5G+",
+	"l/dEE3UKC109A1t/VgxdilmRUbogcV29b2/ckLiCIzJXHThR346mC+Dpcc20FYPWY6Gr2bIWsbX09io7",
+	"z/ol8Z5a4ZsHQ9cdmizLZZ7JipWvDZxoG2yHZ9M4+USkH7eA3pf80erpc4uoIXzAwhcjsH4lg2wwpm+B",
+	"r7IZbBxNZdDrE2Fotc3s1sh5lPVrha9ifEbxuHMRGiKUr+UvBuM/idSX4FC39ep+TTQ32xzHtT6sLIRa",
+	"C0Z+B4FK/Ri7pZPKaW481NRzy2pLXiEMPZDLPRonYh7a4JFimgE3gLpVvbvQhgaCMY2nbIf5RKS52vD5",
+	"nnLDTfSFXJe4lapuIqGJIx6WKGYClghmUPZhbxUSfwPbqHH5lNdjvJhmnHcx6oBOWh7iMaD4N7CNwAav",
+	"eZCwCCtto3w0+4fHgVvW2nwiMl/tTP4g7dBDwZ3s85L621BCsoGdcCuWEe+VpDHbYKzRs32NHPV1+qp1",
+	"0I2PMrPm7y/D7clOXuV91IqNXctYCTEKEcMyV7mGKUh6N6/WKusyA3At3Wbi9cYYt5UZfSJsf6wBUjA3",
+	"VuV9pScHd+7/5VpZdXD37Bn9I8+4kAc0WQrj/pTkuQ/nmiqptKkHfvhYxnBe96L2weSJBwWmDRhvQiMs",
+	"qDTq8fAF8J6IHVZ67d+TGxChSC1fkrZAd3zdloR0uQXh1xu2tImqK34DVQrfU2mMK5mIHz2O1t44GJZ6",
+	"kFPmbLXSZuvmysVSbYBiXT8rQo95jh5JzioEhSC0DehUWdYuxCjHks19HmK2cNrbgXK8HXIj3d9sTcer",
+	"SdKmttiw8zWqOHo1sJHk6JsaS5apCaZAWpHcGLYnlfUJuGTirFEQG8GUz4Ujab5gc64Xr5gt0Erne7gH",
+	"Bg4xUyNlp7WjkLsx5Fxihqa3XXpXd7cerRpCftDT0zBp7pVzoCpcLbBPcR9oRaJgoRDZHUThMMSGkQGj",
+	"19OQA7fsHev1KOjqkJEHgRRy8iEMYxLyMqQ6PhH71ZJv7ysdPXl9ITYk2kylKxB6uHWa8Q7aXAj6bRGO",
+	"PuDyifCyHM/5ICMHBRF+MbeWOxsZNdZhwccIt8u0qpJscDcy9/8oDHmxHJ6MUqt0ERnLnYJmVZ5jakUC",
+	"bI8CErrX0vtkK29M1wkOTMvy7rhuTefzxYCN+EPIyb5/NZcLibLUFIM7nthscS1xuYZnSgNPhXR3uXs9",
+	"u/c4RlGHNYZUQLnQ2RDX82KHsxEY24PxWGl7LatuVGXZ5DBr8FK4mVFRcw8bPgFG6Qk/OtnokBBaWOoZ",
+	"zzDU1KprOQzq5NCX3+dygZBmC1WwVGEItAS346PQ6t+pJF4XxPgM9zX6JUfAfEGd/jX6GTBwpokr6vyu",
+	"C1nWu0W31cta/E0dNx4DXXKvd1E5lssY60dRomS2IOz7qw9kSoGxZQoOxaxfS6u5NEG9fcnEmHF07egq",
+	"/MftG51NboNcZ+5arJiOGZECA2xLG/LaZlxIRw+4NgUCJ+Bp1f1JKtl7fnfn/V25VjmfuAu5fy3PNYxR",
+	"tXbgmWOX/JxjIuewii741yGlAh14GA3Rn+ejW4ltMgjexZ7VYjIBpyddS8IBcZKQiE+fl1mF78cuqwDl",
+	"45J/HzFQgMKCBvXwtqX4jqvXvf/hc2+asUtsxnP2f//3/2EY421gxqUVCZbQPT+6Ov6JrUbPxSve+q8G",
+	"LYGStR2Qj5sN/7ymIMbrzst6nORvH4dbbghHR3fj0brNNmZOaKBmEn8nrVbZH7I9rCRyQHVEDsAm/f0+",
+	"Q4WLqk2HgOpVAqKQctMN/lnMZi0TRJalsahEcSNsqcGpTSaNFsRaE0dyWg/zMWiFDLtP3I2VFFhwo5qi",
+	"j5EhdIwqM2Bt3NF+f3MQyoNDRJ4+fgNjxt2QgZedq9C0XPf/MDYWnYJpX2AQvMNG7AwGm/qkRC+cvSgw",
+	"febFWYi/8pUYsFy2b29UBQ76we7/mYNa23TU4A1kbvweutsp1I4NfZjfAa2Cjv3hPqWbDh3c8kHFEkO6",
+	"FVBEErp9PEM4rJ3yMr7GuPsOP7jVPM9hpY37RnT5Kk/uco+w8cWb0vvjr3fwl3slhdde36UtqMsykBOy",
+	"zyeceM2y54cv/gdV2etWrOcQmGCwL4VRoIzwCKBdjDJoqYrchOUapa1KsAoQRO9BNZYysrXIyVm5RJMl",
+	"Vey5O7IsmOMzibAyOtwRR25Mzf6iXFQNTcjLy1eVullSgZs5g2XfVf8hiv2Lw79uHuc2mIlk5TnwOM7y",
+	"Ze0hPB9a4QSocLn/RVlexnSnLJ9yBHH95XGE+gw929NSocGnvM/ObWqieVaYFdiHQlYHtdu3jLKPhHP7",
+	"W/WpDJyR9jifmKL96iHZchVZH7yXNbyVGkD+bBT74NjlluM40hibg0QDtzAouyAgmRSxiCH8sKxN81Rh",
+	"Q81VdiKVZ+tK6dA5vyDzAp2Uccz5qsAf8JKCE5tb4OUEP3xqvNAq9XZm9/ZLlyihI6YP46wXm8e9U/a1",
+	"KmT6iA5t3Dnj7XgLevAalL0mdffLxhYWSvtvgCjER4kjdSudxuy4a/CHwIJAE7CxAlS20NIwzv5+ds7K",
+	"t0DtDRGeBmWJmKqoWSCN/moMiV//ROi/ixwj8jWfgQVtsPlBW7u/knNQB7Wq1PWdahAOha87N+73AlAc",
+	"0JsulHdr0kC3bsTYVC7ut50uZw/XBzm9HNTDGctKSEhYdQB/jXTpkVUXIe41QIQWHrRxejU23YJgw9t3",
+	"z3JdewDPgnMY9VA31/5aur6Wawib/d3YlKnxGLRhRkykGIuEY+r5mBt6/tGCXn+9linU/+T+zTW9AP8Q",
+	"uTe48GQqYI7NUsEuz4JsFI/MqnGVg9HXwlbdP1dbf5XHxQiGPvtJTKag6b/KDsLMzHiW1c0Ro8Iyy2+A",
+	"ZUpOQPevZY8wYexL9r8ctmkK9qzLfOK/QyykbO9/fX942Pvh8JC9/fHA7LuBvrBBc+D3XTbiGZeJU6Xc",
+	"yAPEANv7X89+qI0lxDWH/ns34DMM+eGw9z8ag1a2+ayLfy1HPD/svShHtGCkRi0DnKZTR0dV0jz8q6q7",
+	"5EHV6dZ+oy3jP0ysIP2uUtFz74PE4tWSXev/I6JxyZxXikc0uITaDV4sNkVD2Up8W5mAksCDdaWr+Zdy",
+	"w+6mE1bt1FcJCrW8Wq/2r5Bs/ga20W0+NA9awV5JNpkwFvV000o3VdP7+10mXyelVKeOkEr1fMuoNslX",
+	"SCuYrYuYp0TCVdrANultz7fQ2PsJQ2Mf4+mGoaiVueMrxBOeAFs5o5drHTNr4Gn56I7y8gXw1D+5t2Nl",
+	"XCyohG7+L4WbVWLB9qqWNQ/SJVD0R/O4vjJiwayxhruuJA4DJOgHtZLprdy9Wrn+6ZKQWkrk37u6Rq0i",
+	"vE8Z+goReQl2ldHr1e4PsJq+mYq8xDB5QNuDsLDOiak5Sn3uuNJVfAldCD5UX8NMeRlAuWz9lqoTQT14",
+	"tOiRUiNpcdGnYOxgQ5cA943vsl1KMF81zSu02/QH6Hbu6833nvxqqzuXYyAoPFolBsRSWYThaxd1keIM",
+	"Y6+v1dkhmDbXFpnhaHihGDTsl0z1ZIQ1lW1zJX1lmb7amIOsm4/GGruSflpvpFCrlFPFSKjt+OCRIlvW",
+	"8cM9CfvvIq/IuobA/zZEzusFj5ZIdIXevXFlA8Hvahpt44truZkxNptIGxbRa7lkEm0vd+RtnI/GXK1R",
+	"VFdTWDa9lFfIFnFDn41p41E+bcVa320f6OO7U/m9YTEjLO/ryKnXw2961bj9/m41lAMenkRcHHkY/jcX",
+	"Gcvk2iI2bpcLEi29BGr9fZ7qDRBpIbQ9bu9ZPBWPHW16/UGK3wuI9b2puPLWg2OreLXleu02mbLHrvH3",
+	"mYiNDlM3UvtCTXJS08QQWgd/BpB/9GXMgYqULNObyityWzJSoOHBWxq83aHE4zrbw2ZTw4tYYX1CFAU7",
+	"f+WIusQGPiGuPGbtW0bSAeXItZqSqGfza3NKn31CXC2bhSzcWdpt1B60yR9wiU9b3zonknNatbBR49pb",
+	"2OcQYu9OnuKp/+z8Z+/y8rTnywf1rqKtKN5CKrivtj7GHjHYesOnJO4tC7H9hucueOlWRF3EKffxayRT",
+	"6hW0DGVf8oTEbkmx7jG/PsgIi/JsY/A8qSlffMX4+Qn93u+rhgShO2NrY8ZG75S/vHjRtk3sZtiyrbXt",
+	"HIn5trnxH2iOvac1oywJ9bVfo2iWcjdniIesQrUyNTEHFWDjLjo18T30W+TwEkH47kLrKDcIGk/iVX3b",
+	"aE/3+DJjlWXqNh550OhoXeu5uIxmTPAo0/bEmNHemTDMb20NY7bfKrusUzt7fLXqg0FObWo6n+1Ge6Mm",
+	"W15ljrC+6NsrdjO4TVMO5eXlKTFInvHFraa0NyoauUV51bL513k5miVO2KIvdKzBTGu9WhE1d5bxCRfS",
+	"0Es8ZCHoQmIJZ6kky1TCs6ky9uVfnz9/TtmpOOuUG+wgZ1BUf5fzCXzXZd/5eb+jhJ7v/JTflZ1iQpUG",
+	"31XRx2LgjNXmsFSuLbSsGrkF8ooZTjwIqnMf0+3wFC+7lbU+U9ZDZB8OoPFklRK4X2I51OoIWHbgEndO",
+	"FBEhTs8gJJOQO9of+r7Bllvoyer7lCt8Jjpo7KCNAqpqxtp/80WUwU3UbOakhFnIZKqVVIUJVW8Dgk3O",
+	"b+VGDF/iV0+KYlzi8+LYb6ENyfjzZy5+sopbvga5f/p/4Nv8RjQrCEUR/bPAUjSb3+XVzGtVwlKTLwqR",
+	"PuSxcC+EutN8kZVK3//8VcYXOFEiJu6laRULams7xVFhgI00d0Gf/behOjrPN7p7vAAlrC/B2fnVf/VG",
+	"1EphM/EZy23RbooMIp+++tS098T3GB0qdoX5X77KKGWPAGbC8dpRn4otdBr86r+N1MHjfGb9ibbQpj/9",
+	"uMDWHWR++2otbtXNx4jO1tKhKuwmQ1wFPFXYtRa5zySPHmBZKs/mhm1pYwrQVYXNC+qRn4kxJIskg28O",
+	"lKdzoNSoWhV2yWCmIcFyoZODygkbl66UOXwRvn/SRO1ylc21ZZfTPf3Az5ei/ZlqW5SJ3bmGucA3IyPk",
+	"QsrmIgVV8yPUsO6Ty1qlWMg+qyN+rfesdFr51XW9yT5VIfNN/BvVXItQq9t7BcrhbY4sFHpxNxbv/XHU",
+	"+/th76+93/7tX+4lGhFgB7P8xYPTCSqK9DGPDQFX/tp7LSQ2qe8dxRo9ixkYy2e5E3LUnB8tu9XUNLjP",
+	"/lZwzaUFipcbAbt4ffz999//tb/eA9LYyiXFo9xrJz6W5b4bcVt5fvh8HWNjcTmRZUxgsciJBmO6LMd+",
+	"FszqBdk+qcZjE9wXYPWidzR2P6yWwi0mE8oVxbYa2AFSSFY1zA/dF/WCmKA6RBnL9iwSy/bxK044pVK8",
+	"BnmRGqhvIVEyQbdHa/7ghWds89D+FGU+wLoLJaxGmZ4rQfYr/BoaV+pyl4+WYMezrD5tE2wrHVAjoXdP",
+	"ffk2F1l79z5bx6JeCHyFFaIQAmUV90qu9dl7Kjlbl3U5aHZ2gi0Qsbb5RBiLXRqxZLWTIP1VLKt8HZJV",
+	"/vQ4rq1xf/XKh8J93oLhVuXN64fAbRKegVV/gFYHvp/92jYh9FZwE/3ylooWuhmw8IdibpauQy7XaYbP",
+	"lzH76erqnFnNx2ORMCWZsH12zLMs1Ao5Oj+jEtnCuClv3W11y2+ACctGkPDCAPsgxY3mY0u/hs7jiW/s",
+	"dAO+SckiFDEIOSe/vI2W+qBjXrqTX6m/g1adbcIa8fueVT13SuZhlT4Kcs5SmOXK0rXhZ0a4QoBqDUT9",
+	"VcSBXI+3CzBWaTC+bCZNXR6l7ERQrdF18lfdogqB0GxuhrQG1GhEmgEhlMaWas4vb5lUvpQIVs42XreZ",
+	"QpYy7tAW9bLLh+MG5BOhhibehBkLGcyc7rOx0E69IVM5qllqr8/Cxy8OXzAxrn1HVburIqnR1jN/A3tV",
+	"7ucJrV/lIpeW26jZ/Sp+wPvqbqvdrdrnLytXLokzrn0TDMp3JYS0IgJvtYRbmFAlXrhzwBKOMAzWj6jX",
+	"UWEjlS6wmiwFdaevwkuuPoUGy2mc0CUlGOrQb3ZCPfN9/VFxGmNOUrWMLXniJcPu/izJgGsTijXVThnr",
+	"XuSg1ySiJ+jQS4EX5TL1QpufzoZ7byr+XBnTsZKd6xihiPXNAbuB8gMdPj981qTDW06EWLOjVDT5yodX",
+	"uXGHbpywbsBjkeorErvu/0oZ7a+f3UTkeWE/H3V/8dS8a7bQ02zIwOcNJ7pcd8E0Lv1a+kdcGTuT/8Tu",
+	"GFyS5Z2JkAlaLUCOgC6bcN9CD1MYEyz/vbyNOnseUvopfm2MmEhIGcg5ZCqHSjXzyxrG02BcfH74IvL7",
+	"WGT0SNuTKiwfCkr71C789jsTWBhZLujG+1331YvDQ6cjzXkmUl72qm9prXFejDJhqtuG3CVP5DOktXCJ",
+	"z+QzrM7pkRSNq0N05LRbJ1ZLjCZch54AFb5DW/8+cW9EW6YJeZJAjuRV2ArT62ntFUn7sJUHVGJvtvij",
+	"CbdgiWVmW3ErLtvXQVKr3jmwpoetmpkYts9OeTJlY81nFHaMxS6UnrGhSF+yPw38/vH6Wqbc8pfsz4CC",
+	"nsO3+/v1tRy6m41g7yv/lw3ZEjCmN1NSWSVFgu68HLRBQ1eilTFL4s4nAr5inL3hxvYQY72zE3pxY28i",
+	"f+O6gRKSENCMXIbPYQ2mmIVHNh27z060ymlTFMJECJ/w3AT1dSjSIXUEwf4/3mIAYg4p/SYM1YywUy7Z",
+	"M8anwNMQYJ25vRoAiZ92g2fxFrQTFAKzhMuu7KNiPAbdZ8eZwK98J1GreXITmc1pBilYSCzut89eY6x5",
+	"dXzqAOUenU2QoYGtWrbSsj2qHDIwicEAYDntQA9XU2C3wsFqynNMaMDGgSBBi4QNmzJqSN1NQ3C7Pzl4",
+	"ld9z1c/YJIRaMLI99/kCmxU5SqGWepylKilmIN2ooV3kMKR2W6WgHVJ3EUcvSs/K8hpV6xuva/wrbusE",
+	"PyZx02UGMkj8fmjyaC8+JJbm8TbWsLtw5Bb6dqBiZpq84PtqKc0MyJQdUkZ8FDWhgd22/NRlRjWZYs6z",
+	"gqL/Z+BYRGtIsGoCLcXdGgLbcwWHGbk+Ko9Zg4Y+X1bKVhfEmy2k21eXsLJ8AsYNu0T3Z+/SEYknSzf6",
+	"/w0AAP//kgERyXu3AQA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -1701,7 +1701,7 @@ components:
     BrowserConsoleLogEvent:
       type: object
       description: A browser console log event (console.log, console.info, console.warn, etc.).
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -1710,6 +1710,9 @@ components:
         type:
           type: string
           const: console_log
+        category:
+          type: string
+          const: console
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -1754,7 +1757,7 @@ components:
         args, and stack_trace. Runtime.exceptionThrown (uncaught exceptions)
         produces text, line, column, source_url, and stack_trace. Fields not
         applicable to the source are absent.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -1763,6 +1766,9 @@ components:
         type:
           type: string
           const: console_error
+        category:
+          type: string
+          const: console
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -1806,7 +1812,7 @@ components:
     BrowserNetworkRequestEvent:
       type: object
       description: A browser network request sent event.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -1815,6 +1821,9 @@ components:
         type:
           type: string
           const: network_request
+        category:
+          type: string
+          const: network
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -1855,7 +1864,7 @@ components:
     BrowserNetworkResponseEvent:
       type: object
       description: A browser network response received event. Fired after the response body is fully received, not when headers arrive.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -1864,6 +1873,9 @@ components:
         type:
           type: string
           const: network_response
+        category:
+          type: string
+          const: network
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -1896,7 +1908,7 @@ components:
         flight when CDP attached (no prior `network_request` was emitted for
         it), `url`, `frame_id`, `loader_id`, and `resource_type` are absent;
         `BrowserEventContext` is partially populated in that case.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -1905,6 +1917,9 @@ components:
         type:
           type: string
           const: network_loading_failed
+        category:
+          type: string
+          const: network
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -1915,7 +1930,7 @@ components:
     BrowserNetworkIdleEvent:
       type: object
       description: A browser network idle event emitted after a 500ms quiet period with no in-flight HTTP requests.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -1924,6 +1939,9 @@ components:
         type:
           type: string
           const: network_idle
+        category:
+          type: string
+          const: network
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -1959,7 +1977,7 @@ components:
     BrowserPageNavigationEvent:
       type: object
       description: A browser page navigation started event (CDP Page.frameNavigated). Carries nav context fields inline but not nav_seq, as this event resets the navigation epoch.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -1968,6 +1986,9 @@ components:
         type:
           type: string
           const: page_navigation
+        category:
+          type: string
+          const: page
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -1987,7 +2008,7 @@ components:
     BrowserPageDomContentLoadedEvent:
       type: object
       description: A browser DOMContentLoaded event (CDP Page.domContentEventFired).
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -1996,6 +2017,9 @@ components:
         type:
           type: string
           const: page_dom_content_loaded
+        category:
+          type: string
+          const: page
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2015,7 +2039,7 @@ components:
     BrowserPageLoadEvent:
       type: object
       description: A browser page load event (CDP Page.loadEventFired).
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2024,6 +2048,9 @@ components:
         type:
           type: string
           const: page_load
+        category:
+          type: string
+          const: page
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2058,7 +2085,7 @@ components:
         target, so `session_id`, `frame_id`, `loader_id`, and `nav_seq` are
         absent; this event does not compose `BrowserEventContext`. Consumers
         reading context fields generically should treat it as a special case.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2067,6 +2094,9 @@ components:
         type:
           type: string
           const: page_tab_opened
+        category:
+          type: string
+          const: page
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2103,7 +2133,7 @@ components:
     BrowserPageLayoutShiftEvent:
       type: object
       description: A browser cumulative layout shift (CLS) event from the Performance Timeline API.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2112,6 +2142,9 @@ components:
         type:
           type: string
           const: page_layout_shift
+        category:
+          type: string
+          const: page
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2157,7 +2190,7 @@ components:
     BrowserPageLcpEvent:
       type: object
       description: A browser Largest Contentful Paint (LCP) event from the Performance Timeline API.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2166,6 +2199,9 @@ components:
         type:
           type: string
           const: page_lcp
+        category:
+          type: string
+          const: page
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2176,7 +2212,7 @@ components:
     BrowserPageLayoutSettledEvent:
       type: object
       description: A browser layout settled event emitted 1 second after page load with no intervening layout shifts, indicating visual stability. Each layout shift resets the 1-second timer.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2185,6 +2221,9 @@ components:
         type:
           type: string
           const: page_layout_settled
+        category:
+          type: string
+          const: page
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2199,7 +2238,7 @@ components:
         fired for the same navigation, indicating the page is loaded and
         visually stable. Independent of network_idle; a single pending request
         does not block it.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2208,6 +2247,9 @@ components:
         type:
           type: string
           const: page_navigation_settled
+        category:
+          type: string
+          const: page
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2239,7 +2281,7 @@ components:
     BrowserInteractionClickEvent:
       type: object
       description: A browser user click event captured via injected page script.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2248,6 +2290,9 @@ components:
         type:
           type: string
           const: interaction_click
+        category:
+          type: string
+          const: interaction
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2273,7 +2318,7 @@ components:
     BrowserInteractionKeyEvent:
       type: object
       description: A browser keyboard event captured via injected page script.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2282,6 +2327,9 @@ components:
         type:
           type: string
           const: interaction_key
+        category:
+          type: string
+          const: interaction
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2313,7 +2361,7 @@ components:
     BrowserInteractionScrollSettledEvent:
       type: object
       description: A browser scroll settled event emitted after scroll position stops changing, captured via injected page script.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2322,6 +2370,9 @@ components:
         type:
           type: string
           const: interaction_scroll_settled
+        category:
+          type: string
+          const: interaction
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2341,7 +2392,7 @@ components:
     BrowserMonitorScreenshotEvent:
       type: object
       description: A periodic screenshot of the browser viewport.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2350,6 +2401,9 @@ components:
         type:
           type: string
           const: monitor_screenshot
+        category:
+          type: string
+          const: system
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2369,7 +2423,7 @@ components:
     BrowserMonitorDisconnectedEvent:
       type: object
       description: The CDP connection to Chrome was lost. Telemetry events may be dropped until monitor_reconnected arrives. Treat any in-progress computed state (network_idle, page_layout_settled) as unreliable until then.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2378,6 +2432,9 @@ components:
         type:
           type: string
           const: monitor_disconnected
+        category:
+          type: string
+          const: system
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2397,7 +2454,7 @@ components:
     BrowserMonitorReconnectedEvent:
       type: object
       description: The CDP connection to Chrome was successfully re-established after a disconnection. Events emitted during the gap are lost. Computed state is reset, so navigation and network tracking restart fresh from this point.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2406,6 +2463,9 @@ components:
         type:
           type: string
           const: monitor_reconnected
+        category:
+          type: string
+          const: system
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2425,7 +2485,7 @@ components:
     BrowserMonitorReconnectFailedEvent:
       type: object
       description: The CDP connection to Chrome could not be re-established after exhausting all reconnection attempts. No further telemetry events will arrive on this session.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2434,6 +2494,9 @@ components:
         type:
           type: string
           const: monitor_reconnect_failed
+        category:
+          type: string
+          const: system
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2452,7 +2515,7 @@ components:
     BrowserMonitorInitFailedEvent:
       type: object
       description: The CDP session could not be initialized.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2461,6 +2524,9 @@ components:
         type:
           type: string
           const: monitor_init_failed
+        category:
+          type: string
+          const: system
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2489,7 +2555,7 @@ components:
     BrowserApiCallEvent:
       type: object
       description: An HTTP call handled by the kernel-images-api server.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2498,6 +2564,9 @@ components:
         type:
           type: string
           const: api_call
+        category:
+          type: string
+          const: api
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2508,7 +2577,7 @@ components:
     BrowserCdpConnectEvent:
       type: object
       description: An external client (e.g. customer SDK, Playwright, Puppeteer) connected to the CDP WebSocket proxy on this VM.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2517,6 +2586,9 @@ components:
         type:
           type: string
           const: cdp_connect
+        category:
+          type: string
+          const: system
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         truncated:
@@ -2550,7 +2622,7 @@ components:
     BrowserCdpDisconnectEvent:
       type: object
       description: An external client disconnected from the CDP WebSocket proxy on this VM. Pair with the immediately preceding `cdp_connect` on the same stream.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2559,6 +2631,9 @@ components:
         type:
           type: string
           const: cdp_disconnect
+        category:
+          type: string
+          const: system
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2779,7 +2854,7 @@ components:
         The Linux kernel OOM-killer terminated a process inside the VM. Sourced from
         `/dev/kmsg`. Fires for any process killed by the kernel due to memory
         exhaustion, including Chrome renderer subprocesses that are not supervised.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2788,6 +2863,9 @@ components:
         type:
           type: string
           const: system_oom_kill
+        category:
+          type: string
+          const: system
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:
@@ -2831,7 +2909,7 @@ components:
         A managed service exited unexpectedly. Intentional stops (e.g.
         operator-initiated shutdown) do not produce this event — only
         unexpected exits and terminal restart-give-up transitions do.
-      required: [ts, type, source]
+      required: [ts, type, category, source]
       properties:
         ts:
           type: integer
@@ -2840,6 +2918,9 @@ components:
         type:
           type: string
           const: service_crashed
+        category:
+          type: string
+          const: system
         source:
           $ref: "#/components/schemas/BrowserEventSource"
         data:


### PR DESCRIPTION
## Summary

- Adds a `category` const to 27 of 30 `Browser*Event` documentation schemas in `server/openapi.yaml`.
- Field maps 1:1 to the `Category` Go field on `events.Event` that the VM already sets on every emitted event (`server/lib/events/event.go:38`), so consumers can read it directly off the per-variant schema instead of falling back to the base `TelemetryEvent`.
- Regenerates `server/lib/oapi/oapi.go` so the Go types pick up the new constants.

Source-of-truth for the const values:

| Schema | Category | Source |
| --- | --- | --- |
| `Browser{Console,Network,Page,Interaction,Monitor}*Event` (22) | derived by prefix (`console`/`network`/`page`/`interaction`/`system`) | matches `cdpmonitor/*.go`, `screenshot.go`, `devtoolsproxy/proxy.go`, `monitor.go` |
| `BrowserApiCallEvent` | `api` | `cmd/api/api/middleware.go:67` |
| `BrowserCdpConnectEvent` / `BrowserCdpDisconnectEvent` | `system` | `lib/devtoolsproxy/proxy.go:474,491` |
| `BrowserSystemOomKillEvent` | `system` | `lib/sysmon/sysmon.go:180` |
| `BrowserServiceCrashedEvent` | `system` | `cmd/supervisord-shim/main.go:234` |

Skipped (left as-is, no `category` declared on the per-variant schema):

- `BrowserLiveViewConnectEvent` / `BrowserLiveViewDisconnectEvent` — emitted by Neko (external)
- `BrowserCaptchaSolveResultEvent` — emitted by external captcha solver

Their producers live outside this repo, so I didn't want to lock down a const without confirmation. Worth a follow-up to either declare them here (likely `system` for live_view; captcha is less obvious) or document them as freeform on those schemas. Wire emission for these still flows through the base `TelemetryEvent` schema, which already declares `category` with the full enum.

Companion to https://github.com/kernel/kernel/pull/2252 (kernel/kernel openapi) — same field, mirrored on the doc-only schemas here.

## Test plan

- [x] `cd server && make oapi-generate` regenerates cleanly
- [x] `cd server && go vet ./...` clean
- [x] `cd server && go build ./...` clean
- [x] `cd server && go test -race $(go list ./... | grep -v /e2e$)` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> OpenAPI and generated Go type changes only; runtime category assignment is unchanged and three external-producer events are intentionally left undocumented.
> 
> **Overview**
> Documents **`category`** on **27** per-variant **`Browser*Event`** schemas in **`server/openapi.yaml`**, each as a fixed const (`console`, `network`, `page`, `interaction`, `api`, or `system`) aligned with what the VM already puts on **`events.Event`**. **`server/lib/oapi/oapi.go`** is regenerated so typed events expose **`Category`**, enum constants, and **`Valid()`** helpers.
> 
> **`BrowserLiveView*`** and **`BrowserCaptchaSolveResultEvent`** are unchanged (no locked const) because those producers sit outside this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a04ed01676a7adcf3ac62e9b1c251f58ebc9d64d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->