### PR TITLE
display: retry neko reconfig when X root never converges

### DIFF
--- a/server/cmd/api/api/display.go
+++ b/server/cmd/api/api/display.go
@@ -522,9 +522,15 @@ func (s *ApiService) setWindowMaximizedViaCDP(ctx context.Context) error {
 // libxcvt rounding is <16 px; the dummy max is >1000 px off any normal
 // request — acceptableDelta=32 sits comfortably between them.
 //
-// If neither condition fires before the timeout, returns the last
-// observation. Always non-fatal — the response always echoes some size,
-// never 500s.
+// The boolean reports convergence. False means the root never settled on
+// the request: either the timeout (or ctx) expired, or — early — the root
+// has been stable at a value far from the request past failFastGrace. A
+// dropped neko reconfig parks X at the dummy default immediately and
+// stably, so once readings stop moving there is nothing left to wait for;
+// returning early lets the caller re-issue the reconfig (neko path) or
+// fail the request instead of burning the rest of the timeout. The
+// realized dimensions returned alongside false are the last observation,
+// for error reporting only.
 //
 // Calls getCurrentResolutionFromXrandr directly rather than the higher-
 // level getCurrentResolution: the latter prefers a cached viewportOverride
@@ -536,6 +542,13 @@ func (s *ApiService) setWindowMaximizedViaCDP(ctx context.Context) error {
 func (s *ApiService) waitForXRootRealized(ctx context.Context, wantW, wantH int, timeout time.Duration) (int, int, bool) {
 	const stableReads = 3
 	const acceptableDelta = 32
+	// failFastGrace must outlast the worst legit transient (chromium in
+	// --kiosk briefly parks the root at the dummy max during mode-switch);
+	// failFastStableReads — ~500ms of identical reads at the 50ms cadence —
+	// rejects values still in motion.
+	const failFastGrace = 2 * time.Second
+	const failFastStableReads = 10
+	start := time.Now()
 	deadline := time.Now().Add(timeout)
 	var lastW, lastH int
 	var stableCount int
@@ -549,6 +562,10 @@ func (s *ApiService) waitForXRootRealized(ctx context.Context, wantW, wantH int,
 				stableCount++
 				if stableCount >= stableReads && abs(w-wantW) <= acceptableDelta && abs(h-wantH) <= acceptableDelta {
 					return w, h, true
+				}
+				if stableCount >= failFastStableReads && time.Since(start) >= failFastGrace &&
+					(abs(w-wantW) > acceptableDelta || abs(h-wantH) > acceptableDelta) {
+					return w, h, false
 				}
 			} else {
 				stableCount = 1

--- a/server/cmd/api/api/display.go
+++ b/server/cmd/api/api/display.go
@@ -115,7 +115,8 @@ func (s *ApiService) PatchDisplay(ctx context.Context, req oapi.PatchDisplayRequ
 
 	// Route to appropriate resolution change handler
 	if displayMode == "xorg" {
-		if s.isNekoEnabled() {
+		useNeko := s.isNekoEnabled()
+		if useNeko {
 			log.Info("using Neko API for Xorg resolution change")
 			err = s.setResolutionViaNeko(ctx, width, height, refreshRate)
 		} else {
@@ -156,16 +157,48 @@ func (s *ApiService) PatchDisplay(ctx context.Context, req oapi.PatchDisplayRequ
 			// DDX's max mode (3840×2160) while mutter settles on the
 			// new screen, and a single immediate read would catch that
 			// transient instead of the steady-state size.
-			realizedW, realizedH := s.waitForXRootRealized(ctx, width, height, 10*time.Second)
-			if realizedW > 0 && realizedH > 0 {
-				if realizedW != width || realizedH != height {
-					log.Info("X root differs from request after resize",
+			//
+			// On the Neko path, retry the reconfig RPC when X never
+			// converges. Neko applies screen configuration asynchronously
+			// and can drop/clobber a PATCH that lands while a previous
+			// reconfig (e.g. its boot 1920x1080) is still in flight —
+			// the new request is silently lost and X stays at the dummy
+			// DDX default (3840x2160). Polling X harder won't recover;
+			// only re-issuing the reconfig will.
+			const maxAttempts = 3
+			var realizedW, realizedH int
+			var converged bool
+			for attempt := 0; attempt < maxAttempts; attempt++ {
+				realizedW, realizedH, converged = s.waitForXRootRealized(ctx, width, height, 10*time.Second)
+				if converged {
+					break
+				}
+				if !useNeko || attempt == maxAttempts-1 {
+					break
+				}
+				log.Warn("X root did not converge after resize, retrying neko reconfig",
+					"attempt", attempt+1,
+					"requested", fmt.Sprintf("%dx%d", width, height),
+					"realized", fmt.Sprintf("%dx%d", realizedW, realizedH))
+				if retryErr := s.setResolutionViaNeko(ctx, width, height, refreshRate); retryErr != nil {
+					err = retryErr
+					break
+				}
+			}
+			if err == nil {
+				if !converged {
+					log.Error("display did not converge to requested mode after retries",
 						"requested", fmt.Sprintf("%dx%d", width, height),
 						"realized", fmt.Sprintf("%dx%d", realizedW, realizedH))
+					err = fmt.Errorf("display did not converge to %dx%d (X root reports %dx%d)", width, height, realizedW, realizedH)
+				} else {
+					if realizedW != width || realizedH != height {
+						log.Info("X root differs from request after resize",
+							"requested", fmt.Sprintf("%dx%d", width, height),
+							"realized", fmt.Sprintf("%dx%d", realizedW, realizedH))
+					}
+					width, height = realizedW, realizedH
 				}
-				width, height = realizedW, realizedH
-			} else {
-				log.Warn("X root never read successfully after resize, returning requested dimensions")
 			}
 		}
 		if err == nil {
@@ -500,7 +533,7 @@ func (s *ApiService) setWindowMaximizedViaCDP(ctx context.Context) error {
 // today, so the Xorg branch never reaches that case — but the invariant
 // is non-local and would silently regress if anyone ever sets the
 // override on the Xorg path.
-func (s *ApiService) waitForXRootRealized(ctx context.Context, wantW, wantH int, timeout time.Duration) (int, int) {
+func (s *ApiService) waitForXRootRealized(ctx context.Context, wantW, wantH int, timeout time.Duration) (int, int, bool) {
 	const stableReads = 3
 	const acceptableDelta = 32
 	deadline := time.Now().Add(timeout)
@@ -510,12 +543,12 @@ func (s *ApiService) waitForXRootRealized(ctx context.Context, wantW, wantH int,
 		w, h, _, _, err := s.getCurrentResolutionFromXrandr(ctx)
 		if err == nil {
 			if w == wantW && h == wantH {
-				return w, h
+				return w, h, true
 			}
 			if w == lastW && h == lastH {
 				stableCount++
 				if stableCount >= stableReads && abs(w-wantW) <= acceptableDelta && abs(h-wantH) <= acceptableDelta {
-					return w, h
+					return w, h, true
 				}
 			} else {
 				stableCount = 1
@@ -523,11 +556,11 @@ func (s *ApiService) waitForXRootRealized(ctx context.Context, wantW, wantH int,
 			}
 		}
 		if time.Now().After(deadline) {
-			return lastW, lastH
+			return lastW, lastH, false
 		}
 		select {
 		case <-ctx.Done():
-			return lastW, lastH
+			return lastW, lastH, false
 		case <-time.After(50 * time.Millisecond):
 		}
 	}


### PR DESCRIPTION
## Summary

`PATCH /display` could return **HTTP 200** with the unconverged dummy DDX default (`3840×2160`) in the response body instead of the requested mode. This was being papered over at the test layer by adding retry loops in e2e tests (PR #279); this PR fixes it at the server layer so SDK callers get correct behavior.

## The race

`setResolutionViaNeko` calls neko's `ScreenConfigurationChange` RPC, which is asynchronous. If a PATCH lands while a previous reconfig is in flight — e.g. neko's boot `1920×1080@25` config — the new request can be dropped/clobbered. `waitForXRootRealized` then polls X until timeout, sees the dummy default `3840×2160`, and the handler echoes that value back as the realized size.

The function had no way to signal "I gave up" vs "I converged on something close to the request", so the handler treated both the same and returned 200 either way.

## Fix

Two changes in `server/cmd/api/api/display.go`:

1. **`waitForXRootRealized` returns a `converged bool`.** Same polling logic, but the function now distinguishes a successful settle from a timeout. No behavior change for the existing exact-match and stable-within-delta success paths.
2. **Neko path retries the reconfig RPC.** When convergence fails, the handler re-issues `setResolutionViaNeko` up to 3 times before giving up. Polling X harder can't recover a request neko dropped — only re-issuing the RPC will. The xrandr (no-neko) path skips the RPC retry (xrandr is synchronous and idempotent) but still surfaces the non-convergence honestly.

If all retries fail, the handler now returns 500 with `display did not converge to WxH (X root reports W'xH')` instead of 200 with the wrong size. SDK callers see an honest error and can decide to retry.

## Verification

Reproduced locally on a quiet VM (no concurrent load):

| Test | Before | After |
|---|---|---|
| `TestDisplayResizeOddWidthHonoursLibxcvtRounding` | 2 fails / 5 runs (~40%) | 8/8 pass |
| `TestDisplayResizeChromiumWindow` headful subtests | (not measured) | 12/12 pass (4 runs × 3 subtests) |

The failing body before the fix was `{"width":3840,"height":2160}` for a request of `{1365,768}`. Two of the 8 runs after the fix took ~10s longer than baseline — that's the retry firing transparently and recovering, exactly the intended behavior.

## Follow-ups

Once this lands, the e2e retry loops added in #279 become redundant and can be removed — keeping the `waitForXRootResolution(1920, 1080)` baseline-wait there is fine as a latency optimization but is no longer load-bearing.


## Fail-fast update (second commit)

`waitForXRootRealized` now returns non-converged **early** when the root has been stable at a value far from the request (2s grace + ~500ms of identical reads at the 50ms cadence), instead of always burning the full 10s poll. A dropped reconfig parks X at the dummy default immediately and stably — polling longer never recovers it — so the retry now fires after ~2.2s instead of ~10.3s, and the worst case before the 500 drops from ~30s to ~7s.

Measured via local docker e2e (fresh headful container boot + immediate `PATCH /display` 1365×768, quiet and with 3–4 concurrent boots):

| | retry needed | racy resize latency | clean resize latency | false-positive retries | converge-fail 500s |
|---|---|---|---|---|---|
| 10s poll (first commit) | 5/43 cold boots | 10.23–10.32s | ~225ms mean | n/a | 0 |
| fail-fast (this commit) | 2/55 cold boots | 2.21–2.27s | ~224ms mean | **0** | 0 |

Every racy case had the same signature — root parked at 3840×2160 for the entire window, convergence ~200ms after the re-issued reconfig — and every response was 200 with the correct realized size. Zero of 98 warm resizes needed a retry; the race is purely a boot-window phenomenon. The kiosk transient (root briefly at the dummy max during mode-switch) can't trip the early-fail: the consecutive-identical-reads requirement resets on any moving value, and the `headful_kiosk` / `headful_start_maximized` / `headful_xorg_no_neko` subtests plus `TestDisplayResizeOddWidthHonoursLibxcvtRounding` all pass against an image built from this branch.

Also rewrites the stale "never 500s" doc paragraph on `waitForXRootRealized` flagged in review.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core display resize success/failure semantics for headful Neko deployments; callers that relied on 200 with wrong sizes will now see errors, which is intended but is a behavioral contract change.
> 
> **Overview**
> **`PATCH /display`** on the Xorg + Neko path no longer returns **HTTP 200** with the wrong realized size (e.g. dummy **3840×2160**) when Neko drops an async screen reconfig.
> 
> `waitForXRootRealized` now returns a **`converged`** flag so the handler can tell a successful settle from a timeout. On the Neko path, if X never converges within the poll window, the handler **re-issues `setResolutionViaNeko` up to 3 times** before giving up; the xrandr-only path does not retry the RPC but still treats non-convergence as failure.
> 
> If convergence still fails, the API returns **500** with `display did not converge to WxH (X root reports W'xH')` instead of echoing the stale X root in a 200 response. Successful convergence still uses the realized X root dimensions (including libxcvt rounding) in the response body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a00bbbea2006dfc863552109d3ec6695128448c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
