### PR TITLE
Increase kernel-images-api stop time

### DIFF
--- a/images/chromium-headful/supervisor/services/kernel-images-api.conf
+++ b/images/chromium-headful/supervisor/services/kernel-images-api.conf
@@ -4,5 +4,7 @@ command=/bin/bash -lc 'mkdir -p "${KERNEL_IMAGES_API_OUTPUT_DIR:-/recordings}" &
 autostart=false
 autorestart=true
 startsecs=0
+; graceful shutdown + buffer
+stopwaitsecs=25
 stdout_logfile=/var/log/supervisord/kernel-images-api
 redirect_stderr=true

--- a/images/chromium-headless/image/supervisor/services/kernel-images-api.conf
+++ b/images/chromium-headless/image/supervisor/services/kernel-images-api.conf
@@ -4,5 +4,7 @@ command=/bin/bash -lc 'mkdir -p "${KERNEL_IMAGES_API_OUTPUT_DIR:-/recordings}" &
 autostart=false
 autorestart=true
 startsecs=0
+; graceful shutdown + buffer
+stopwaitsecs=25
 stdout_logfile=/var/log/supervisord/kernel-images-api
 redirect_stderr=true


### PR DESCRIPTION
align to graceful shutdown upperbound

note: less than optimal to hardcode but fine for now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Supervisor-only timing tweak for container stop behavior; no application logic or security paths change.
> 
> **Overview**
> Supervisor now waits **25 seconds** (`stopwaitsecs=25`) before force-killing `kernel-images-api` on stop, instead of the default ~10s. The change is applied identically in **chromium-headful** and **chromium-headless** `kernel-images-api.conf`, with a comment that the value covers graceful shutdown plus a small buffer (aligned with the API’s shutdown upper bound).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f4f79e995b49ccce74f9559d4e560ae7d0ab377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->