### PR TITLE
Fix flaky TestUpstreamManagerDetectsChromiumAndRestart (raise cold-start timeout)

### DIFF
--- a/.github/workflows/server-test.yaml
+++ b/.github/workflows/server-test.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Chrome
+        id: setup-chrome
         uses: browser-actions/setup-chrome@v2
 
       - name: Set up Node.js
@@ -62,3 +63,8 @@ jobs:
         env:
           E2E_CHROMIUM_HEADFUL_IMAGE: onkernel/chromium-headful:${{ steps.vars.outputs.short_sha }}
           E2E_CHROMIUM_HEADLESS_IMAGE: onkernel/chromium-headless:${{ steps.vars.outputs.short_sha }}
+          # Pin the browser used by devtoolsproxy's UpstreamManager test to the
+          # Chrome for Testing installed above (rather than the runner image's
+          # /usr/bin/chromium snapshot build) so the browser under test is
+          # deterministic across runner-image updates.
+          CHROMIUM_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}

--- a/server/lib/devtoolsproxy/proxy_test.go
+++ b/server/lib/devtoolsproxy/proxy_test.go
@@ -55,7 +55,32 @@ func newTestLogWriter(t *testing.T) *testLogWriter {
 }
 
 func findBrowserBinary() (string, error) {
-	candidates := []string{"chromium", "chromium-browser", "google-chrome", "google-chrome-stable"}
+	// Allow CI/developers to pin an exact browser binary. This is important
+	// because the UpstreamManager detects the CDP endpoint solely by scraping
+	// the "DevTools listening on ws://..." line from the browser's stderr, and
+	// not every Chromium build emits that line reliably (see candidate ordering
+	// below).
+	for _, env := range []string{"CHROMIUM_BIN", "CHROME_BIN"} {
+		if v := os.Getenv(env); v != "" {
+			if p, err := exec.LookPath(v); err == nil {
+				return p, nil
+			}
+			// Treat a non-PATH value as an explicit path.
+			if _, err := os.Stat(v); err == nil {
+				return v, nil
+			}
+		}
+	}
+
+	// Prefer the deterministic Chrome/Chrome-for-Testing binaries over a bare
+	// "chromium". On GitHub's ubuntu-latest runner /usr/bin/chromium is a
+	// symlink to an open-source Chromium *snapshot* build (installed by
+	// runner-images from chromium-browser-snapshots); the CI workflow separately
+	// installs a pinned Chrome for Testing via browser-actions/setup-chrome,
+	// exposed on PATH as "chrome". Preferring "chrome"/"google-chrome" keeps the
+	// browser under test deterministic across runner-image updates. (This is
+	// hygiene, not the flake fix — see browserDetectTimeout below.)
+	candidates := []string{"chrome", "google-chrome", "google-chrome-stable", "chromium", "chromium-browser"}
 	for _, name := range candidates {
 		if p, err := exec.LookPath(name); err == nil {
 			return p, nil
@@ -234,6 +259,16 @@ func TestDialUpstreamWithRetry_RechecksCurrentAfterMissedUpdate(t *testing.T) {
 	}
 }
 
+// browserDetectTimeout bounds how long the test waits for the UpstreamManager
+// to scrape the "DevTools listening on ws://..." line from a freshly launched
+// browser. Chromium's cold-start time has a long tail on shared CI runners:
+// across recent CI runs this same launch printed the line in ~6s on a warm
+// runner but took 15-17s on a slow/contended one, and occasionally exceeded the
+// previous 20s budget (failing at exactly ~20.15s — the timeout, not a missing
+// line). 60s gives ample headroom for the slow tail while still failing fast if
+// the browser truly never comes up.
+const browserDetectTimeout = 60 * time.Second
+
 func TestUpstreamManagerDetectsChromiumAndRestart(t *testing.T) {
 	browser, err := findBrowserBinary()
 	if err != nil {
@@ -317,7 +352,7 @@ func TestUpstreamManagerDetectsChromiumAndRestart(t *testing.T) {
 	}()
 
 	// Wait for initial upstream containing port1
-	ok := waitForCondition(20*time.Second, func() bool {
+	ok := waitForCondition(browserDetectTimeout, func() bool {
 		u := mgr.Current()
 		return strings.Contains(u, fmt.Sprintf(":%d/", port1))
 	})
@@ -351,7 +386,7 @@ func TestUpstreamManagerDetectsChromiumAndRestart(t *testing.T) {
 	}()
 
 	// Expect manager to update to new port
-	ok = waitForCondition(20*time.Second, func() bool {
+	ok = waitForCondition(browserDetectTimeout, func() bool {
 		u := mgr.Current()
 		return strings.Contains(u, fmt.Sprintf(":%d/", port2))
 	})


### PR DESCRIPTION
## Problem

`TestUpstreamManagerDetectsChromiumAndRestart` (`server/lib/devtoolsproxy/proxy_test.go`) fails intermittently in CI (blocking #282):

```
proxy_test.go: chromium log file contents:
  ...ERROR:dbus/bus.cc:405] Failed to connect to the bus: Could not parse server address...
proxy_test.go: did not detect initial upstream for port 40185; got: ""
--- FAIL: TestUpstreamManagerDetectsChromiumAndRestart (20.15s)
```

Pre-existing flake on `main`, independent of #282 (which only touches `chromedriverproxy` + e2e).

## Root cause (corrected after investigation)

The test launches a real headless Chromium and waits for `UpstreamManager` to scrape the `DevTools listening on ws://...` line from the browser log. The wait was capped at **20s per launch**.

The real cause is **Chromium cold-start latency with a long tail on shared CI runners** — the wait times out, the line is not missing. Hard evidence:

**1. CI duration distribution** across recent `main` runs of this exact test (same `/usr/bin/chromium` invocation):

| Result | Durations |
|---|---|
| PASS (warm) | 6.4s, 6.6s, 6.7s, 6.8s |
| PASS (slow) | 10.1s, 14.3s, 15.4s, 16.96s |
| **FAIL** | **20.14s, 20.15s, 20.16s** |

The failures cluster at exactly the 20s timeout — a classic too-tight-deadline signature, with PASS times already creeping to 17s on slow runners.

**2. Reproduced with the runner's exact browser.** GitHub's `ubuntu-latest` (24.04) `/usr/bin/chromium` is a symlink to an open-source **Chromium 148.0.7778.0** snapshot build (installed by `runner-images` from `chromium-browser-snapshots`; confirmed via the runner-images README + `install-google-chrome.sh`). I downloaded that exact snapshot and ran the **exact** test command:

```
stdbuf -oL -eL <chromium> --headless=new --remote-debugging-address=127.0.0.1 \
  --remote-debugging-port=40185 --no-first-run ... about:blank
```

Result: the `DevTools listening on ws://127.0.0.1:40185/...` line **is printed reliably** (~0.5s warm, 20/20 iterations). So the earlier "this Chromium build never prints the line" theory was **wrong**.

**3. The dbus errors are a red herring.** The failure log's `dbus/bus.cc:405 Could not parse server address` is benign — I reproduced it by setting a malformed `DBUS_SESSION_BUS_ADDRESS`, and Chromium **still printed the DevTools line** despite the dbus errors. dbus has nothing to do with CDP/DevTools startup.

So: on a contended runner, the first Chromium launch occasionally takes >20s to bring up its DevTools HTTP server, and the test's 20s `waitForCondition` expires first.

## Fix

- **Raise the per-launch detection wait to 60s** (named `browserDetectTimeout`, with the rationale documented) so the slow cold-start tail clears while still failing fast if the browser genuinely never comes up. **This is the actual flake fix.**
- **Secondary hygiene (not the root cause):** `findBrowserBinary` now honors `CHROMIUM_BIN`/`CHROME_BIN` and prefers the deterministic `chrome`/`google-chrome` binaries, and `server-test.yaml` pins `CHROMIUM_BIN` to `setup-chrome`'s `chrome-path`. This makes the browser-under-test deterministic across runner-image updates; it does not by itself fix the latency flake.

## Test output

```
$ go build ./... && go vet ./lib/devtoolsproxy/      # clean
# run with the EXACT runner Chromium 148.0.7778.0 snapshot:
$ CHROMIUM_BIN=.../chrome-linux/chrome go test ./lib/devtoolsproxy/ -run ...AndRestart -v
--- PASS: TestUpstreamManagerDetectsChromiumAndRestart (1.28s)
```

## Relationship to #282

#282 is blocked only by this pre-existing flake. After this merges, **#282 should rebase on `main`** to pick up the timeout + workflow changes and get a green CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)