### PR TITLE
Disambiguate chromium launcher test check

### DIFF
--- a/.github/workflows/chromium-launcher-test.yaml
+++ b/.github/workflows/chromium-launcher-test.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  chromium-launcher-test:
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Rename the chromium launcher workflow job from `test` to `chromium-launcher-test`.
- This gives branch protection/rulesets a unique required-check context instead of colliding with the server workflow's `test` job.

## Test plan
- Not run; workflow metadata-only change.
- After this merges and runs on `main`, require the `chromium-launcher-test` check in the main branch ruleset.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow metadata-only rename; no application or test logic changes.
> 
> **Overview**
> Renames the **chromium-launcher** GitHub Actions job from `test` to `chromium-launcher-test` in `.github/workflows/chromium-launcher-test.yaml`.
> 
> That gives branch protection and rulesets a **distinct required-check name** instead of sharing the generic `test` label with the server workflow’s `test` job. **No test steps or commands change**—only the job identifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6d6e2de0379b24011a0aaec28a144de44b9999f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->