### PR TITLE
test(e2e): de-flake display-resize and zip/zstd transfer tests

### DIFF
--- a/server/e2e/e2e_display_resize_window_test.go
+++ b/server/e2e/e2e_display_resize_window_test.go
@@ -457,7 +457,6 @@ func TestDisplayResizeChromiumWindow(t *testing.T) {
 	}
 }
 
-
 // navigateBlank points the active page at about:blank via playwright so the
 // renderer is alive before we query window dimensions.
 func navigateBlank(t *testing.T, ctx context.Context, c *TestContainer) {
@@ -491,14 +490,44 @@ func patchDisplayExpectingOK(t *testing.T, ctx context.Context, c *TestContainer
 		Height:      &height,
 		RefreshRate: &rate,
 	}
-	rsp, err := client.PatchDisplayWithResponse(ctx, req)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, rsp.StatusCode(), "PATCH /display: %s body=%s", rsp.Status(), string(rsp.Body))
-	require.NotNil(t, rsp.JSON200)
-	require.NotNil(t, rsp.JSON200.Width)
-	require.NotNil(t, rsp.JSON200.Height)
+	// Retry on the "neko not converged" signal: under concurrent
+	// privileged-container load neko's ScreenConfigurationChange can fail to
+	// apply, leaving the X root at the dummy DDX default (3840x2160). The
+	// server polls the X root for the realized size, so on that race it
+	// truthfully reports back 3840x2160 instead of the requested mode. That's
+	// a transient environmental hiccup, not a resize bug — re-issue the PATCH
+	// until neko applies the mode (or give up and let the assertions fail with
+	// the real observed value).
+	var rsp *instanceoapi.PatchDisplayResponse
+	for attempt := 0; attempt < 5; attempt++ {
+		rsp, err = client.PatchDisplayWithResponse(ctx, req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rsp.StatusCode(), "PATCH /display: %s body=%s", rsp.Status(), string(rsp.Body))
+		require.NotNil(t, rsp.JSON200)
+		require.NotNil(t, rsp.JSON200.Width)
+		require.NotNil(t, rsp.JSON200.Height)
+		if !isUnconvergedNekoSize(*rsp.JSON200.Width, *rsp.JSON200.Height, width, height) {
+			break
+		}
+		t.Logf("PATCH /display returned unconverged neko size %dx%d (requested %dx%d), retrying",
+			*rsp.JSON200.Width, *rsp.JSON200.Height, width, height)
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context cancelled while retrying PATCH /display: %v", ctx.Err())
+		case <-time.After(time.Second):
+		}
+	}
 	require.Equal(t, width, *rsp.JSON200.Width)
 	require.Equal(t, height, *rsp.JSON200.Height)
+}
+
+// isUnconvergedNekoSize reports whether a realized (w,h) looks like neko's
+// unconverged dummy-DDX default rather than the requested mode. The dummy max
+// (3840x2160) is >1000px off any normal request; real libxcvt rounding is
+// <16px, so a >64px gap on either axis is a safe "neko didn't apply" signal.
+func isUnconvergedNekoSize(realizedW, realizedH, wantW, wantH int) bool {
+	const slack = 64
+	return abs(realizedW-wantW) > slack || abs(realizedH-wantH) > slack
 }
 
 // TestDisplayResizeOddWidthHonoursLibxcvtRounding covers the path where a
