### PR TITLE
Decode CHROMIUM_FLAGS_B64 in chromium-launcher

### DIFF
--- a/server/cmd/chromium-launcher/main.go
+++ b/server/cmd/chromium-launcher/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"flag"
 	"fmt"
 	"net"
@@ -73,7 +74,10 @@ func main() {
 		}
 	}
 
-	baseFlags := os.Getenv("CHROMIUM_FLAGS")
+	baseFlags, decErr := resolveBaseFlags(os.Getenv("CHROMIUM_FLAGS"), os.Getenv("CHROMIUM_FLAGS_B64"))
+	if decErr != nil {
+		fmt.Fprintf(os.Stderr, "CHROMIUM_FLAGS_B64 set but failed to decode (%v); using CHROMIUM_FLAGS\n", decErr)
+	}
 	runtimeTokens, err := chromiumflags.ReadOptionalFlagFile(*runtimeFlagsPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed reading runtime flags: %v\n", err)
@@ -157,6 +161,25 @@ func main() {
 		fmt.Fprintf(os.Stderr, "exec runuser failed: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// resolveBaseFlags returns the Chromium base flag string. It prefers the
+// base64url-encoded value, falling back to the plain value. The API sends the
+// encoded form because some unikernel platform versions backslash-escape spaces
+// when serializing env vars into the guest kernel command line, which corrupts
+// the space-separated plain value; base64url has no characters the cmdline
+// encoder alters. A malformed encoded value falls back to the plain value and
+// returns the decode error for logging.
+func resolveBaseFlags(plain, encoded string) (string, error) {
+	encoded = strings.TrimSpace(encoded)
+	if encoded == "" {
+		return plain, nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return plain, err
+	}
+	return string(decoded), nil
 }
 
 // execLookPath helps satisfy syscall.Exec's requirement to pass an absolute path.

--- a/server/cmd/chromium-launcher/main_test.go
+++ b/server/cmd/chromium-launcher/main_test.go
@@ -1,11 +1,44 @@
 package main
 
 import (
+	"encoding/base64"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 )
+
+func TestResolveBaseFlags(t *testing.T) {
+	// Mirrors a real flag string: spaces, a quoted value, and comma lists —
+	// exactly the characters a cmdline encoder may escape.
+	flags := `--no-sandbox --lang="en-US,en;q=0.9" --disable-features=A,B,C`
+	enc := base64.RawURLEncoding.EncodeToString([]byte(flags))
+
+	tests := []struct {
+		name    string
+		plain   string
+		encoded string
+		want    string
+		wantErr bool
+	}{
+		{name: "plain only", plain: flags, encoded: "", want: flags},
+		{name: "encoded preferred over plain", plain: "--corrupted\\ value", encoded: enc, want: flags},
+		{name: "blank encoded falls back to plain", plain: flags, encoded: "   ", want: flags},
+		{name: "both empty", plain: "", encoded: "", want: ""},
+		{name: "malformed encoded falls back to plain", plain: flags, encoded: "not!base64!", want: flags, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveBaseFlags(tt.plain, tt.encoded)
+			if got != tt.want {
+				t.Errorf("resolveBaseFlags(%q, %q) = %q, want %q", tt.plain, tt.encoded, got, tt.want)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("resolveBaseFlags(%q, %q) err = %v, wantErr %v", tt.plain, tt.encoded, err, tt.wantErr)
+			}
+		})
+	}
+}
 
 func TestExecLookPath(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- Some unikernel platform versions backslash-escape spaces when serializing env vars into the guest kernel command line, corrupting the space-separated `CHROMIUM_FLAGS`. The launcher splits on whitespace, so `--no-sandbox` becomes `--no-sandbox\`, Chromium ignores it, aborts with `No usable sandbox`, and supervisord crash-loops it.
- `chromium-launcher` now prefers a base64url-encoded `CHROMIUM_FLAGS_B64`, decoding it into the base flag string. base64url has no characters a cmdline encoder escapes, so it survives transport intact.
- Falls back to `CHROMIUM_FLAGS` when the encoded var is unset or malformed, so behavior is unchanged with an older API.

## Backward compatibility / idempotency
- Decode is a pure read with no write-back; every launcher start (including supervisord restarts and scale-to-zero restores) resolves the same flags.
- `CHROMIUM_FLAGS_B64` unset → identical to previous behavior. Malformed value → logs and falls back to the raw value.

## Deploy ordering — this PR ships FIRST
The companion API PR (`kernel/kernel`) switches to sending **only** `CHROMIUM_FLAGS_B64` (sending both overflows Firecracker's kernel cmdline limit on the longest variant). So this launcher change must land and every browser image variant must be rebuilt and rolled out **before** the API PR deploys — otherwise headful/stealth browsers would get no base flags. This PR is backward-compatible with the current API (raw-only) via the fallback, so it is safe to ship and roll out ahead of time.

## Test plan
- [x] `go test ./cmd/chromium-launcher/ ./lib/chromiumflags/` — `TestResolveBaseFlags` covers precedence, blank/malformed fallback, and round-trip of a value containing spaces, a quoted token, and comma lists.
- [ ] Build a headless image from this branch, provision on an affected host with `CHROMIUM_FLAGS_B64`, and confirm `FINAL_FLAGS` shows a clean `--no-sandbox` and DevTools comes up.