### PR TITLE
Avoid extension install wait deadline race

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,6 @@ Dockerfile
 initrd
 .tmp
 server/api
+server/e2e
+server/**/*_test.go
+server/**/testdata

--- a/.github/workflows/server-test.yaml
+++ b/.github/workflows/server-test.yaml
@@ -77,7 +77,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: "server/go.mod"
-          cache: false
+          cache: true
+          cache-dependency-path: server/go.sum
 
       - name: Compute short SHA for images
         id: vars
@@ -89,6 +90,23 @@ jobs:
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull e2e images
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker pull "$E2E_CHROMIUM_HEADFUL_IMAGE" &
+          headful_pid=$!
+
+          docker pull "$E2E_CHROMIUM_HEADLESS_IMAGE" &
+          headless_pid=$!
+
+          wait "$headful_pid"
+          wait "$headless_pid"
+        env:
+          E2E_CHROMIUM_HEADFUL_IMAGE: onkernel/chromium-headful:${{ steps.vars.outputs.short_sha }}
+          E2E_CHROMIUM_HEADLESS_IMAGE: onkernel/chromium-headless:${{ steps.vars.outputs.short_sha }}
 
       - name: Run server e2e tests
         run: make test-e2e

--- a/server/e2e/e2e_enterprise_extension_test.go
+++ b/server/e2e/e2e_enterprise_extension_test.go
@@ -443,6 +443,16 @@ func TestExtensionDownloadLogSince(t *testing.T) {
 	require.Equal(t, "line 3\n", extensionDownloadLogSince("line 3\n", ""))
 }
 
+func TestNextExtensionInstallPollDelay(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, nextExtensionInstallPollDelay(0))
+	require.Zero(t, nextExtensionInstallPollDelay(-time.Millisecond))
+	require.Equal(t, 250*time.Millisecond, nextExtensionInstallPollDelay(500*time.Millisecond))
+	require.Equal(t, time.Second, nextExtensionInstallPollDelay(time.Second))
+	require.Equal(t, time.Second, nextExtensionInstallPollDelay(5*time.Second))
+}
+
 // checkChromePolicies checks how Chrome sees the policies.
 func checkChromePolicies(t *testing.T, ctx context.Context, c *TestContainer) {
 	t.Helper()
@@ -598,13 +608,28 @@ func waitForExtensionInstalled(t *testing.T, ctx context.Context, c *TestContain
 			return
 		}
 
+		delay := nextExtensionInstallPollDelay(time.Until(deadline))
+		if delay <= 0 {
+			continue
+		}
+
 		select {
 		case <-ctx.Done():
 			require.NoError(t, ctx.Err(), "context cancelled waiting for extension installation")
 			return
-		case <-time.After(1 * time.Second):
+		case <-time.After(delay):
 		}
 	}
+}
+
+func nextExtensionInstallPollDelay(remaining time.Duration) time.Duration {
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining < time.Second {
+		return remaining / 2
+	}
+	return time.Second
 }
 
 func chromeExtensionsCheckOutput(ctx context.Context, c *TestContainer, expectedExtensionName string) ([]byte, error) {


### PR DESCRIPTION
## Summary
- fix the enterprise extension install wait so it does not sleep across its deadline before failing
- add focused coverage for the retry-delay calculation
- speed up public e2e startup by restoring the Go build cache for the e2e job and pre-pulling headful/headless images in parallel before the Go e2e suite
- keep server e2e files, Go test files, and testdata out of Docker image build contexts so test-only edits do not invalidate runtime image build layers

## Timing
Before this PR on the rebased public branch:
- test-server-e2e job: 4m20s
- Run server e2e tests step: 3m50s
- Go e2e package runtime: 186.989s
- first display headless container start: 25.4s
- first display headful container start: 28.0s

After this PR:
- build-headful / docker: 50s
- build-headless / docker: 52s
- test-server-e2e job: 3m28s
- Pull e2e images step: 32s
- Run server e2e tests step: 2m29s
- Go e2e package runtime: 129.429s
- first measured container starts are now about 3-4s instead of paying the serial image pull during the display tests

The Go e2e package runtime is now under 2.5m. The total e2e job is still above 2.5m because GitHub Actions setup plus the explicit image pull are counted around the Go test process.

The Docker context cleanup makes image builds more stable for test-only PRs by preventing e2e/test-only files from invalidating runtime image builder layers.

## Validation
- git diff --check
- yq . .github/workflows/server-test.yaml >/dev/null
- cd server && go test ./e2e -run TestNextExtensionInstallPollDelay -count=1
- autoreview clean after Docker context cleanup
- CI green after Docker context cleanup: build-headful, build-headless, test-server-unit, test-server-e2e, scan, chromium-launcher test, socket checks

Follow-up for Cursor Bugbot feedback on #299.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to e2e test timing, GitHub Actions workflow, and Docker ignore rules with no production runtime or auth logic touched.
> 
> **Overview**
> Fixes a **deadline race** in enterprise extension install polling: `waitForExtensionInstalled` now uses `nextExtensionInstallPollDelay` (shorter sleeps when little time remains, skip sleep when past deadline) instead of a fixed 1s wait, with unit tests for the delay helper.
> 
> **CI / build speed:** the server e2e job re-enables the Go module cache (`server/go.sum`) and **pre-pulls** headful and headless Chromium images in parallel before `make test-e2e`.
> 
> **Docker context:** `.dockerignore` excludes `server/e2e`, `server/**/*_test.go`, and `server/**/testdata` so test-only changes do not invalidate runtime image build layers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46007d20b63cefa0e2ef9219a4b513d9a96b8203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->