### PR TITLE
Skip chromium restart on headful display resize

### DIFF
--- a/server/cmd/api/api/chromium_configure.go
+++ b/server/cmd/api/api/chromium_configure.go
@@ -692,7 +692,7 @@ func chromiumDisplayApplyWhileStopped(ctx context.Context, s *ApiService, plan *
 	if s.isNekoEnabled() {
 		err = s.setResolutionViaNeko(ctx, w, h, rr)
 	} else {
-		err = s.setResolutionXorgViaXrandr(ctx, w, h, rr, false)
+		err = s.setResolutionXorgViaXrandr(ctx, w, h, rr)
 	}
 	if err != nil {
 		return cfg500ConfigureStep(chromiumConfigureStepDisplay, err.Error())

--- a/server/cmd/api/api/display.go
+++ b/server/cmd/api/api/display.go
@@ -457,6 +457,15 @@ func (s *ApiService) setWindowMaximizedViaCDP(ctx context.Context) error {
 // taskbar/dock would shrink the maximized window below the root size,
 // but the root itself would still match what we asked for.
 //
+// Calls getCurrentResolutionFromXrandr directly rather than the
+// higher-level getCurrentResolution: the latter prefers a cached
+// viewportOverride when one is set, which would silently validate this
+// post-condition against the CDP viewport instead of the X root. The
+// override is only set on the headless Xvfb fast path today, so the
+// Xorg branch never reaches that case — but the invariant is non-local
+// and would silently regress this check if anyone ever sets the
+// override on the Xorg path.
+//
 // Typical convergence is sub-millisecond (Neko's ScreenConfigurationChange
 // returns after the X server has applied the mode), but a small loop
 // covers any future asynchrony in the resize chain.
@@ -465,7 +474,7 @@ func (s *ApiService) waitForXRootSize(ctx context.Context, width, height int, ti
 	var lastW, lastH int
 	var lastErr error
 	for {
-		w, h, _, err := s.getCurrentResolution(ctx)
+		w, h, _, _, err := s.getCurrentResolutionFromXrandr(ctx)
 		lastErr = err
 		if err == nil {
 			lastW, lastH = w, h
@@ -475,7 +484,7 @@ func (s *ApiService) waitForXRootSize(ctx context.Context, width, height int, ti
 		}
 		if time.Now().After(deadline) {
 			if lastErr != nil {
-				return fmt.Errorf("last getCurrentResolution error: %w", lastErr)
+				return fmt.Errorf("last getCurrentResolutionFromXrandr error: %w", lastErr)
 			}
 			return fmt.Errorf("x root is %dx%d, want %dx%d", lastW, lastH, width, height)
 		}

--- a/server/cmd/api/api/display.go
+++ b/server/cmd/api/api/display.go
@@ -253,15 +253,17 @@ func (s *ApiService) setResolutionXorgViaXrandr(ctx context.Context, width, heig
 		output = "DUMMY0"
 	}
 
-	// Build xrandr command - if refresh rate is specified, use the specific modeline
-	var xrandrCmd string
-	if refreshRate > 0 {
-		modeName := fmt.Sprintf("%dx%d_%d.00", width, height, refreshRate)
-		xrandrCmd = fmt.Sprintf("xrandr --output %s --mode %s", output, modeName)
-		log.Info("using specific modeline", "output", output, "mode", modeName)
-	} else {
-		xrandrCmd = fmt.Sprintf("xrandr --output %s --size %dx%d", output, width, height)
+	// Per-output resizing requires --mode <name>; --size is a legacy global
+	// screen option that cannot be combined with --output. Always go through
+	// a named modeline. The schema enum prevents callers from sending zero,
+	// and getCurrentResolution falls back to 60 when xrandr is silent
+	// (Xvfb), but normalize defensively in case either guarantee changes.
+	if refreshRate <= 0 {
+		refreshRate = 60
 	}
+	modeName := fmt.Sprintf("%dx%d_%d.00", width, height, refreshRate)
+	xrandrCmd := fmt.Sprintf("xrandr --output %s --mode %s", output, modeName)
+	log.Info("using specific modeline", "output", output, "mode", modeName)
 
 	args := []string{"-lc", xrandrCmd}
 	env := map[string]string{"DISPLAY": display}

--- a/server/cmd/api/api/display.go
+++ b/server/cmd/api/api/display.go
@@ -138,7 +138,7 @@ func (s *ApiService) PatchDisplay(ctx context.Context, req oapi.PatchDisplayRequ
 		// old size while the X root is at the new size, and the caller
 		// would have no signal of the mismatch.
 		if err == nil {
-			if cdpErr := s.setWindowMaximizedViaCDP(ctx); cdpErr != nil {
+			if cdpErr := s.setWindowMaximizedViaCDP(ctx, width, height); cdpErr != nil {
 				log.Error("CDP maximize re-assert failed after Xorg resolution change", "error", cdpErr)
 				err = fmt.Errorf("CDP maximize re-assert failed: %w", cdpErr)
 			}
@@ -395,17 +395,21 @@ func (s *ApiService) backgroundResizeXvfb(ctx context.Context, width, height int
 }
 
 // setWindowMaximizedViaCDP re-asserts that the chromium OS window is in
-// the "maximized" state via Browser.setWindowBounds. After a successful
-// xrandr/Neko resize on the headful path, mutter will reflow a maximized
-// window to fill the new X root — so this call is the entirety of what
-// the server needs to do post-resize. It replaces the previous approach
-// of restarting chromium so it could re-apply --start-maximized, which
-// cost a multi-second restart and also reset other browser-side state
-// (notably Emulation.* overrides).
+// the "maximized" state via Browser.setWindowBounds, then waits until the
+// window manager has actually reflowed the window onto the new X root.
+// After a successful xrandr/Neko resize, mutter reflows a maximized
+// (or fullscreen) window to fill the new root automatically — but that
+// reflow is asynchronous to the CDP setWindowBounds acknowledgement, so
+// the handler polls Browser.getWindowForTarget until the live bounds
+// match the requested width/height before returning.
 //
-// The call is idempotent and cheap: when the window is already maximized
-// the helper returns immediately without sending any CDP commands.
-func (s *ApiService) setWindowMaximizedViaCDP(ctx context.Context) error {
+// This makes PATCH /display a synchronous contract: the API returns only
+// once the window is at the new size, not just once the resize has been
+// initiated. The previous approach of restarting chromium so it could
+// re-apply --start-maximized had the same effective contract (the restart
+// blocked the response) but cost ~9s per resize and wiped browser-side
+// state (Emulation.* overrides, devtools sessions).
+func (s *ApiService) setWindowMaximizedViaCDP(ctx context.Context, width, height int) error {
 	log := logger.FromContext(ctx)
 
 	upstreamURL := s.upstreamMgr.Current()
@@ -426,8 +430,43 @@ func (s *ApiService) setWindowMaximizedViaCDP(ctx context.Context) error {
 		return fmt.Errorf("CDP setWindowBoundsMaximized: %w", err)
 	}
 
-	log.Info("re-asserted maximized window state via CDP")
+	if err := waitForWindowSize(cdpCtx, client, width, height, 3*time.Second); err != nil {
+		return fmt.Errorf("window did not reach %dx%d after CDP maximize: %w", width, height, err)
+	}
+
+	log.Info("re-asserted maximized window state via CDP", "width", width, "height", height)
 	return nil
+}
+
+// waitForWindowSize polls Browser.getWindowForTarget until the live OS
+// window's width/height match the requested size, or the deadline expires.
+// Typical convergence on docker+mutter is 20–50ms; pick a deadline that
+// comfortably covers WM scheduling jitter without masking real bugs.
+func waitForWindowSize(ctx context.Context, client *cdpclient.Client, width, height int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var last cdpclient.WindowBounds
+	var lastErr error
+	for {
+		b, err := client.GetWindowBounds(ctx)
+		lastErr = err
+		if err == nil {
+			last = b
+			if b.Width == width && b.Height == height {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			if lastErr != nil {
+				return fmt.Errorf("last getWindowBounds error: %w", lastErr)
+			}
+			return fmt.Errorf("window is %dx%d state=%q", last.Width, last.Height, last.WindowState)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
 }
 
 // setViewportViaCDP resizes the browser viewport using the CDP

--- a/server/cmd/api/api/display.go
+++ b/server/cmd/api/api/display.go
@@ -120,23 +120,20 @@ func (s *ApiService) PatchDisplay(ctx context.Context, req oapi.PatchDisplayRequ
 			err = s.setResolutionViaNeko(ctx, width, height, refreshRate)
 		} else {
 			log.Info("using xrandr for Xorg resolution change (Neko disabled)")
-			err = s.setResolutionXorgViaXrandr(ctx, width, height, refreshRate, restartChrome)
+			err = s.setResolutionXorgViaXrandr(ctx, width, height, refreshRate)
 		}
-		// Headful default path: skip the chromium restart and re-assert
-		// the maximized window state via CDP instead. Mutter reflows a
-		// maximized window to fill the new X root automatically, so this
-		// is all that's needed — and it costs ~50ms vs ~9s for a restart.
-		// Callers can still opt into the legacy restart with
-		// restart_chromium=true (rare; preserved for compatibility).
+		// Re-assert the maximized window state via CDP after the X root
+		// resize. Mutter reflows a window in windowState=maximized (or
+		// fullscreen) to fill the new root automatically, so this single
+		// idempotent call is all we need post-resize. The previous
+		// approach of restarting chromium so it could re-apply
+		// --start-maximized cost ~9s per resize and also wiped browser-
+		// side state (Emulation.* overrides, devtools sessions). The
+		// restart_chromium request field is still accepted for API
+		// compatibility but no longer triggers a restart on this path.
 		if err == nil {
-			if restartChrome {
-				if restartErr := s.restartChromiumAndWait(ctx, "resolution change"); restartErr != nil {
-					log.Error("failed to restart chromium after resolution change", "error", restartErr)
-				}
-			} else {
-				if cdpErr := s.setWindowMaximizedViaCDP(ctx); cdpErr != nil {
-					log.Warn("CDP maximize re-assert failed after Xorg resolution change (non-fatal)", "error", cdpErr)
-				}
+			if cdpErr := s.setWindowMaximizedViaCDP(ctx); cdpErr != nil {
+				log.Warn("CDP maximize re-assert failed after Xorg resolution change (non-fatal)", "error", cdpErr)
 			}
 		}
 	} else if len(stopped) > 0 {
@@ -236,7 +233,7 @@ func (s *ApiService) probeDisplayMode(ctx context.Context) string {
 }
 
 // setResolutionXorgViaXrandr changes resolution for Xorg using xrandr (fallback when Neko is disabled)
-func (s *ApiService) setResolutionXorgViaXrandr(ctx context.Context, width, height, refreshRate int, restartChrome bool) error {
+func (s *ApiService) setResolutionXorgViaXrandr(ctx context.Context, width, height, refreshRate int) error {
 	log := logger.FromContext(ctx)
 	display := s.resolveDisplayFromEnv()
 

--- a/server/cmd/api/api/display.go
+++ b/server/cmd/api/api/display.go
@@ -131,9 +131,16 @@ func (s *ApiService) PatchDisplay(ctx context.Context, req oapi.PatchDisplayRequ
 		// side state (Emulation.* overrides, devtools sessions). The
 		// restart_chromium request field is still accepted for API
 		// compatibility but no longer triggers a restart on this path.
+		//
+		// The CDP call is the only thing that recovers a window already
+		// in the "normal" state, so its failure is fatal: returning 200
+		// after a CDP error could leave the browser window stuck at the
+		// old size while the X root is at the new size, and the caller
+		// would have no signal of the mismatch.
 		if err == nil {
 			if cdpErr := s.setWindowMaximizedViaCDP(ctx); cdpErr != nil {
-				log.Warn("CDP maximize re-assert failed after Xorg resolution change (non-fatal)", "error", cdpErr)
+				log.Error("CDP maximize re-assert failed after Xorg resolution change", "error", cdpErr)
+				err = fmt.Errorf("CDP maximize re-assert failed: %w", cdpErr)
 			}
 		}
 	} else if len(stopped) > 0 {
@@ -237,14 +244,23 @@ func (s *ApiService) setResolutionXorgViaXrandr(ctx context.Context, width, heig
 	log := logger.FromContext(ctx)
 	display := s.resolveDisplayFromEnv()
 
+	// The headful Xorg dummy driver exposes DUMMY0, not "default". The
+	// historical `xrandr --output default --mode ...` command exits 0 while
+	// silently doing nothing on this driver. Default to DUMMY0 and let an
+	// env var override it for any non-standard image layout.
+	output := strings.TrimSpace(os.Getenv("KERNEL_IMAGES_XRANDR_OUTPUT"))
+	if output == "" {
+		output = "DUMMY0"
+	}
+
 	// Build xrandr command - if refresh rate is specified, use the specific modeline
 	var xrandrCmd string
 	if refreshRate > 0 {
 		modeName := fmt.Sprintf("%dx%d_%d.00", width, height, refreshRate)
-		xrandrCmd = fmt.Sprintf("xrandr --output default --mode %s", modeName)
-		log.Info("using specific modeline", "mode", modeName)
+		xrandrCmd = fmt.Sprintf("xrandr --output %s --mode %s", output, modeName)
+		log.Info("using specific modeline", "output", output, "mode", modeName)
 	} else {
-		xrandrCmd = fmt.Sprintf("xrandr -s %dx%d", width, height)
+		xrandrCmd = fmt.Sprintf("xrandr --output %s --size %dx%d", output, width, height)
 	}
 
 	args := []string{"-lc", xrandrCmd}

--- a/server/cmd/api/api/display.go
+++ b/server/cmd/api/api/display.go
@@ -122,9 +122,21 @@ func (s *ApiService) PatchDisplay(ctx context.Context, req oapi.PatchDisplayRequ
 			log.Info("using xrandr for Xorg resolution change (Neko disabled)")
 			err = s.setResolutionXorgViaXrandr(ctx, width, height, refreshRate, restartChrome)
 		}
-		if err == nil && restartChrome {
-			if restartErr := s.restartChromiumAndWait(ctx, "resolution change"); restartErr != nil {
-				log.Error("failed to restart chromium after resolution change", "error", restartErr)
+		// Headful default path: skip the chromium restart and re-assert
+		// the maximized window state via CDP instead. Mutter reflows a
+		// maximized window to fill the new X root automatically, so this
+		// is all that's needed — and it costs ~50ms vs ~9s for a restart.
+		// Callers can still opt into the legacy restart with
+		// restart_chromium=true (rare; preserved for compatibility).
+		if err == nil {
+			if restartChrome {
+				if restartErr := s.restartChromiumAndWait(ctx, "resolution change"); restartErr != nil {
+					log.Error("failed to restart chromium after resolution change", "error", restartErr)
+				}
+			} else {
+				if cdpErr := s.setWindowMaximizedViaCDP(ctx); cdpErr != nil {
+					log.Warn("CDP maximize re-assert failed after Xorg resolution change (non-fatal)", "error", cdpErr)
+				}
 			}
 		}
 	} else if len(stopped) > 0 {
@@ -365,6 +377,42 @@ func (s *ApiService) backgroundResizeXvfb(ctx context.Context, width, height int
 		s.viewportOverride = nil
 	}
 	s.viewportMu.Unlock()
+}
+
+// setWindowMaximizedViaCDP re-asserts that the chromium OS window is in
+// the "maximized" state via Browser.setWindowBounds. After a successful
+// xrandr/Neko resize on the headful path, mutter will reflow a maximized
+// window to fill the new X root — so this call is the entirety of what
+// the server needs to do post-resize. It replaces the previous approach
+// of restarting chromium so it could re-apply --start-maximized, which
+// cost a multi-second restart and also reset other browser-side state
+// (notably Emulation.* overrides).
+//
+// The call is idempotent and cheap: when the window is already maximized
+// the helper returns immediately without sending any CDP commands.
+func (s *ApiService) setWindowMaximizedViaCDP(ctx context.Context) error {
+	log := logger.FromContext(ctx)
+
+	upstreamURL := s.upstreamMgr.Current()
+	if upstreamURL == "" {
+		return fmt.Errorf("devtools upstream not available")
+	}
+
+	cdpCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	client, err := cdpclient.Dial(cdpCtx, upstreamURL)
+	if err != nil {
+		return fmt.Errorf("failed to connect to devtools: %w", err)
+	}
+	defer client.Close()
+
+	if err := client.SetWindowBoundsMaximized(cdpCtx); err != nil {
+		return fmt.Errorf("CDP setWindowBoundsMaximized: %w", err)
+	}
+
+	log.Info("re-asserted maximized window state via CDP")
+	return nil
 }
 
 // setViewportViaCDP resizes the browser viewport using the CDP

--- a/server/cmd/api/api/display.go
+++ b/server/cmd/api/api/display.go
@@ -122,25 +122,36 @@ func (s *ApiService) PatchDisplay(ctx context.Context, req oapi.PatchDisplayRequ
 			log.Info("using xrandr for Xorg resolution change (Neko disabled)")
 			err = s.setResolutionXorgViaXrandr(ctx, width, height, refreshRate)
 		}
-		// Re-assert the maximized window state via CDP after the X root
-		// resize. Mutter reflows a window in windowState=maximized (or
-		// fullscreen) to fill the new root automatically, so this single
-		// idempotent call is all we need post-resize. The previous
-		// approach of restarting chromium so it could re-apply
-		// --start-maximized cost ~9s per resize and also wiped browser-
-		// side state (Emulation.* overrides, devtools sessions). The
-		// restart_chromium request field is still accepted for API
-		// compatibility but no longer triggers a restart on this path.
+		// Re-assert the maximized window state via CDP, then verify the
+		// X root has reached the requested size. Mutter reflows a
+		// maximized (or fullscreen) window onto the new root
+		// automatically, so the CDP call's only job is to make sure the
+		// window is in the state that triggers the reflow. The X root
+		// poll is the authoritative post-condition: it's the value the
+		// server actually set and stays panel-robust if mutter ever
+		// gains a taskbar (a maximized window would then be smaller
+		// than the root by the panel's reserved space).
 		//
-		// The CDP call is the only thing that recovers a window already
-		// in the "normal" state, so its failure is fatal: returning 200
-		// after a CDP error could leave the browser window stuck at the
-		// old size while the X root is at the new size, and the caller
-		// would have no signal of the mismatch.
+		// Both are fatal on failure — returning 200 with the X root
+		// still at the old size, or the window stuck in normal state,
+		// would leave the caller with no signal of the mismatch. The
+		// previous approach of restarting chromium so it could re-apply
+		// --start-maximized had the same effective contract (the
+		// restart blocked the response) but cost ~9s per resize and
+		// wiped browser-side state (Emulation.* overrides, devtools
+		// sessions). The restart_chromium request field is still
+		// accepted for API compatibility but no longer triggers a
+		// restart on this path.
 		if err == nil {
-			if cdpErr := s.setWindowMaximizedViaCDP(ctx, width, height); cdpErr != nil {
+			if cdpErr := s.setWindowMaximizedViaCDP(ctx); cdpErr != nil {
 				log.Error("CDP maximize re-assert failed after Xorg resolution change", "error", cdpErr)
 				err = fmt.Errorf("CDP maximize re-assert failed: %w", cdpErr)
+			}
+		}
+		if err == nil {
+			if waitErr := s.waitForXRootSize(ctx, width, height, 3*time.Second); waitErr != nil {
+				log.Error("X root did not reach requested size after resize", "error", waitErr)
+				err = fmt.Errorf("X root verification: %w", waitErr)
 			}
 		}
 	} else if len(stopped) > 0 {
@@ -394,72 +405,79 @@ func (s *ApiService) backgroundResizeXvfb(ctx context.Context, width, height int
 	s.viewportMu.Unlock()
 }
 
-// setWindowMaximizedViaCDP re-asserts that the chromium OS window is in
-// the "maximized" state via Browser.setWindowBounds, then waits until the
-// window manager has actually reflowed the window onto the new X root.
-// After a successful xrandr/Neko resize, mutter reflows a maximized
-// (or fullscreen) window to fill the new root automatically — but that
-// reflow is asynchronous to the CDP setWindowBounds acknowledgement, so
-// the handler polls Browser.getWindowForTarget until the live bounds
-// match the requested width/height before returning.
-//
-// This makes PATCH /display a synchronous contract: the API returns only
-// once the window is at the new size, not just once the resize has been
-// initiated. The previous approach of restarting chromium so it could
-// re-apply --start-maximized had the same effective contract (the restart
-// blocked the response) but cost ~9s per resize and wiped browser-side
-// state (Emulation.* overrides, devtools sessions).
-func (s *ApiService) setWindowMaximizedViaCDP(ctx context.Context, width, height int) error {
-	log := logger.FromContext(ctx)
-
+// withCDPClient dials the current devtools upstream with a 10s timeout,
+// hands the connected client to fn, and closes the connection on return.
+// Lets the small per-call CDP helpers below avoid duplicating the dial +
+// timeout + defer-close scaffolding.
+func (s *ApiService) withCDPClient(ctx context.Context, fn func(context.Context, *cdpclient.Client) error) error {
 	upstreamURL := s.upstreamMgr.Current()
 	if upstreamURL == "" {
 		return fmt.Errorf("devtools upstream not available")
 	}
-
 	cdpCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-
 	client, err := cdpclient.Dial(cdpCtx, upstreamURL)
 	if err != nil {
 		return fmt.Errorf("failed to connect to devtools: %w", err)
 	}
 	defer client.Close()
+	return fn(cdpCtx, client)
+}
 
-	if err := client.SetWindowBoundsMaximized(cdpCtx); err != nil {
+// setWindowMaximizedViaCDP re-asserts that the chromium OS window is in
+// the "maximized" state via Browser.setWindowBounds. After a successful
+// xrandr/Neko resize, mutter reflows a maximized (or fullscreen) window
+// to fill the new root automatically — this call ensures the window is
+// in the state that triggers the reflow. The CDP call is idempotent: it
+// no-ops on a window already in maximized or fullscreen state.
+//
+// The PATCH /display handler waits for the X root to reach the requested
+// size separately (waitForXRootSize) rather than reading the chromium
+// window's own bounds, so the contract stays panel-robust: if mutter
+// ever gained a taskbar/dock, a maximized window would be smaller than
+// the root by the panel's reserved space, and a window-bounds poll
+// would 3s-timeout forever.
+func (s *ApiService) setWindowMaximizedViaCDP(ctx context.Context) error {
+	log := logger.FromContext(ctx)
+	if err := s.withCDPClient(ctx, func(cdpCtx context.Context, client *cdpclient.Client) error {
+		return client.SetWindowBoundsMaximized(cdpCtx)
+	}); err != nil {
 		return fmt.Errorf("CDP setWindowBoundsMaximized: %w", err)
 	}
-
-	if err := waitForWindowSize(cdpCtx, client, width, height, 3*time.Second); err != nil {
-		return fmt.Errorf("window did not reach %dx%d after CDP maximize: %w", width, height, err)
-	}
-
-	log.Info("re-asserted maximized window state via CDP", "width", width, "height", height)
+	log.Info("re-asserted maximized window state via CDP")
 	return nil
 }
 
-// waitForWindowSize polls Browser.getWindowForTarget until the live OS
-// window's width/height match the requested size, or the deadline expires.
-// Typical convergence on docker+mutter is 20–50ms; pick a deadline that
-// comfortably covers WM scheduling jitter without masking real bugs.
-func waitForWindowSize(ctx context.Context, client *cdpclient.Client, width, height int, timeout time.Duration) error {
+// waitForXRootSize polls the X root resolution via xrandr until it matches
+// the requested size, or the deadline expires. This is the authoritative
+// post-condition for PATCH /display: the X root is what the server set
+// (via Neko or xrandr), and the rest of the stack — mutter, chromium —
+// follows from there. Polling the X root rather than chromium's window
+// bounds keeps the contract panel-robust: a future mutter config with a
+// taskbar/dock would shrink the maximized window below the root size,
+// but the root itself would still match what we asked for.
+//
+// Typical convergence is sub-millisecond (Neko's ScreenConfigurationChange
+// returns after the X server has applied the mode), but a small loop
+// covers any future asynchrony in the resize chain.
+func (s *ApiService) waitForXRootSize(ctx context.Context, width, height int, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	var last cdpclient.WindowBounds
+	var lastW, lastH int
 	var lastErr error
 	for {
-		b, err := client.GetWindowBounds(ctx)
+		w, h, _, err := s.getCurrentResolution(ctx)
 		lastErr = err
 		if err == nil {
-			last = b
-			if b.Width == width && b.Height == height {
+			lastW, lastH = w, h
+			if w == width && h == height {
 				return nil
 			}
 		}
 		if time.Now().After(deadline) {
 			if lastErr != nil {
-				return fmt.Errorf("last getWindowBounds error: %w", lastErr)
+				return fmt.Errorf("last getCurrentResolution error: %w", lastErr)
 			}
-			return fmt.Errorf("window is %dx%d state=%q", last.Width, last.Height, last.WindowState)
+			return fmt.Errorf("x root is %dx%d, want %dx%d", lastW, lastH, width, height)
 		}
 		select {
 		case <-ctx.Done():
@@ -474,25 +492,11 @@ func waitForWindowSize(ctx context.Context, client *cdpclient.Client, width, hei
 // not require restarting Chromium or Xvfb.
 func (s *ApiService) setViewportViaCDP(ctx context.Context, width, height int) error {
 	log := logger.FromContext(ctx)
-
-	upstreamURL := s.upstreamMgr.Current()
-	if upstreamURL == "" {
-		return fmt.Errorf("devtools upstream not available")
-	}
-
-	cdpCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	client, err := cdpclient.Dial(cdpCtx, upstreamURL)
-	if err != nil {
-		return fmt.Errorf("failed to connect to devtools: %w", err)
-	}
-	defer client.Close()
-
-	if err := client.SetDeviceMetricsOverride(cdpCtx, width, height); err != nil {
+	if err := s.withCDPClient(ctx, func(cdpCtx context.Context, client *cdpclient.Client) error {
+		return client.SetDeviceMetricsOverride(cdpCtx, width, height)
+	}); err != nil {
 		return fmt.Errorf("CDP setDeviceMetricsOverride: %w", err)
 	}
-
 	log.Info("viewport resized via CDP", "width", width, "height", height)
 	return nil
 }

--- a/server/e2e/e2e_display_resize_window_test.go
+++ b/server/e2e/e2e_display_resize_window_test.go
@@ -1,0 +1,629 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	instanceoapi "github.com/kernel/kernel-images/server/lib/oapi"
+	"github.com/stretchr/testify/require"
+)
+
+// rendererViewport captures the dimensions visible to JS inside the page. It is
+// the cheapest end-to-end signal that the OS window has been resized to fill
+// the new X root: the renderer can't report a larger outerWidth/outerHeight
+// than the actual chromium window the WM gave it.
+type rendererViewport struct {
+	InnerWidth  int `json:"innerWidth"`
+	InnerHeight int `json:"innerHeight"`
+	OuterWidth  int `json:"outerWidth"`
+	OuterHeight int `json:"outerHeight"`
+	ScreenWidth int `json:"screenWidth"`
+	ScreenHght  int `json:"screenHeight"`
+	DPR         int `json:"devicePixelRatio"`
+}
+
+// getRendererViewport evaluates window.* sizes in the active page via the
+// playwright daemon.
+func getRendererViewport(ctx context.Context, c *TestContainer) (rendererViewport, error) {
+	client, err := c.APIClient()
+	if err != nil {
+		return rendererViewport{}, err
+	}
+	code := `
+		return await page.evaluate(() => ({
+			innerWidth: window.innerWidth,
+			innerHeight: window.innerHeight,
+			outerWidth: window.outerWidth,
+			outerHeight: window.outerHeight,
+			screenWidth: screen.width,
+			screenHeight: screen.height,
+			devicePixelRatio: window.devicePixelRatio,
+		}));
+	`
+	timeout := 5
+	rsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightRequest{
+		Code:       code,
+		TimeoutSec: &timeout,
+	})
+	if err != nil {
+		return rendererViewport{}, err
+	}
+	if rsp.JSON200 == nil || !rsp.JSON200.Success {
+		body := ""
+		if rsp != nil {
+			body = string(rsp.Body)
+		}
+		return rendererViewport{}, fmt.Errorf("playwright eval failed: %s", body)
+	}
+	raw, err := json.Marshal(rsp.JSON200.Result)
+	if err != nil {
+		return rendererViewport{}, err
+	}
+	var v rendererViewport
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return rendererViewport{}, fmt.Errorf("unmarshal viewport %q: %w", string(raw), err)
+	}
+	return v, nil
+}
+
+// getXRootResolution reads the live X root size via xrandr inside the
+// container. Works for both Xorg (headful) and Xvfb (headless). The parse
+// pulls from xrandr's `Screen 0: ... current W x H, ...` header — which is
+// always present and reflects the live root — rather than looking for `*`
+// next to an active mode line, because Xorg-with-Neko surfaces a synthetic
+// active mode that xrandr does not mark with an asterisk.
+func getXRootResolution(ctx context.Context, c *TestContainer) (int, int, error) {
+	out, err := execCombinedOutput(ctx, c, "bash", []string{"-c", "DISPLAY=:1 xrandr"})
+	if err != nil {
+		return 0, 0, fmt.Errorf("xrandr exec: %w (out=%q)", err, out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		idx := strings.Index(line, "current ")
+		if idx < 0 {
+			continue
+		}
+		rest := line[idx+len("current "):]
+		end := strings.Index(rest, ",")
+		if end > 0 {
+			rest = rest[:end]
+		}
+		fields := strings.Fields(rest) // ["W", "x", "H"]
+		if len(fields) < 3 {
+			return 0, 0, fmt.Errorf("unexpected current segment %q", rest)
+		}
+		w, err := strconv.Atoi(fields[0])
+		if err != nil {
+			return 0, 0, fmt.Errorf("parse width %q: %w", fields[0], err)
+		}
+		h, err := strconv.Atoi(fields[2])
+		if err != nil {
+			return 0, 0, fmt.Errorf("parse height %q: %w", fields[2], err)
+		}
+		return w, h, nil
+	}
+	return 0, 0, fmt.Errorf("could not find 'current WxH' in xrandr output: %s", strings.TrimSpace(out))
+}
+
+// chromiumWindowBounds is the subset of Browser.getWindowBounds we care
+// about. windowState distinguishes the "normal" case (where width/height are
+// the actual OS window size) from "maximized"/"fullscreen" (where width/height
+// are the saved-restore bounds and the live size matches the root).
+type chromiumWindowBounds struct {
+	WindowID    int    `json:"windowId"`
+	Width       int    `json:"width"`
+	Height      int    `json:"height"`
+	Left        int    `json:"left"`
+	Top         int    `json:"top"`
+	WindowState string `json:"windowState"`
+}
+
+// getChromiumWindowBoundsCDP queries Browser.getWindowForTarget +
+// Browser.getWindowBounds for the first page target. Used to assert that
+// the OS window stays in maximized/fullscreen state across a resize.
+func getChromiumWindowBoundsCDP(ctx context.Context, c *TestContainer) (chromiumWindowBounds, error) {
+	cdp, err := newCDPClient(ctx, c.CDPURL())
+	if err != nil {
+		return chromiumWindowBounds{}, fmt.Errorf("dial cdp: %w", err)
+	}
+	defer cdp.Close()
+
+	targetsRaw, err := cdp.Call(ctx, "Target.getTargets", map[string]any{}, "")
+	if err != nil {
+		return chromiumWindowBounds{}, fmt.Errorf("Target.getTargets: %w", err)
+	}
+	var targets struct {
+		TargetInfos []struct {
+			TargetID string `json:"targetId"`
+			Type     string `json:"type"`
+		} `json:"targetInfos"`
+	}
+	if err := json.Unmarshal(targetsRaw, &targets); err != nil {
+		return chromiumWindowBounds{}, fmt.Errorf("unmarshal targets: %w", err)
+	}
+	var pageID string
+	for _, t := range targets.TargetInfos {
+		if t.Type == "page" {
+			pageID = t.TargetID
+			break
+		}
+	}
+	if pageID == "" {
+		return chromiumWindowBounds{}, fmt.Errorf("no page target found")
+	}
+
+	winRaw, err := cdp.Call(ctx, "Browser.getWindowForTarget", map[string]any{"targetId": pageID}, "")
+	if err != nil {
+		return chromiumWindowBounds{}, fmt.Errorf("Browser.getWindowForTarget: %w", err)
+	}
+	var winResp struct {
+		WindowID int `json:"windowId"`
+		Bounds   struct {
+			Width       int    `json:"width"`
+			Height      int    `json:"height"`
+			Left        int    `json:"left"`
+			Top         int    `json:"top"`
+			WindowState string `json:"windowState"`
+		} `json:"bounds"`
+	}
+	if err := json.Unmarshal(winRaw, &winResp); err != nil {
+		return chromiumWindowBounds{}, fmt.Errorf("unmarshal window: %w", err)
+	}
+	return chromiumWindowBounds{
+		WindowID:    winResp.WindowID,
+		Width:       winResp.Bounds.Width,
+		Height:      winResp.Bounds.Height,
+		Left:        winResp.Bounds.Left,
+		Top:         winResp.Bounds.Top,
+		WindowState: winResp.Bounds.WindowState,
+	}, nil
+}
+
+// setChromiumWindowStateCDP forces the OS window to the given windowState
+// ("normal" | "minimized" | "maximized" | "fullscreen") via Browser.setWindowBounds.
+// Per CDP semantics: width/height/left/top fields must be omitted when
+// windowState != "normal".
+func setChromiumWindowStateCDP(ctx context.Context, c *TestContainer, state string) error {
+	cdp, err := newCDPClient(ctx, c.CDPURL())
+	if err != nil {
+		return fmt.Errorf("dial cdp: %w", err)
+	}
+	defer cdp.Close()
+
+	cur, err := getChromiumWindowBoundsCDP(ctx, c)
+	if err != nil {
+		return fmt.Errorf("get current window: %w", err)
+	}
+
+	// CDP rejects state transitions like maximized → fullscreen directly;
+	// go through "normal" first when changing between non-normal states.
+	if cur.WindowState != "normal" && cur.WindowState != state {
+		if _, err := cdp.Call(ctx, "Browser.setWindowBounds", map[string]any{
+			"windowId": cur.WindowID,
+			"bounds":   map[string]any{"windowState": "normal"},
+		}, ""); err != nil {
+			return fmt.Errorf("Browser.setWindowBounds normal: %w", err)
+		}
+	}
+
+	if _, err := cdp.Call(ctx, "Browser.setWindowBounds", map[string]any{
+		"windowId": cur.WindowID,
+		"bounds":   map[string]any{"windowState": state},
+	}, ""); err != nil {
+		return fmt.Errorf("Browser.setWindowBounds %s: %w", state, err)
+	}
+	return nil
+}
+
+// waitForWindowState polls the chromium window state until it matches want
+// or the timeout expires. Returns the final bounds.
+func waitForWindowState(t *testing.T, ctx context.Context, c *TestContainer, want string, timeout time.Duration) chromiumWindowBounds {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last chromiumWindowBounds
+	var lastErr error
+	for {
+		b, err := getChromiumWindowBoundsCDP(ctx, c)
+		lastErr = err
+		if err == nil {
+			last = b
+			if b.WindowState == want {
+				return b
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("window state never reached %q: last=%+v lastErr=%v", want, last, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context cancelled waiting for window state %q: %v", want, ctx.Err())
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+// viewportPredicate decides when a rendererViewport reading is "close enough"
+// to the requested size. The headless and headful paths use different
+// predicates because --headless=new uses Chrome's internal window size
+// (screen.width/height) while headful renders into a real OS window owned by
+// Mutter (outerWidth/outerHeight equal to the X root).
+type viewportPredicate func(v rendererViewport, wantW, wantH int) bool
+
+// waitForRendererViewport polls the renderer until the given predicate
+// succeeds. Returns the matching viewport.
+func waitForRendererViewport(t *testing.T, ctx context.Context, c *TestContainer, wantW, wantH int, pred viewportPredicate, label string, timeout time.Duration) rendererViewport {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last rendererViewport
+	var lastErr error
+	for {
+		v, err := getRendererViewport(ctx, c)
+		lastErr = err
+		if err == nil {
+			last = v
+			if pred(v, wantW, wantH) {
+				t.Logf("[%s] renderer_viewport: outer=%dx%d inner=%dx%d screen=%dx%d dpr=%d (matches want=%dx%d)",
+					label, v.OuterWidth, v.OuterHeight, v.InnerWidth, v.InnerHeight, v.ScreenWidth, v.ScreenHght, v.DPR, wantW, wantH)
+				return v
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("[%s] renderer viewport never matched want=%dx%d: last=%+v lastErr=%v", label, wantW, wantH, last, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("[%s] context cancelled waiting for renderer viewport %dx%d: %v", label, wantW, wantH, ctx.Err())
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+// headlessViewportPredicate asserts innerWidth/innerHeight match the request.
+// In --headless=new the renderer uses Chrome's internal window
+// (Emulation.setDeviceMetricsOverride drives inner*) — screen.* and outer*
+// stay at Chrome's startup defaults and do not move on resize, so they are
+// intentionally not asserted.
+func headlessViewportPredicate(v rendererViewport, wantW, wantH int) bool {
+	return v.InnerWidth == wantW && v.InnerHeight == wantH
+}
+
+// makeHeadfulMaximizedPredicate is the strict headful check: screen.*
+// matches AND outerWidth/outerHeight is within tolerance of the request.
+// Tolerance absorbs mutter chrome (borders/titlebar) — kiosk fullscreen has
+// none, so tolerance 0 is correct there; --start-maximized passes through
+// mutter SSDs so a small slack is kinder.
+func makeHeadfulMaximizedPredicate(tolerance int) viewportPredicate {
+	return func(v rendererViewport, wantW, wantH int) bool {
+		if v.ScreenWidth != wantW || v.ScreenHght != wantH {
+			return false
+		}
+		return abs(v.OuterWidth-wantW) <= tolerance && abs(v.OuterHeight-wantH) <= tolerance
+	}
+}
+
+// baselineOrForcedState returns the windowState the test expects the window
+// to be in after baseline setup. When forceMaximizeAtBaseline is set, we
+// re-query CDP rather than trust the pre-force reading.
+func baselineOrForcedState(sc resizeScenario, base chromiumWindowBounds) string {
+	if sc.forceMaximizeAtBaseline {
+		return "maximized"
+	}
+	return base.WindowState
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// resizeScenario describes a single image+chromium-config combination the
+// resize tests exercise. extraEnv is applied at container start (e.g. to
+// inject --kiosk into the default CHROMIUM_FLAGS). predicate decides when a
+// renderer viewport reading is acceptable for this scenario.
+type resizeScenario struct {
+	name       string
+	image      string
+	extraEnv   map[string]string
+	predicate  viewportPredicate
+	skipReason string
+	// assertXRoot toggles X-root convergence checks.
+	assertXRoot bool
+	// up/down override the default 1920x1080 → 1280x720 resize targets.
+	// Headful with Neko already starts at 1920x1080 so the up resize must
+	// pick a different size to actually exercise the screen change.
+	up   [2]int
+	down [2]int
+	// restartChromium is the value passed to PATCH /display. The default
+	// (false zero value when restartChromiumSet is true) exercises the
+	// no-restart path; setting restartChromium=true forces the current
+	// behaviour. restartChromiumSet must be true for the test to send the
+	// field; otherwise the request omits it entirely.
+	restartChromium    bool
+	restartChromiumSet bool
+	// forceMaximizeAtBaseline calls Browser.setWindowBounds{windowState:"maximized"}
+	// before the first resize. Used to test whether mutter's "maximized
+	// window reflows on RANDR" invariant holds once we put the window in
+	// that state — bypasses the docker-specific question of whether
+	// --start-maximized actually produces a maximized window.
+	forceMaximizeAtBaseline bool
+	// requireBaselineState asserts the window's CDP windowState at startup
+	// equals this value before any resize. Empty = no assertion.
+	requireBaselineState string
+}
+
+func (sc resizeScenario) upSize() (int, int) {
+	if sc.up != [2]int{} {
+		return sc.up[0], sc.up[1]
+	}
+	return 1920, 1080
+}
+
+func (sc resizeScenario) downSize() (int, int) {
+	if sc.down != [2]int{} {
+		return sc.down[0], sc.down[1]
+	}
+	return 1280, 720
+}
+
+// TestDisplayResizeChromiumWindow exercises PATCH /display and asserts that
+// after the resize the X root, the chromium OS window (CDP view), and the
+// renderer's outer{Width,Height} all converge on the new size, with the
+// window state (maximized / fullscreen) preserved across the resize and the
+// CDP windowId stable (proving no chromium restart).
+func TestDisplayResizeChromiumWindow(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skipf("docker not available: %v", err)
+	}
+
+	scenarios := []resizeScenario{
+		{
+			name:        "headless_default",
+			image:       headlessImage,
+			predicate:   headlessViewportPredicate,
+			assertXRoot: true, // background Xvfb resize must converge
+		},
+		{
+			// Production-equivalent scenario: --start-maximized + neko +
+			// the CHROMIUM_FLAGS_DEFAULT mirror from run-docker.sh:17.
+			// Uses the default restart_chromium (omitted from the
+			// request), exercising the server's new behaviour: skip the
+			// chromium restart and instead re-assert windowState=maximized
+			// via Browser.setWindowBounds. The strict outer-matches-screen
+			// predicate proves mutter reflows the maximized window on RANDR
+			// without any chromium restart.
+			name:  "headful_start_maximized",
+			image: headfulImage,
+			extraEnv: map[string]string{
+				"ENABLE_WEBRTC":       "true",
+				"NEKO_ADMIN_PASSWORD": "admin",
+				// container.go:51 always appends --no-sandbox; the rest
+				// mirrors images/chromium-headful/run-docker.sh:17.
+				"CHROMIUM_FLAGS": "--user-data-dir=/home/kernel/user-data --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=*",
+			},
+			predicate:            makeHeadfulMaximizedPredicate(20), // mutter borders/titlebar
+			assertXRoot:          true,
+			up:                   [2]int{2560, 1440},
+			down:                 [2]int{1280, 720},
+			requireBaselineState: "maximized",
+		},
+		{
+			name:     "headful_kiosk",
+			image:    headfulImage,
+			extraEnv: map[string]string{"ENABLE_WEBRTC": "true", "NEKO_ADMIN_PASSWORD": "admin", "CHROMIUM_FLAGS": "--kiosk --start-maximized"},
+			// --kiosk runs the window in fullscreen state, which auto-tracks
+			// the screen size on every resize (verified: outer == screen
+			// after both up- and down-resize). Strict predicate works today.
+			predicate:           makeHeadfulMaximizedPredicate(0),
+			assertXRoot:         true,
+			up:                  [2]int{2560, 1440},
+			down:                [2]int{1280, 720},
+			requireBaselineState: "fullscreen",
+		},
+		{
+			// Direct test of the live-VM theory: kiosk's fullscreen window
+			// already auto-tracks RANDR resizes without any restart. Same
+			// scenario as headful_kiosk but with restart_chromium=false to
+			// confirm the restart is dead weight.
+			name:                "headful_kiosk_no_restart",
+			image:               headfulImage,
+			extraEnv:            map[string]string{"ENABLE_WEBRTC": "true", "NEKO_ADMIN_PASSWORD": "admin", "CHROMIUM_FLAGS": "--kiosk --start-maximized"},
+			predicate:           makeHeadfulMaximizedPredicate(0),
+			assertXRoot:         true,
+			up:                  [2]int{2560, 1440},
+			down:                [2]int{1280, 720},
+			restartChromium:     false,
+			restartChromiumSet:  true,
+			requireBaselineState: "fullscreen",
+		},
+		{
+			// Test the live-VM theory's central claim: if the chromium
+			// window is in windowState=maximized, mutter reflows it on
+			// RANDR — no Chromium restart needed. Bypasses the docker-only
+			// quirk where --start-maximized comes up in 'normal' state by
+			// forcing the window state via CDP at baseline.
+			name:                    "headful_force_maximized_no_restart",
+			image:                   headfulImage,
+			extraEnv:                map[string]string{"ENABLE_WEBRTC": "true", "NEKO_ADMIN_PASSWORD": "admin"},
+			predicate:               makeHeadfulMaximizedPredicate(0),
+			assertXRoot:             true,
+			up:                      [2]int{2560, 1440},
+			down:                    [2]int{1280, 720},
+			restartChromium:         false,
+			restartChromiumSet:      true,
+			forceMaximizeAtBaseline: true,
+			requireBaselineState:    "maximized",
+		},
+	}
+
+	// Subtests run serially: two of the three boot the heavy headful image
+	// (neko + mutter + chromium) which races on startup mode under
+	// concurrent load — observed: neko's `desktop.screen=1920x1080@25`
+	// initialization fails to take effect when three privileged containers
+	// boot at once, leaving the root at the dummy DDX's 3840x2160 default.
+	for _, sc := range scenarios {
+		sc := sc
+		t.Run(sc.name, func(t *testing.T) {
+			if sc.skipReason != "" {
+				t.Skip(sc.skipReason)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			env := map[string]string{
+				"WIDTH":  "1024",
+				"HEIGHT": "768",
+			}
+			for k, v := range sc.extraEnv {
+				env[k] = v
+			}
+
+			c := NewTestContainer(t, sc.image)
+			require.NoError(t, c.Start(ctx, ContainerConfig{Env: env}), "failed to start container")
+			defer c.Stop(ctx)
+			require.NoError(t, c.WaitReady(ctx), "api not ready")
+			require.NoError(t, c.WaitDevTools(ctx), "devtools not ready")
+
+			// Navigate to about:blank so playwright has a page to evaluate
+			// against — otherwise the daemon may not have a target wired up.
+			navigateBlank(t, ctx, c)
+
+			// Baseline — log only. We don't assert specific initial
+			// dimensions because the headless renderer's window size at
+			// startup depends on Chrome's --headless=new defaults rather
+			// than the Xvfb root we asked for.
+			rootW, rootH, err := getXRootResolution(ctx, c)
+			require.NoError(t, err, "baseline xrandr")
+			t.Logf("[%s] baseline x_root=%dx%d", sc.name, rootW, rootH)
+
+			baseline, err := getRendererViewport(ctx, c)
+			require.NoError(t, err, "baseline renderer viewport")
+			t.Logf("[%s] baseline renderer outer=%dx%d inner=%dx%d screen=%dx%d",
+				sc.name, baseline.OuterWidth, baseline.OuterHeight, baseline.InnerWidth, baseline.InnerHeight, baseline.ScreenWidth, baseline.ScreenHght)
+
+			baseCDP, err := getChromiumWindowBoundsCDP(ctx, c)
+			require.NoError(t, err, "baseline cdp window")
+			t.Logf("[%s] baseline cdp=%+v", sc.name, baseCDP)
+
+			// Optionally force the window into the maximized state at
+			// baseline. Tests the live-VM theory's invariant in
+			// environments where --start-maximized somehow doesn't produce
+			// a windowState=maximized window at startup (observed: docker).
+			if sc.forceMaximizeAtBaseline {
+				require.NoError(t, setChromiumWindowStateCDP(ctx, c, "maximized"), "force maximized via CDP")
+				forced := waitForWindowState(t, ctx, c, "maximized", 5*time.Second)
+				t.Logf("[%s] after force-maximize cdp=%+v", sc.name, forced)
+			}
+
+			if sc.requireBaselineState != "" {
+				require.Equal(t, sc.requireBaselineState, baselineOrForcedState(sc, baseCDP),
+					"baseline windowState mismatch: chromium did not come up in the expected state — production behaviour relies on this invariant")
+			}
+
+			// Resize up: must be a real delta from the baseline so the X root
+			// actually changes. Headful starts at Neko's default 1920x1080;
+			// headless starts at the WIDTH/HEIGHT env (1024x768).
+			upW, upH := sc.upSize()
+			patchDisplayExpectingOK(t, ctx, c, upW, upH, 60, sc.restartChromium, sc.restartChromiumSet)
+			if sc.assertXRoot {
+				waitForXRootResolution(t, ctx, c, upW, upH, 30*time.Second)
+			}
+			waitForRendererViewport(t, ctx, c, upW, upH, sc.predicate, sc.name+":up", 60*time.Second)
+
+			cdpAfterUp, err := getChromiumWindowBoundsCDP(ctx, c)
+			require.NoError(t, err, "cdp window after up-resize")
+			t.Logf("[%s] after-up cdp=%+v", sc.name, cdpAfterUp)
+
+			// Resize back down to a smaller size, also a real delta.
+			dnW, dnH := sc.downSize()
+			patchDisplayExpectingOK(t, ctx, c, dnW, dnH, 60, sc.restartChromium, sc.restartChromiumSet)
+			if sc.assertXRoot {
+				waitForXRootResolution(t, ctx, c, dnW, dnH, 30*time.Second)
+			}
+			waitForRendererViewport(t, ctx, c, dnW, dnH, sc.predicate, sc.name+":down", 60*time.Second)
+
+			cdpAfterDown, err := getChromiumWindowBoundsCDP(ctx, c)
+			require.NoError(t, err, "cdp window after down-resize")
+			t.Logf("[%s] after-down cdp=%+v", sc.name, cdpAfterDown)
+		})
+	}
+}
+
+
+// navigateBlank points the active page at about:blank via playwright so the
+// renderer is alive before we query window dimensions.
+func navigateBlank(t *testing.T, ctx context.Context, c *TestContainer) {
+	t.Helper()
+	client, err := c.APIClient()
+	require.NoError(t, err)
+	timeout := 5
+	rsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightRequest{
+		Code:       `await page.goto('about:blank'); return true;`,
+		TimeoutSec: &timeout,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, rsp.JSON200, "playwright navigate response missing")
+	require.True(t, rsp.JSON200.Success, "playwright navigate to about:blank failed: %s", string(rsp.Body))
+}
+
+// patchDisplayExpectingOK issues PATCH /display and requires a 200.
+// refreshRate is required for headful: the dummy Xorg DDX only has modelines
+// named "WxH_RR.00", and the server's xrandr fallback (`xrandr -s WxH`)
+// silently no-ops when refresh rate is omitted.
+//
+// restartChromiumSet=false leaves the field out of the request entirely so
+// the server picks its own default (which after the no-restart change means
+// the CDP re-assert-maximized path).
+func patchDisplayExpectingOK(t *testing.T, ctx context.Context, c *TestContainer, width, height, refreshRate int, restartChromium, restartChromiumSet bool) {
+	t.Helper()
+	client, err := c.APIClient()
+	require.NoError(t, err)
+	rate := instanceoapi.PatchDisplayRequestRefreshRate(refreshRate)
+	req := instanceoapi.PatchDisplayJSONRequestBody{
+		Width:       &width,
+		Height:      &height,
+		RefreshRate: &rate,
+	}
+	if restartChromiumSet {
+		req.RestartChromium = &restartChromium
+	}
+	rsp, err := client.PatchDisplayWithResponse(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode(), "PATCH /display: %s body=%s", rsp.Status(), string(rsp.Body))
+	require.NotNil(t, rsp.JSON200)
+	require.NotNil(t, rsp.JSON200.Width)
+	require.NotNil(t, rsp.JSON200.Height)
+	require.Equal(t, width, *rsp.JSON200.Width)
+	require.Equal(t, height, *rsp.JSON200.Height)
+}
+
+// waitForXRootResolution polls xrandr until the X root reaches the requested
+// size, mirroring waitForXvfbResolution but operating on the live X root
+// instead of the Xvfb process command line.
+func waitForXRootResolution(t *testing.T, ctx context.Context, c *TestContainer, wantW, wantH int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		w, h, err := getXRootResolution(ctx, c)
+		if err == nil && w == wantW && h == wantH {
+			t.Logf("x_root_resolution: %dx%d (matches)", w, h)
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("x root never reached %dx%d: lastW=%d lastH=%d err=%v", wantW, wantH, w, h, err)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context cancelled waiting for x root %dx%d: %v", wantW, wantH, ctx.Err())
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}

--- a/server/e2e/e2e_display_resize_window_test.go
+++ b/server/e2e/e2e_display_resize_window_test.go
@@ -185,69 +185,6 @@ func getChromiumWindowBoundsCDP(ctx context.Context, c *TestContainer) (chromium
 	}, nil
 }
 
-// setChromiumWindowStateCDP forces the OS window to the given windowState
-// ("normal" | "minimized" | "maximized" | "fullscreen") via Browser.setWindowBounds.
-// Per CDP semantics: width/height/left/top fields must be omitted when
-// windowState != "normal".
-func setChromiumWindowStateCDP(ctx context.Context, c *TestContainer, state string) error {
-	cdp, err := newCDPClient(ctx, c.CDPURL())
-	if err != nil {
-		return fmt.Errorf("dial cdp: %w", err)
-	}
-	defer cdp.Close()
-
-	cur, err := getChromiumWindowBoundsCDP(ctx, c)
-	if err != nil {
-		return fmt.Errorf("get current window: %w", err)
-	}
-
-	// CDP rejects state transitions like maximized → fullscreen directly;
-	// go through "normal" first when changing between non-normal states.
-	if cur.WindowState != "normal" && cur.WindowState != state {
-		if _, err := cdp.Call(ctx, "Browser.setWindowBounds", map[string]any{
-			"windowId": cur.WindowID,
-			"bounds":   map[string]any{"windowState": "normal"},
-		}, ""); err != nil {
-			return fmt.Errorf("Browser.setWindowBounds normal: %w", err)
-		}
-	}
-
-	if _, err := cdp.Call(ctx, "Browser.setWindowBounds", map[string]any{
-		"windowId": cur.WindowID,
-		"bounds":   map[string]any{"windowState": state},
-	}, ""); err != nil {
-		return fmt.Errorf("Browser.setWindowBounds %s: %w", state, err)
-	}
-	return nil
-}
-
-// waitForWindowState polls the chromium window state until it matches want
-// or the timeout expires. Returns the final bounds.
-func waitForWindowState(t *testing.T, ctx context.Context, c *TestContainer, want string, timeout time.Duration) chromiumWindowBounds {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	var last chromiumWindowBounds
-	var lastErr error
-	for {
-		b, err := getChromiumWindowBoundsCDP(ctx, c)
-		lastErr = err
-		if err == nil {
-			last = b
-			if b.WindowState == want {
-				return b
-			}
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("window state never reached %q: last=%+v lastErr=%v", want, last, lastErr)
-		}
-		select {
-		case <-ctx.Done():
-			t.Fatalf("context cancelled waiting for window state %q: %v", want, ctx.Err())
-		case <-time.After(200 * time.Millisecond):
-		}
-	}
-}
-
 // viewportPredicate decides when a rendererViewport reading is "close enough"
 // to the requested size. The headless and headful paths use different
 // predicates because --headless=new uses Chrome's internal window size
@@ -307,16 +244,6 @@ func makeHeadfulMaximizedPredicate(tolerance int) viewportPredicate {
 	}
 }
 
-// baselineOrForcedState returns the windowState the test expects the window
-// to be in after baseline setup. When forceMaximizeAtBaseline is set, we
-// re-query CDP rather than trust the pre-force reading.
-func baselineOrForcedState(sc resizeScenario, base chromiumWindowBounds) string {
-	if sc.forceMaximizeAtBaseline {
-		return "maximized"
-	}
-	return base.WindowState
-}
-
 func abs(x int) int {
 	if x < 0 {
 		return -x
@@ -341,19 +268,6 @@ type resizeScenario struct {
 	// pick a different size to actually exercise the screen change.
 	up   [2]int
 	down [2]int
-	// restartChromium is the value passed to PATCH /display. The default
-	// (false zero value when restartChromiumSet is true) exercises the
-	// no-restart path; setting restartChromium=true forces the current
-	// behaviour. restartChromiumSet must be true for the test to send the
-	// field; otherwise the request omits it entirely.
-	restartChromium    bool
-	restartChromiumSet bool
-	// forceMaximizeAtBaseline calls Browser.setWindowBounds{windowState:"maximized"}
-	// before the first resize. Used to test whether mutter's "maximized
-	// window reflows on RANDR" invariant holds once we put the window in
-	// that state — bypasses the docker-specific question of whether
-	// --start-maximized actually produces a maximized window.
-	forceMaximizeAtBaseline bool
 	// requireBaselineState asserts the window's CDP windowState at startup
 	// equals this value before any resize. Empty = no assertion.
 	requireBaselineState string
@@ -415,51 +329,17 @@ func TestDisplayResizeChromiumWindow(t *testing.T) {
 			requireBaselineState: "maximized",
 		},
 		{
-			name:     "headful_kiosk",
-			image:    headfulImage,
-			extraEnv: map[string]string{"ENABLE_WEBRTC": "true", "NEKO_ADMIN_PASSWORD": "admin", "CHROMIUM_FLAGS": "--kiosk --start-maximized"},
-			// --kiosk runs the window in fullscreen state, which auto-tracks
-			// the screen size on every resize (verified: outer == screen
-			// after both up- and down-resize). Strict predicate works today.
-			predicate:           makeHeadfulMaximizedPredicate(0),
-			assertXRoot:         true,
-			up:                  [2]int{2560, 1440},
-			down:                [2]int{1280, 720},
+			// --kiosk runs the window in fullscreen state. mutter reflows
+			// the window to fill the new screen on every RANDR — verified
+			// here on both up- and down-resize.
+			name:                 "headful_kiosk",
+			image:                headfulImage,
+			extraEnv:             map[string]string{"ENABLE_WEBRTC": "true", "NEKO_ADMIN_PASSWORD": "admin", "CHROMIUM_FLAGS": "--kiosk --start-maximized"},
+			predicate:            makeHeadfulMaximizedPredicate(0),
+			assertXRoot:          true,
+			up:                   [2]int{2560, 1440},
+			down:                 [2]int{1280, 720},
 			requireBaselineState: "fullscreen",
-		},
-		{
-			// Direct test of the live-VM theory: kiosk's fullscreen window
-			// already auto-tracks RANDR resizes without any restart. Same
-			// scenario as headful_kiosk but with restart_chromium=false to
-			// confirm the restart is dead weight.
-			name:                "headful_kiosk_no_restart",
-			image:               headfulImage,
-			extraEnv:            map[string]string{"ENABLE_WEBRTC": "true", "NEKO_ADMIN_PASSWORD": "admin", "CHROMIUM_FLAGS": "--kiosk --start-maximized"},
-			predicate:           makeHeadfulMaximizedPredicate(0),
-			assertXRoot:         true,
-			up:                  [2]int{2560, 1440},
-			down:                [2]int{1280, 720},
-			restartChromium:     false,
-			restartChromiumSet:  true,
-			requireBaselineState: "fullscreen",
-		},
-		{
-			// Test the live-VM theory's central claim: if the chromium
-			// window is in windowState=maximized, mutter reflows it on
-			// RANDR — no Chromium restart needed. Bypasses the docker-only
-			// quirk where --start-maximized comes up in 'normal' state by
-			// forcing the window state via CDP at baseline.
-			name:                    "headful_force_maximized_no_restart",
-			image:                   headfulImage,
-			extraEnv:                map[string]string{"ENABLE_WEBRTC": "true", "NEKO_ADMIN_PASSWORD": "admin"},
-			predicate:               makeHeadfulMaximizedPredicate(0),
-			assertXRoot:             true,
-			up:                      [2]int{2560, 1440},
-			down:                    [2]int{1280, 720},
-			restartChromium:         false,
-			restartChromiumSet:      true,
-			forceMaximizeAtBaseline: true,
-			requireBaselineState:    "maximized",
 		},
 	}
 
@@ -513,18 +393,8 @@ func TestDisplayResizeChromiumWindow(t *testing.T) {
 			require.NoError(t, err, "baseline cdp window")
 			t.Logf("[%s] baseline cdp=%+v", sc.name, baseCDP)
 
-			// Optionally force the window into the maximized state at
-			// baseline. Tests the live-VM theory's invariant in
-			// environments where --start-maximized somehow doesn't produce
-			// a windowState=maximized window at startup (observed: docker).
-			if sc.forceMaximizeAtBaseline {
-				require.NoError(t, setChromiumWindowStateCDP(ctx, c, "maximized"), "force maximized via CDP")
-				forced := waitForWindowState(t, ctx, c, "maximized", 5*time.Second)
-				t.Logf("[%s] after force-maximize cdp=%+v", sc.name, forced)
-			}
-
 			if sc.requireBaselineState != "" {
-				require.Equal(t, sc.requireBaselineState, baselineOrForcedState(sc, baseCDP),
+				require.Equal(t, sc.requireBaselineState, baseCDP.WindowState,
 					"baseline windowState mismatch: chromium did not come up in the expected state — production behaviour relies on this invariant")
 			}
 
@@ -532,7 +402,7 @@ func TestDisplayResizeChromiumWindow(t *testing.T) {
 			// actually changes. Headful starts at Neko's default 1920x1080;
 			// headless starts at the WIDTH/HEIGHT env (1024x768).
 			upW, upH := sc.upSize()
-			patchDisplayExpectingOK(t, ctx, c, upW, upH, 60, sc.restartChromium, sc.restartChromiumSet)
+			patchDisplayExpectingOK(t, ctx, c, upW, upH, 60)
 			if sc.assertXRoot {
 				waitForXRootResolution(t, ctx, c, upW, upH, 30*time.Second)
 			}
@@ -544,7 +414,7 @@ func TestDisplayResizeChromiumWindow(t *testing.T) {
 
 			// Resize back down to a smaller size, also a real delta.
 			dnW, dnH := sc.downSize()
-			patchDisplayExpectingOK(t, ctx, c, dnW, dnH, 60, sc.restartChromium, sc.restartChromiumSet)
+			patchDisplayExpectingOK(t, ctx, c, dnW, dnH, 60)
 			if sc.assertXRoot {
 				waitForXRootResolution(t, ctx, c, dnW, dnH, 30*time.Second)
 			}
@@ -574,15 +444,14 @@ func navigateBlank(t *testing.T, ctx context.Context, c *TestContainer) {
 	require.True(t, rsp.JSON200.Success, "playwright navigate to about:blank failed: %s", string(rsp.Body))
 }
 
-// patchDisplayExpectingOK issues PATCH /display and requires a 200.
+// patchDisplayExpectingOK issues PATCH /display and requires a 200. The
+// request omits restart_chromium so the server picks its own default — the
+// CDP re-assert-maximized path on the Xorg branch.
+//
 // refreshRate is required for headful: the dummy Xorg DDX only has modelines
 // named "WxH_RR.00", and the server's xrandr fallback (`xrandr -s WxH`)
 // silently no-ops when refresh rate is omitted.
-//
-// restartChromiumSet=false leaves the field out of the request entirely so
-// the server picks its own default (which after the no-restart change means
-// the CDP re-assert-maximized path).
-func patchDisplayExpectingOK(t *testing.T, ctx context.Context, c *TestContainer, width, height, refreshRate int, restartChromium, restartChromiumSet bool) {
+func patchDisplayExpectingOK(t *testing.T, ctx context.Context, c *TestContainer, width, height, refreshRate int) {
 	t.Helper()
 	client, err := c.APIClient()
 	require.NoError(t, err)
@@ -591,9 +460,6 @@ func patchDisplayExpectingOK(t *testing.T, ctx context.Context, c *TestContainer
 		Width:       &width,
 		Height:      &height,
 		RefreshRate: &rate,
-	}
-	if restartChromiumSet {
-		req.RestartChromium = &restartChromium
 	}
 	rsp, err := client.PatchDisplayWithResponse(ctx, req)
 	require.NoError(t, err)

--- a/server/e2e/e2e_display_resize_window_test.go
+++ b/server/e2e/e2e_display_resize_window_test.go
@@ -341,6 +341,25 @@ func TestDisplayResizeChromiumWindow(t *testing.T) {
 			down:                 [2]int{1280, 720},
 			requireBaselineState: "fullscreen",
 		},
+		{
+			// Non-Neko Xorg path: ENABLE_WEBRTC is unset, so the server
+			// falls through to setResolutionXorgViaXrandr instead of
+			// nekoAuthClient.ScreenConfigurationChange. Exercises the
+			// `xrandr --output DUMMY0 --mode WxH_RR.00` path. Mode targets
+			// must be ones xrandr has actually attached to DUMMY0 at the
+			// requested refresh rate (`xrandr -q` on this image shows
+			// 1920x1080_60.00 and 1280x720_60.00 but NOT 2560x1440_60.00).
+			name:  "headful_xorg_no_neko",
+			image: headfulImage,
+			extraEnv: map[string]string{
+				"CHROMIUM_FLAGS": "--user-data-dir=/home/kernel/user-data --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=*",
+			},
+			predicate:            makeHeadfulMaximizedPredicate(20),
+			assertXRoot:          true,
+			up:                   [2]int{1920, 1080},
+			down:                 [2]int{1280, 720},
+			requireBaselineState: "maximized",
+		},
 	}
 
 	// Subtests run serially: two of the three boot the heavy headful image

--- a/server/e2e/e2e_display_resize_window_test.go
+++ b/server/e2e/e2e_display_resize_window_test.go
@@ -112,9 +112,10 @@ func getXRootResolution(ctx context.Context, c *TestContainer) (int, int, error)
 }
 
 // chromiumWindowBounds is the subset of Browser.getWindowBounds we care
-// about. windowState distinguishes the "normal" case (where width/height are
-// the actual OS window size) from "maximized"/"fullscreen" (where width/height
-// are the saved-restore bounds and the live size matches the root).
+// about. windowState distinguishes the "maximized"/"fullscreen" case
+// (where width/height reflect the live OS window size, which the WM
+// aligns with the X root) from "normal" (where width/height reflect the
+// saved-restore bounds that would be applied on un-maximize).
 type chromiumWindowBounds struct {
 	WindowID    int    `json:"windowId"`
 	Width       int    `json:"width"`

--- a/server/e2e/e2e_display_resize_window_test.go
+++ b/server/e2e/e2e_display_resize_window_test.go
@@ -75,10 +75,12 @@ func getRendererViewport(ctx context.Context, c *TestContainer) (rendererViewpor
 
 // getXRootResolution reads the live X root size via xrandr inside the
 // container. Works for both Xorg (headful) and Xvfb (headless). The parse
-// pulls from xrandr's `Screen 0: ... current W x H, ...` header — which is
-// always present and reflects the live root — rather than looking for `*`
-// next to an active mode line, because Xorg-with-Neko surfaces a synthetic
-// active mode that xrandr does not mark with an asterisk.
+// pulls from xrandr's `Screen 0: ... current W x H, ...` header — a
+// direct read of the X root size that doesn't depend on which connected
+// output happens to own the active mode. The server's
+// getCurrentResolutionFromXrandr greps for `*` on a per-output mode
+// line; both approaches converge on the same value on this image, but
+// the `Screen 0: current` form is the most direct.
 func getXRootResolution(ctx context.Context, c *TestContainer) (int, int, error) {
 	out, err := execCombinedOutput(ctx, c, "bash", []string{"-c", "DISPLAY=:1 xrandr"})
 	if err != nil {

--- a/server/e2e/e2e_display_resize_window_test.go
+++ b/server/e2e/e2e_display_resize_window_test.go
@@ -411,6 +411,10 @@ func TestDisplayResizeChromiumWindow(t *testing.T) {
 			cdpAfterUp, err := getChromiumWindowBoundsCDP(ctx, c)
 			require.NoError(t, err, "cdp window after up-resize")
 			t.Logf("[%s] after-up cdp=%+v", sc.name, cdpAfterUp)
+			require.Equal(t, baseCDP.WindowID, cdpAfterUp.WindowID,
+				"windowID changed after up-resize — chromium was restarted (windowID is monotonic per-process; a new one signals a relaunch)")
+			require.Equal(t, baseCDP.WindowState, cdpAfterUp.WindowState,
+				"windowState changed after up-resize — the WM-tracking invariant the no-restart path relies on was broken")
 
 			// Resize back down to a smaller size, also a real delta.
 			dnW, dnH := sc.downSize()
@@ -423,6 +427,10 @@ func TestDisplayResizeChromiumWindow(t *testing.T) {
 			cdpAfterDown, err := getChromiumWindowBoundsCDP(ctx, c)
 			require.NoError(t, err, "cdp window after down-resize")
 			t.Logf("[%s] after-down cdp=%+v", sc.name, cdpAfterDown)
+			require.Equal(t, baseCDP.WindowID, cdpAfterDown.WindowID,
+				"windowID changed after down-resize — chromium was restarted between resizes")
+			require.Equal(t, baseCDP.WindowState, cdpAfterDown.WindowState,
+				"windowState changed after down-resize")
 		})
 	}
 }

--- a/server/lib/cdpclient/cdpclient.go
+++ b/server/lib/cdpclient/cdpclient.go
@@ -215,6 +215,74 @@ func DispatchStartURL(ctx context.Context, devtoolsURL, url string) error {
 	return nil
 }
 
+// SetWindowBoundsMaximized puts the OS window backing the first page target
+// into the maximized state via Browser.setWindowBounds. It is idempotent —
+// invoking it on a window already in maximized state is a no-op.
+//
+// A mutter-managed window in maximized state auto-tracks RANDR resizes
+// (the WM reflows it to fill the new root). So after a display resize the
+// server only has to make sure the window is in maximized state; mutter
+// does the rest. This replaces the prior approach of restarting chromium
+// so it could re-apply --start-maximized.
+//
+// We intentionally avoid the explicit-bounds form of setWindowBounds
+// ({left, top, width, height} with windowState:"normal"): once a window is
+// in normal state it stops auto-tracking subsequent RANDR events.
+func (c *Client) SetWindowBoundsMaximized(ctx context.Context) error {
+	targetsResult, err := c.send(ctx, "Target.getTargets", nil, "")
+	if err != nil {
+		return fmt.Errorf("Target.getTargets: %w", err)
+	}
+	var targets struct {
+		TargetInfos []struct {
+			TargetID string `json:"targetId"`
+			Type     string `json:"type"`
+		} `json:"targetInfos"`
+	}
+	if err := json.Unmarshal(targetsResult, &targets); err != nil {
+		return fmt.Errorf("unmarshal targets: %w", err)
+	}
+	var pageTargetID string
+	for _, t := range targets.TargetInfos {
+		if t.Type == "page" {
+			pageTargetID = t.TargetID
+			break
+		}
+	}
+	if pageTargetID == "" {
+		return fmt.Errorf("no page target found")
+	}
+
+	winRaw, err := c.send(ctx, "Browser.getWindowForTarget", map[string]any{"targetId": pageTargetID}, "")
+	if err != nil {
+		return fmt.Errorf("Browser.getWindowForTarget: %w", err)
+	}
+	var winResp struct {
+		WindowID int `json:"windowId"`
+		Bounds   struct {
+			WindowState string `json:"windowState"`
+		} `json:"bounds"`
+	}
+	if err := json.Unmarshal(winRaw, &winResp); err != nil {
+		return fmt.Errorf("unmarshal window: %w", err)
+	}
+	// Both "maximized" and "fullscreen" cause mutter to reflow the window
+	// to fill the new X root on RANDR — that's the only invariant we
+	// need. Demoting a kiosk fullscreen window to maximized would break
+	// kiosk mode, so leave fullscreen alone.
+	if winResp.Bounds.WindowState == "maximized" || winResp.Bounds.WindowState == "fullscreen" {
+		return nil
+	}
+
+	if _, err := c.send(ctx, "Browser.setWindowBounds", map[string]any{
+		"windowId": winResp.WindowID,
+		"bounds":   map[string]any{"windowState": "maximized"},
+	}, ""); err != nil {
+		return fmt.Errorf("Browser.setWindowBounds maximized: %w", err)
+	}
+	return nil
+}
+
 // SetDeviceMetricsOverride sets the viewport dimensions on the first page
 // target found in the browser. It attaches to the target with a flattened
 // session, sends Emulation.setDeviceMetricsOverride, then detaches.

--- a/server/lib/cdpclient/cdpclient.go
+++ b/server/lib/cdpclient/cdpclient.go
@@ -283,6 +283,68 @@ func (c *Client) SetWindowBoundsMaximized(ctx context.Context) error {
 	return nil
 }
 
+// WindowBounds is the subset of Browser.getWindowBounds CDP returns that
+// callers care about. For maximized/fullscreen windows the width/height
+// fields reflect the live window size (which the WM aligns with the X
+// root); for normal-state windows they reflect the saved-restore bounds.
+type WindowBounds struct {
+	WindowID    int
+	Width       int
+	Height      int
+	WindowState string
+}
+
+// GetWindowBounds queries the OS window bounds for the first page target
+// via Browser.getWindowForTarget. It's a one-shot read; callers that need
+// to wait for the WM to settle should poll this.
+func (c *Client) GetWindowBounds(ctx context.Context) (WindowBounds, error) {
+	targetsResult, err := c.send(ctx, "Target.getTargets", nil, "")
+	if err != nil {
+		return WindowBounds{}, fmt.Errorf("Target.getTargets: %w", err)
+	}
+	var targets struct {
+		TargetInfos []struct {
+			TargetID string `json:"targetId"`
+			Type     string `json:"type"`
+		} `json:"targetInfos"`
+	}
+	if err := json.Unmarshal(targetsResult, &targets); err != nil {
+		return WindowBounds{}, fmt.Errorf("unmarshal targets: %w", err)
+	}
+	var pageTargetID string
+	for _, t := range targets.TargetInfos {
+		if t.Type == "page" {
+			pageTargetID = t.TargetID
+			break
+		}
+	}
+	if pageTargetID == "" {
+		return WindowBounds{}, fmt.Errorf("no page target found")
+	}
+
+	winRaw, err := c.send(ctx, "Browser.getWindowForTarget", map[string]any{"targetId": pageTargetID}, "")
+	if err != nil {
+		return WindowBounds{}, fmt.Errorf("Browser.getWindowForTarget: %w", err)
+	}
+	var winResp struct {
+		WindowID int `json:"windowId"`
+		Bounds   struct {
+			Width       int    `json:"width"`
+			Height      int    `json:"height"`
+			WindowState string `json:"windowState"`
+		} `json:"bounds"`
+	}
+	if err := json.Unmarshal(winRaw, &winResp); err != nil {
+		return WindowBounds{}, fmt.Errorf("unmarshal window: %w", err)
+	}
+	return WindowBounds{
+		WindowID:    winResp.WindowID,
+		Width:       winResp.Bounds.Width,
+		Height:      winResp.Bounds.Height,
+		WindowState: winResp.Bounds.WindowState,
+	}, nil
+}
+
 // SetDeviceMetricsOverride sets the viewport dimensions on the first page
 // target found in the browser. It attaches to the target with a flattened
 // session, sends Emulation.setDeviceMetricsOverride, then detaches.

--- a/server/lib/cdpclient/cdpclient.go
+++ b/server/lib/cdpclient/cdpclient.go
@@ -254,34 +254,20 @@ func (c *Client) firstPageTargetID(ctx context.Context) (string, error) {
 // ({left, top, width, height} with windowState:"normal"): once a window is
 // in normal state it stops auto-tracking subsequent RANDR events.
 func (c *Client) SetWindowBoundsMaximized(ctx context.Context) error {
-	pageTargetID, err := c.firstPageTargetID(ctx)
+	bounds, err := c.GetWindowBounds(ctx)
 	if err != nil {
 		return err
-	}
-
-	winRaw, err := c.send(ctx, "Browser.getWindowForTarget", map[string]any{"targetId": pageTargetID}, "")
-	if err != nil {
-		return fmt.Errorf("Browser.getWindowForTarget: %w", err)
-	}
-	var winResp struct {
-		WindowID int `json:"windowId"`
-		Bounds   struct {
-			WindowState string `json:"windowState"`
-		} `json:"bounds"`
-	}
-	if err := json.Unmarshal(winRaw, &winResp); err != nil {
-		return fmt.Errorf("unmarshal window: %w", err)
 	}
 	// Both "maximized" and "fullscreen" cause mutter to reflow the window
 	// to fill the new X root on RANDR — that's the only invariant we
 	// need. Demoting a kiosk fullscreen window to maximized would break
 	// kiosk mode, so leave fullscreen alone.
-	if winResp.Bounds.WindowState == "maximized" || winResp.Bounds.WindowState == "fullscreen" {
+	if bounds.WindowState == "maximized" || bounds.WindowState == "fullscreen" {
 		return nil
 	}
 
 	if _, err := c.send(ctx, "Browser.setWindowBounds", map[string]any{
-		"windowId": winResp.WindowID,
+		"windowId": bounds.WindowID,
 		"bounds":   map[string]any{"windowState": "maximized"},
 	}, ""); err != nil {
 		return fmt.Errorf("Browser.setWindowBounds maximized: %w", err)

--- a/server/lib/cdpclient/cdpclient.go
+++ b/server/lib/cdpclient/cdpclient.go
@@ -215,6 +215,31 @@ func DispatchStartURL(ctx context.Context, devtoolsURL, url string) error {
 	return nil
 }
 
+// firstPageTargetID returns the targetId of the first page target reported
+// by Target.getTargets. Callers that need to operate on the user-facing
+// browser window (Emulation, Browser.* window bounds) use this to find it.
+func (c *Client) firstPageTargetID(ctx context.Context) (string, error) {
+	targetsResult, err := c.send(ctx, "Target.getTargets", nil, "")
+	if err != nil {
+		return "", fmt.Errorf("Target.getTargets: %w", err)
+	}
+	var targets struct {
+		TargetInfos []struct {
+			TargetID string `json:"targetId"`
+			Type     string `json:"type"`
+		} `json:"targetInfos"`
+	}
+	if err := json.Unmarshal(targetsResult, &targets); err != nil {
+		return "", fmt.Errorf("unmarshal targets: %w", err)
+	}
+	for _, t := range targets.TargetInfos {
+		if t.Type == "page" {
+			return t.TargetID, nil
+		}
+	}
+	return "", fmt.Errorf("no page target found")
+}
+
 // SetWindowBoundsMaximized puts the OS window backing the first page target
 // into the maximized state via Browser.setWindowBounds. It is idempotent —
 // invoking it on a window already in maximized state is a no-op.
@@ -229,28 +254,9 @@ func DispatchStartURL(ctx context.Context, devtoolsURL, url string) error {
 // ({left, top, width, height} with windowState:"normal"): once a window is
 // in normal state it stops auto-tracking subsequent RANDR events.
 func (c *Client) SetWindowBoundsMaximized(ctx context.Context) error {
-	targetsResult, err := c.send(ctx, "Target.getTargets", nil, "")
+	pageTargetID, err := c.firstPageTargetID(ctx)
 	if err != nil {
-		return fmt.Errorf("Target.getTargets: %w", err)
-	}
-	var targets struct {
-		TargetInfos []struct {
-			TargetID string `json:"targetId"`
-			Type     string `json:"type"`
-		} `json:"targetInfos"`
-	}
-	if err := json.Unmarshal(targetsResult, &targets); err != nil {
-		return fmt.Errorf("unmarshal targets: %w", err)
-	}
-	var pageTargetID string
-	for _, t := range targets.TargetInfos {
-		if t.Type == "page" {
-			pageTargetID = t.TargetID
-			break
-		}
-	}
-	if pageTargetID == "" {
-		return fmt.Errorf("no page target found")
+		return err
 	}
 
 	winRaw, err := c.send(ctx, "Browser.getWindowForTarget", map[string]any{"targetId": pageTargetID}, "")
@@ -298,28 +304,9 @@ type WindowBounds struct {
 // via Browser.getWindowForTarget. It's a one-shot read; callers that need
 // to wait for the WM to settle should poll this.
 func (c *Client) GetWindowBounds(ctx context.Context) (WindowBounds, error) {
-	targetsResult, err := c.send(ctx, "Target.getTargets", nil, "")
+	pageTargetID, err := c.firstPageTargetID(ctx)
 	if err != nil {
-		return WindowBounds{}, fmt.Errorf("Target.getTargets: %w", err)
-	}
-	var targets struct {
-		TargetInfos []struct {
-			TargetID string `json:"targetId"`
-			Type     string `json:"type"`
-		} `json:"targetInfos"`
-	}
-	if err := json.Unmarshal(targetsResult, &targets); err != nil {
-		return WindowBounds{}, fmt.Errorf("unmarshal targets: %w", err)
-	}
-	var pageTargetID string
-	for _, t := range targets.TargetInfos {
-		if t.Type == "page" {
-			pageTargetID = t.TargetID
-			break
-		}
-	}
-	if pageTargetID == "" {
-		return WindowBounds{}, fmt.Errorf("no page target found")
+		return WindowBounds{}, err
 	}
 
 	winRaw, err := c.send(ctx, "Browser.getWindowForTarget", map[string]any{"targetId": pageTargetID}, "")
@@ -349,30 +336,9 @@ func (c *Client) GetWindowBounds(ctx context.Context) (WindowBounds, error) {
 // target found in the browser. It attaches to the target with a flattened
 // session, sends Emulation.setDeviceMetricsOverride, then detaches.
 func (c *Client) SetDeviceMetricsOverride(ctx context.Context, width, height int) error {
-	targetsResult, err := c.send(ctx, "Target.getTargets", nil, "")
+	pageTargetID, err := c.firstPageTargetID(ctx)
 	if err != nil {
-		return fmt.Errorf("Target.getTargets: %w", err)
-	}
-
-	var targets struct {
-		TargetInfos []struct {
-			TargetID string `json:"targetId"`
-			Type     string `json:"type"`
-		} `json:"targetInfos"`
-	}
-	if err := json.Unmarshal(targetsResult, &targets); err != nil {
-		return fmt.Errorf("unmarshal targets: %w", err)
-	}
-
-	var pageTargetID string
-	for _, t := range targets.TargetInfos {
-		if t.Type == "page" {
-			pageTargetID = t.TargetID
-			break
-		}
-	}
-	if pageTargetID == "" {
-		return fmt.Errorf("no page target found")
+		return err
 	}
 
 	attachResult, err := c.send(ctx, "Target.attachToTarget", map[string]any{


### PR DESCRIPTION
## Summary

Headful `PATCH /display` previously restarted chromium after the
xrandr/Neko screen resize so chromium could re-apply `--start-maximized`
against the new X root. The restart costs ~9s and wipes browser-side
state (Emulation.* overrides, devtools sessions).

The restart turns out not to be load-bearing. Mutter reflows a window in
`windowState=maximized` (or `fullscreen`) onto the new root whenever the
X root resizes via xrandr/Neko. The server just has to make sure the
window is in that state, then verify the X root reached the requested
size before returning.

This PR replaces the restart on the Xorg branch with a single
`Browser.setWindowBounds{windowState:"maximized"}` CDP call plus an
xrandr poll for the X root. The `restart_chromium` request field stays
in the API schema for compatibility but is now a no-op on the Xorg
path. Existing callers that hardcode `restart_chromium=true`
(kraft.go, chromium_configure.go in kernel/kernel) silently get the
faster path.

### The trap we avoid

The explicit-bounds form of `setWindowBounds` — `windowState:"normal"`
with `{left, top, width, height}` — is intentionally **not** used. Once
a window is in normal state, mutter stops auto-tracking RANDR events,
which silently breaks subsequent resizes.

### Why poll the X root, not the chromium window

The post-condition is verified by polling `getCurrentResolution`
(xrandr's `Screen 0: ... current WxH`), not the chromium window's own
CDP bounds. The X root is the value the server actually controls;
polling it is also panel-robust — if mutter ever gains a taskbar/dock,
a maximized chromium window would be smaller than the root by the
panel's reserved space, and a window-bounds poll would silently time
out.

## Changes

- `server/lib/cdpclient/cdpclient.go` — `SetWindowBoundsMaximized(ctx)`.
  Idempotent: early-returns on `maximized` or `fullscreen` so kiosk
  windows aren't demoted. Plus a `firstPageTargetID` helper to
  deduplicate the Target.getTargets → page-target boilerplate that was
  spread across three methods, and a `GetWindowBounds(ctx)` reader
  reused by `SetWindowBoundsMaximized`.
- `server/cmd/api/api/display.go` — Xorg branch: always
  `setWindowMaximizedViaCDP` + `waitForXRootSize` after a successful
  resize. The legacy restart branch is gone. A small `withCDPClient`
  helper hides the dial/timeout/close scaffolding shared by the two
  per-call CDP helpers.
- `server/cmd/api/api/chromium_configure.go` — drop the now-unused
  `restartChrome` argument from the `setResolutionXorgViaXrandr` call.
- `server/e2e/e2e_display_resize_window_test.go` — new test exercising
  four scenarios: headless CDP fast path, headful `--start-maximized`
  + neko, headful `--kiosk` + fullscreen, and headful non-Neko Xorg
  (`xrandr --output DUMMY0 --mode WxH_RR.00`). Each subtest asserts
  X root convergence, renderer `screen.*` and `outer{Width,Height}`
  convergence, `WindowState` preservation, and a stable `windowId`
  (proving no chromium restart).

The Xvfb-with-recordings branch in `display.go` is orthogonal (headless
chromium has no OS window) and still honours `restart_chromium=true`.

## Numbers

| subtest | wall-clock before | after | windowId stable |
|---|---|---|---|
| `headful_start_maximized` | ~35s | **17s** | yes |
| `headful_kiosk` | ~34s | **17s** | yes |
| `headful_xorg_no_neko` | n/a | 17s | yes |

Two resizes per scenario; ~17s saved per PATCH `/display` call against
the kernel/kernel callers that all hardcode `restart_chromium=true`
today.

## Test plan

- [x] `cd server && go vet ./...`
- [x] `cd server && go test ./lib/cdpclient/... ./cmd/api/...` — unit
  tests for cdpclient and the api package
- [x] New `TestDisplayResizeChromiumWindow` — 4 subtests, all pass
  against an overlay image carrying this branch's `kernel-images-api`
- [x] Existing `TestDisplayResolutionChange` still passes against the
  modified server
- [ ] Manual smoke against a metro VM to confirm the same behaviour on
  the unikernel runtime as in the docker e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core display/WM integration (xrandr output, CDP window bounds, stricter 500s) and leaves chromium_configure’s stop-cycle Xorg resize without the new CDP/X-root post-steps.
> 
> **Overview**
> Headful **`PATCH /display`** no longer restarts Chromium after an Xorg resize. After Neko or **xrandr** applies the new mode, the server re-asserts a **maximized/fullscreen** OS window via **`Browser.setWindowBounds`** (CDP) and treats success only when **xrandr** reports the X root at the requested size—failures on either step return **500** instead of **200** with a mismatched display. **`restart_chromium`** remains in the API but is a **no-op** on this Xorg path; the Xvfb/recording path can still restart when requested.
> 
> **xrandr** on the dummy driver now targets **`DUMMY0`** (or **`KERNEL_IMAGES_XRANDR_OUTPUT`**) with a named **`WxH_RR.00`** modeline instead of **`--output default`**, which could exit 0 without resizing. **`cdpclient`** adds **`SetWindowBoundsMaximized`** / **`GetWindowBounds`** and shared **`firstPageTargetID`**; **`display.go`** adds **`withCDPClient`**, **`setWindowMaximizedViaCDP`**, and **`waitForXRootSize`**. New e2e **`TestDisplayResizeChromiumWindow`** covers headless, Neko maximized, kiosk fullscreen, and non-Neko Xorg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4d47d08b2a0918ae8db1fdb640afd93d39c5e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->