### PR TITLE
Reject Manifest V2 extensions at upload with a clear error

### DIFF
--- a/server/cmd/api/api/chromium.go
+++ b/server/cmd/api/api/chromium.go
@@ -208,6 +208,14 @@ func (s *ApiService) applyExtensionZipItems(ctx context.Context, items []extensi
 			return "invalid zip file", nil
 		}
 
+		manifestVersion, found, err := policy.ManifestVersion(filepath.Join(dest, "manifest.json"))
+		if err != nil {
+			return fmt.Sprintf("extension %s has an invalid manifest.json: %v", p.name, err), nil
+		}
+		if found && manifestVersion > 0 && manifestVersion < 3 {
+			return fmt.Sprintf("extension %s uses Manifest V%d, which Chromium no longer supports; upgrade it to Manifest V3", p.name, manifestVersion), nil
+		}
+
 		updateXMLPath := filepath.Join(dest, "update.xml")
 		if err := policy.RewriteUpdateXMLUrls(updateXMLPath, p.name); err != nil {
 			log.Warn("failed to rewrite update.xml URLs", "error", err, "extension", p.name)

--- a/server/cmd/api/api/chromium.go
+++ b/server/cmd/api/api/chromium.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -210,7 +211,11 @@ func (s *ApiService) applyExtensionZipItems(ctx context.Context, items []extensi
 
 		manifestVersion, found, err := policy.ManifestVersion(filepath.Join(dest, "manifest.json"))
 		if err != nil {
-			return fmt.Sprintf("extension %s has an invalid manifest.json: %v", p.name, err), nil
+			if errors.Is(err, policy.ErrInvalidManifest) {
+				return fmt.Sprintf("extension %s has an invalid manifest.json: %v", p.name, err), nil
+			}
+			log.Error("failed to read extension manifest", "error", err, "extension", p.name)
+			return "", fmt.Errorf("failed to read extension manifest: %w", err)
 		}
 		if found && manifestVersion > 0 && manifestVersion < 3 {
 			return fmt.Sprintf("extension %s uses Manifest V%d, which Chromium no longer supports; upgrade it to Manifest V3", p.name, manifestVersion), nil

--- a/server/lib/policy/policy.go
+++ b/server/lib/policy/policy.go
@@ -271,6 +271,29 @@ func (p *Policy) RequiresEnterprisePolicy(manifestPath string) (bool, error) {
 	return false, nil
 }
 
+// ManifestVersion reads the manifest_version field from an extension's manifest.json.
+// It returns the version and whether a manifest.json was present. A missing manifest.json
+// is not an error: extensions installed via update.xml + .crx may not ship an unpacked
+// manifest, and those are validated by Chromium itself.
+func ManifestVersion(manifestPath string) (version int, found bool, err error) {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+
+	var m struct {
+		ManifestVersion int `json:"manifest_version"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return 0, false, fmt.Errorf("failed to parse manifest.json: %w", err)
+	}
+
+	return m.ManifestVersion, true, nil
+}
+
 // updateManifest represents the Chrome extension update manifest XML structure
 type updateManifest struct {
 	XMLName xml.Name  `xml:"gupdate"`

--- a/server/lib/policy/policy.go
+++ b/server/lib/policy/policy.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -10,6 +11,10 @@ import (
 	"strings"
 	"sync"
 )
+
+// ErrInvalidManifest indicates a manifest.json that exists but could not be parsed.
+// It distinguishes a malformed manifest (a client error) from an I/O failure reading it.
+var ErrInvalidManifest = errors.New("invalid manifest.json")
 
 const PolicyPath = "/etc/chromium/policies/managed/policy.json"
 
@@ -288,7 +293,7 @@ func ManifestVersion(manifestPath string) (version int, found bool, err error) {
 		ManifestVersion int `json:"manifest_version"`
 	}
 	if err := json.Unmarshal(data, &m); err != nil {
-		return 0, false, fmt.Errorf("failed to parse manifest.json: %w", err)
+		return 0, false, fmt.Errorf("%w: %v", ErrInvalidManifest, err)
 	}
 
 	return m.ManifestVersion, true, nil

--- a/server/lib/policy/policy_test.go
+++ b/server/lib/policy/policy_test.go
@@ -202,5 +202,6 @@ func TestManifestVersion(t *testing.T) {
 	t.Run("invalid json", func(t *testing.T) {
 		_, _, err := ManifestVersion(write("bad.json", `{not json`))
 		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidManifest)
 	})
 }

--- a/server/lib/policy/policy_test.go
+++ b/server/lib/policy/policy_test.go
@@ -2,6 +2,8 @@ package policy
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -167,4 +169,38 @@ func TestPolicy_EmptyPolicy(t *testing.T) {
 
 	// Should have empty ExtensionSettings as null/missing
 	assert.Nil(t, result["ExtensionSettings"])
+}
+
+func TestManifestVersion(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, contents string) string {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+		return path
+	}
+
+	t.Run("manifest v3", func(t *testing.T) {
+		version, found, err := ManifestVersion(write("mv3.json", `{"manifest_version": 3, "name": "x"}`))
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, 3, version)
+	})
+
+	t.Run("manifest v2", func(t *testing.T) {
+		version, found, err := ManifestVersion(write("mv2.json", `{"manifest_version": 2, "name": "x"}`))
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, 2, version)
+	})
+
+	t.Run("missing file is not an error", func(t *testing.T) {
+		_, found, err := ManifestVersion(filepath.Join(dir, "does-not-exist.json"))
+		require.NoError(t, err)
+		assert.False(t, found)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		_, _, err := ManifestVersion(write("bad.json", `{not json`))
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
## Summary

Chromium hasn't supported Manifest V2 extensions for ~a while. Right now if a user uploads a MV2 extension it's accepted by the upload endpoint, extracted, and wired into `--load-extension` / the enterprise policy. Then silently fails to load when Chromium starts, with no signal back to the caller.

This adds an explicit `manifest_version` check at upload time:

- `policy.ManifestVersion` reads `manifest_version` from the extracted `manifest.json`. A missing manifest is not an error (crx + update.xml installs may not ship an unpacked manifest; Chromium validates those itself).
- `applyExtensionZipItems` rejects any extension whose manifest declares version 1 or 2 with a 400 explaining it must be upgraded to Manifest V3. The existing cleanup path removes the partially-extracted dir.

## Test plan

CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds upload-time validation only; no auth or policy persistence changes beyond failing fast with 400s before install completes.
> 
> **Overview**
> Extension zip uploads now **validate `manifest.json` immediately after extraction**, before policy/flags updates or Chromium restart.
> 
> **`policy.ManifestVersion`** reads `manifest_version` from the unpacked manifest. A **missing** manifest is allowed (e.g. crx + `update.xml` flows). **Malformed JSON** returns **`ErrInvalidManifest`** and surfaces as a **400** with a clear message. Extensions declaring **Manifest V1 or V2** are rejected with a **400** explaining Chromium requires **Manifest V3**. Failed validation still uses the existing **partial-directory cleanup** on the upload path.
> 
> Unit tests cover **`ManifestVersion`** for MV3, MV2, missing file, and invalid JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf25794a5646034c6f7dc64d0349df3438b7d832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->