### PR TITLE
test: de-flake TestUpstreamManagerDetectsChromiumAndRestart

### DIFF
--- a/server/lib/devtoolsproxy/proxy_test.go
+++ b/server/lib/devtoolsproxy/proxy_test.go
@@ -87,13 +87,15 @@ func waitForCondition(timeout time.Duration, cond func() bool) bool {
 
 // killProcessGroup kills cmd's entire process group and reaps the parent.
 // Requires the command to have been started with Setpgid so the group ID
-// equals the child's PID.
+// equals the child's PID. Idempotent: a reaped cmd (ProcessState set by
+// Wait below) is never re-signalled, so a recycled PGID can't be hit by
+// a second call — e.g. a defer following an explicit kill.
 func killProcessGroup(cmd *exec.Cmd) {
-	if cmd == nil || cmd.Process == nil {
+	if cmd == nil || cmd.Process == nil || cmd.ProcessState != nil {
 		return
 	}
 	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	_, _ = cmd.Process.Wait()
+	_ = cmd.Wait()
 }
 
 func TestWaitForInitialTimeoutWhenLogMissing(t *testing.T) {

--- a/server/lib/devtoolsproxy/proxy_test.go
+++ b/server/lib/devtoolsproxy/proxy_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -82,6 +83,17 @@ func waitForCondition(timeout time.Duration, cond func() bool) bool {
 		time.Sleep(50 * time.Millisecond)
 	}
 	return cond()
+}
+
+// killProcessGroup kills cmd's entire process group and reaps the parent.
+// Requires the command to have been started with Setpgid so the group ID
+// equals the child's PID.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	_, _ = cmd.Process.Wait()
 }
 
 func TestWaitForInitialTimeoutWhenLogMissing(t *testing.T) {
@@ -294,6 +306,10 @@ func TestUpstreamManagerDetectsChromiumAndRestart(t *testing.T) {
 			cmd = exec.Command(browser, chromiumArgs...)
 		}
 
+		// Own process group so cleanup can kill the whole tree — killing
+		// only the parent leaves renderer/crashpad children writing the
+		// user-data-dir while t.TempDir() cleanup deletes it.
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		cmd.Stdout = logFile
 		cmd.Stderr = logFile
 		if err := cmd.Start(); err != nil {
@@ -311,13 +327,13 @@ func TestUpstreamManagerDetectsChromiumAndRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("start chromium 1: %v", err)
 	}
-	defer func() {
-		_ = cmd1.Process.Kill()
-		_, _ = cmd1.Process.Wait()
-	}()
+	defer killProcessGroup(cmd1)
 
-	// Wait for initial upstream containing port1
-	ok := waitForCondition(20*time.Second, func() bool {
+	// Wait for initial upstream containing port1. Generous timeout: CI
+	// runners can take tens of seconds to bring up chromium's devtools
+	// endpoint under load.
+	const upstreamDetectTimeout = 60 * time.Second
+	ok := waitForCondition(upstreamDetectTimeout, func() bool {
 		u := mgr.Current()
 		return strings.Contains(u, fmt.Sprintf(":%d/", port1))
 	})
@@ -338,20 +354,16 @@ func TestUpstreamManagerDetectsChromiumAndRestart(t *testing.T) {
 		t.Fatalf("get free port 2: %v", err)
 	}
 	t.Logf("killing first chromium instance to restart on port %d", port2)
-	_ = cmd1.Process.Kill()
-	_, _ = cmd1.Process.Wait()
+	killProcessGroup(cmd1)
 
 	cmd2, err := startChromium(port2)
 	if err != nil {
 		t.Fatalf("start chromium 2: %v", err)
 	}
-	defer func() {
-		_ = cmd2.Process.Kill()
-		_, _ = cmd2.Process.Wait()
-	}()
+	defer killProcessGroup(cmd2)
 
 	// Expect manager to update to new port
-	ok = waitForCondition(20*time.Second, func() bool {
+	ok = waitForCondition(upstreamDetectTimeout, func() bool {
 		u := mgr.Current()
 		return strings.Contains(u, fmt.Sprintf(":%d/", port2))
 	})


### PR DESCRIPTION
## Summary

`TestUpstreamManagerDetectsChromiumAndRestart` (lib/devtoolsproxy) is flaky in two distinct modes — it reproduces locally at ~20% (3/15 runs) and has been failing CI runs on main and PRs (including several attempts on #280's run, and runs on other branches the same day):

1. **Teardown race** — the test kills the chromium *parent* process (`Process.Kill()`), but chromium's renderer/crashpad children outlive it and keep writing the `--user-data-dir` while Go's `t.TempDir()` cleanup deletes it → `TempDir RemoveAll cleanup: unlinkat .../Default: directory not empty`. This is the dominant mode locally.
2. **Detection timeout** — the 20s `waitForCondition` for the DevTools endpoint is too tight on loaded CI runners; chromium starts but hasn't printed `DevTools listening` within the window (log shows only dbus noise).

## Fix

- Start chromium in its own process group (`Setpgid`, same pattern as `lib/recorder/ffmpeg.go` and `cmd/api/api/process.go`) and kill the whole group on cleanup via a small `killProcessGroup` helper, replacing the three parent-only kill sites.
- Raise the two detection waits from 20s to a shared `upstreamDetectTimeout = 60s`. A genuinely hung chromium still fails (with the existing log dump), slow runners no longer do.

Test-only change; no production code touched.

## Verification

- Before: 3/15 local runs fail (teardown race).
- After: 60/60 local runs pass (`-count=30` twice); full `lib/devtoolsproxy` package suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in `proxy_test.go`; no production code paths affected.
> 
> **Overview**
> Stabilizes **`TestUpstreamManagerDetectsChromiumAndRestart`** in `proxy_test.go` by fixing Chromium teardown and loosening DevTools detection timing on slow CI.
> 
> Chromium is started with **`Setpgid`** and teardown uses a new **`killProcessGroup`** helper (`SIGKILL` on the process group + `Wait`) instead of killing only the parent—avoiding leftover renderer/crashpad processes racing **`t.TempDir()`** cleanup. The two upstream-detection waits share **`upstreamDetectTimeout = 60s`** (was 20s).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4566e1ce05ede939a6fcc4b1beea7190ba3dd51e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->