@@ -544,6 +573,16 @@ func TestDisplayResizeOddWidthHonoursLibxcvtRounding(t *testing.T) {
 
 	navigateBlank(t, ctx, c)
 
+	// Wait for neko to apply its boot screen config (neko.yaml: 1920x1080@25)
+	// before resizing. Under concurrent privileged-container load neko's
+	// initial ScreenConfigurationChange can be slow; until it lands the X root
+	// sits at the dummy DDX default (3840x2160, the largest attached modeline).
+	// Resizing while neko is still unconverged makes neko echo back that stale
+	// 3840x2160 screen — which is exactly the flake this test used to hit
+	// (PATCH returned 200 body={3840x2160}). Gate on the baseline so the resize
+	// runs against a converged neko.
+	waitForXRootResolution(t, ctx, c, 1920, 1080, 60*time.Second)
+
 	// Request an odd width — the exact pattern from the production taint.
 	// libxcvt rounds 1365 to 1360 (CVT 8-pixel grid) then bumps to 1366
 	// (FWXGA hack for 1360×768 specifically). The X root lands at 1366×768.
@@ -554,13 +593,38 @@ func TestDisplayResizeOddWidthHonoursLibxcvtRounding(t *testing.T) {
 	require.NoError(t, err)
 	rate := instanceoapi.PatchDisplayRequestRefreshRate(refreshRate)
 	w, h := requestedWidth, height
-	rsp, err := client.PatchDisplayWithResponse(ctx, instanceoapi.PatchDisplayJSONRequestBody{
-		Width:       &w,
-		Height:      &h,
-		RefreshRate: &rate,
-	})
-	require.NoError(t, err)
 
+	// Retry on the unconverged-neko signal (X root stuck at the 3840x2160
+	// dummy default) just like patchDisplayExpectingOK; see that helper for
+	// the rationale. Without this the resize occasionally lands while neko is
+	// still mid-reconfiguration and echoes back 3840x2160.
+	var rsp *instanceoapi.PatchDisplayResponse
+	for attempt := 0; attempt < 5; attempt++ {
+		rsp, err = client.PatchDisplayWithResponse(ctx, instanceoapi.PatchDisplayJSONRequestBody{
+			Width:       &w,
+			Height:      &h,
+			RefreshRate: &rate,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.JSON200, "JSON200 response must be present")
+		require.NotNil(t, rsp.JSON200.Width, "response must include realized width")
+		require.NotNil(t, rsp.JSON200.Height, "response must include realized height")
+		if !isUnconvergedNekoSize(*rsp.JSON200.Width, *rsp.JSON200.Height, requestedWidth, height) {
+			break
+		}
+		t.Logf("PATCH /display returned unconverged neko size %dx%d (requested %dx%d), retrying",
+			*rsp.JSON200.Width, *rsp.JSON200.Height, requestedWidth, height)
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context cancelled while retrying PATCH /display: %v", ctx.Err())
+		case <-time.After(time.Second):
+		}
+	}
+
+	// Poll the X root until it converges on the realized mode rather than
+	// reading once: neko's ScreenConfigurationChange is asynchronous and the
+	// root may not reflect the new mode the instant PATCH returns.
+	waitForXRootResolution(t, ctx, c, realizedWidth, height, 30*time.Second)
 	rootW, rootH, xrErr := getXRootResolution(ctx, c)
 	require.NoError(t, xrErr, "read x root after resize")
 	t.Logf("PATCH /display(width=%d, height=%d) -> status=%d body=%s; x_root=%dx%d",

--- a/server/e2e/e2e_zip_transfer_bench_test.go
+++ b/server/e2e/e2e_zip_transfer_bench_test.go
@@ -113,13 +113,23 @@ func TestZipTransferTiming(t *testing.T) {
 // populateUserData creates some realistic content in the user-data directory
 // by executing a playwright script that navigates to a page.
 func populateUserData(ctx context.Context, client *instanceoapi.ClientWithResponses) error {
-	// Navigate to example.com to generate some browser state
+	// Navigate to generate some browser state (cache/cookies/history) so the
+	// user-data dir is non-trivial for the transfer benchmark. We only need
+	// *some* state, not a specific site. Use example.com (small, reliable) and
+	// wait for 'domcontentloaded' rather than 'load': the previous version
+	// navigated to www.google.com with the default 'load' wait, which
+	// regularly timed out at 30s under concurrent CI network pressure (it
+	// fans out to many subresources) and failed the whole test. Any secondary
+	// navigation is best-effort — its only purpose is to add more state.
 	code := `
-		await page.goto('https://example.com');
+		await page.goto('https://example.com', { waitUntil: 'domcontentloaded' });
 		await page.waitForTimeout(500);
-		// Visit another page to generate more cache/state
-		await page.goto('https://www.google.com');
-		await page.waitForTimeout(500);
+		try {
+			await page.goto('https://example.org', { waitUntil: 'domcontentloaded', timeout: 10000 });
+			await page.waitForTimeout(500);
+		} catch (e) {
+			// best-effort: extra state is a nice-to-have, not required
+		}
 		return 'done';
 	`
 	req := instanceoapi.ExecutePlaywrightCodeJSONRequestBody{Code: code}


### PR DESCRIPTION
## Summary

Two general, fork-agnostic e2e flakiness fixes. Both are timing / external-dependency issues seen under concurrent privileged-container load on self-hosted CI — neither is a product bug. Test/harness-only; no server or image changes.

These were first found and fixed while stabilizing the downstream private fork's e2e suite; this PR contributes back only the parts that are general-purpose (no fork-specific features), so the fixes live upstream and future syncs carry fewer conflicts.

### display-resize (`e2e_display_resize_window_test.go`)
`TestDisplayResizeOddWidthHonoursLibxcvtRounding` and `TestDisplayResizeChromiumWindow` flaked because, under concurrent load, neko's `ScreenConfigurationChange` is slow/unconverged at boot, leaving the X root at the dummy DDX default (3840x2160). A resize issued before neko converges makes neko echo that stale 3840x2160 back (`PATCH 200 body={3840x2160}`), failing the assertions.

Fix:
- Gate the odd-width resize on neko's 1920x1080 boot baseline (`neko.yaml` `screen: "1920x1080@25"`) before resizing.
- Poll the X root for the realized mode instead of reading once — `ScreenConfigurationChange` is asynchronous, so the root may not reflect the new mode the instant `PATCH` returns.
- Retry `PATCH` (in `patchDisplayExpectingOK` and the odd-width path) when the realized size is the dummy-default "neko not converged" signal (`isUnconvergedNekoSize`: >64px off the request; real libxcvt rounding is <16px, the dummy max is >1000px off, so 64px is a safe separator). A genuine resize bug — wrong-but-close size or non-200 — is still caught, since only the far-off dummy-default echo is retried.

### zip/zstd transfer (`e2e_zip_transfer_bench_test.go`)
`populateUserData` navigated to `www.google.com` with the default `load` wait, which timed out at 30s under CI network pressure (google fans out to many subresources), failing the transfer benchmarks. The helper only needs to generate *some* user-data state, so it now uses example.com/.org with `domcontentloaded` and makes the secondary navigation best-effort.

Also drops a stray double blank line for gofmt compliance.

## Verification

- `gofmt` clean on both touched files; `go vet ./e2e/` clean.
- The equivalent changes were verified to pass locally against built chromium-headful/headless images (display-resize odd-width + all window-resize scenarios; zip + zstd transfer timing) and green on the downstream fork's `test-server-e2e` CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to e2e test helpers and assertions; no server, API, or image behavior is modified.
> 
> **Overview**
> Hardens **display-resize** e2e tests against neko/X timing under heavy CI load. **`patchDisplayExpectingOK`** and the odd-width libxcvt test now **retry `PATCH /display` up to five times** when the API reports a realized size that looks like the unconverged dummy DDX default (**3840×2160**, detected via new **`isUnconvergedNekoSize`** with a 64px slack). The odd-width test also **waits for the 1920×1080 boot baseline** before resizing and **polls the X root** for the libxcvt-realized mode instead of asserting immediately after `PATCH`.
> 
> In **zip/zstd transfer** benchmarks, **`populateUserData`** stops navigating to Google with a full **`load`** wait (30s timeouts under CI). It uses **example.com** with **`domcontentloaded`** and treats a secondary **example.org** visit as **best-effort** so the benchmark only needs some browser profile state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e3a26934f604025a766cadcf2d1b1b2b6b178c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->