### PR TITLE
Stop and remove `buildkit` helper container after builds

### DIFF
--- a/shared/start-buildkit.sh
+++ b/shared/start-buildkit.sh
@@ -5,13 +5,17 @@
 # Variable used by KraftKit, hence the requirement for sourcing the script
 export KRAFTKIT_BUILDKIT_HOST=docker-container://buildkit
 
+cleanup_buildkit() {
+    echo "Stopping 'buildkit' container ... "
+    docker stop buildkit
+}
+
 # Install container if not already installed.
 if [ -n "$(docker ps --all --no-trunc --quiet --filter 'name=^buildkit$')" ]; then
     echo "Container 'buildkit' is already installed. Nothing to do."
 else
     echo "Installing 'buildkit' container ... "
-    docker run -d --name buildkit --privileged moby/buildkit:latest
-    return $?
+    docker run -d --rm --name buildkit --privileged moby/buildkit:latest
 fi
 
 if [ "$(docker container inspect -f '{{.State.Running}}' buildkit 2> /dev/null)" = "true" ]; then
@@ -19,5 +23,6 @@ if [ "$(docker container inspect -f '{{.State.Running}}' buildkit 2> /dev/null)"
 else
     echo "Starting 'buildkit' container ... "
     docker start buildkit
-    return $?
 fi
+
+trap cleanup_buildkit EXIT


### PR DESCRIPTION
In local development, I noticed the `buildkit` container sticking around whenever I built the Kernel image. To solve this, this updates `shared/start-buildkit.sh` to stop the `moby/buildkit:latest` container named `buildkit` on `EXIT`, which removes it because of the `--rm` flag not being passed into `docker run`. 