### PR TITLE
play around with stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Deployed successfully!
 
 ## Connect to the browser via Chrome DevTools Protocol
 
-Port `9222` is exposed via `ncat`, allowing you to connect Chrome DevTools Protocol-based browser frameworks like Playwright and Puppeteer (and CDP-based SDKs like Browser Use). You can use these frameworks to drive the browser in the cloud. You can also disconnect from the browser and reconnect to it.
+Port `9222` exposes a DevTools proxy in front of the browser, allowing you to connect Chrome DevTools Protocol-based browser frameworks like Playwright and Puppeteer (and CDP-based SDKs like Browser Use). You can use these frameworks to drive the browser in the cloud. The proxy tracks the browser across restarts, so you can also disconnect and reconnect to it.
 
 First, fetch the browser's CDP websocket endpoint:
 
@@ -145,7 +145,7 @@ You can use the embedded live view to monitor and control the browser. The live 
 
 ## Replay Capture
 
-You can use the embedded recording server to capture recordings of the entire screen in our headful images. It allows for one recording at a time and can be enabled with `WITH_KERNEL_IMAGES_API=true`
+You can use the embedded recording server to capture recordings of the entire screen in our headful images. It allows for one recording at a time. The API server is part of the image; `run-docker.sh` exposes it on host port `444`.
 
 For example:
 
@@ -153,18 +153,18 @@ For example:
 cd images/chromium-headful
 export IMAGE=kernel-docker
 ./build-docker.sh
-WITH_KERNEL_IMAGES_API=true ENABLE_WEBRTC=true ./run-docker.sh
+ENABLE_WEBRTC=true ./run-docker.sh
 
 # 1. Start a new recording
-curl http://localhost:10001/recording/start -d {}
+curl http://localhost:444/recording/start -d {}
 
 # recording in progress - run your agent
 
 # 2. Stop recording
-curl http://localhost:10001/recording/stop -d {}
+curl http://localhost:444/recording/stop -d {}
 
 # 3. Download the recorded file
-curl http://localhost:10001/recording/download --output recording.mp4
+curl http://localhost:444/recording/download --output recording.mp4
 ```
 
 Note: the recording file is encoded into a H.264/MPEG-4 AVC video file. [QuickTime has known issues with playback](https://discussions.apple.com/thread/254851789?sortBy=rank) so please make sure to use a compatible media player!

--- a/images/chromium-headful/supervisor/services/kernel-images-api.conf
+++ b/images/chromium-headful/supervisor/services/kernel-images-api.conf
@@ -1,6 +1,6 @@
 [program:kernel-images-api]
 ; AUDIO_SOURCE and PULSE_SERVER defaults must match shared/start-pulseaudio.sh.
-command=/bin/bash -lc 'mkdir -p "${KERNEL_IMAGES_API_OUTPUT_DIR:-/recordings}" && PORT="${KERNEL_IMAGES_API_PORT:-10001}" FRAME_RATE="${KERNEL_IMAGES_API_FRAME_RATE:-10}" DISPLAY_NUM="${KERNEL_IMAGES_API_DISPLAY_NUM:-${DISPLAY_NUM:-1}}" MAX_SIZE_MB="${KERNEL_IMAGES_API_MAX_SIZE_MB:-500}" OUTPUT_DIR="${KERNEL_IMAGES_API_OUTPUT_DIR:-/recordings}" AUDIO_SOURCE="${KERNEL_IMAGES_API_AUDIO_SOURCE:-${AUDIO_SOURCE:-KernelOutput.monitor}}" PULSE_SERVER="${PULSE_SERVER:-unix:/tmp/pulse/native}" LOG_CDP_MESSAGES="${LOG_CDP_MESSAGES:-false}" S2_BASIN="${S2_BASIN:-}" S2_ACCESS_TOKEN="${S2_ACCESS_TOKEN:-}" S2_STREAM="${S2_STREAM:-}" exec /usr/local/bin/kernel-images-api'
+command=/bin/bash -lc 'mkdir -p "${KERNEL_IMAGES_API_OUTPUT_DIR:-/recordings}" && PORT="${KERNEL_IMAGES_API_PORT:-10001}" FRAME_RATE="${KERNEL_IMAGES_API_FRAME_RATE:-10}" DISPLAY_NUM="${KERNEL_IMAGES_API_DISPLAY_NUM:-${DISPLAY_NUM:-1}}" MAX_SIZE_MB="${KERNEL_IMAGES_API_MAX_SIZE_MB:-500}" OUTPUT_DIR="${KERNEL_IMAGES_API_OUTPUT_DIR:-/recordings}" AUDIO_SOURCE="${KERNEL_IMAGES_API_AUDIO_SOURCE:-${AUDIO_SOURCE:-KernelOutput.monitor}}" PULSE_SERVER="${PULSE_SERVER:-unix:/tmp/pulse/native}" LOG_CDP_MESSAGES="${LOG_CDP_MESSAGES:-false}" CHROMIUM_LOG_PATH="${KERNEL_IMAGES_API_CHROMIUM_LOG_PATH:-/var/log/supervisord/chromium}" S2_BASIN="${S2_BASIN:-}" S2_ACCESS_TOKEN="${S2_ACCESS_TOKEN:-}" S2_STREAM="${S2_STREAM:-}" exec /usr/local/bin/kernel-images-api'
 autostart=false
 autorestart=true
 startsecs=0

--- a/images/chromium-headless/image/supervisor/services/kernel-images-api.conf
+++ b/images/chromium-headless/image/supervisor/services/kernel-images-api.conf
@@ -1,6 +1,6 @@
 [program:kernel-images-api]
 ; AUDIO_SOURCE and PULSE_SERVER defaults must match shared/start-pulseaudio.sh.
-command=/bin/bash -lc 'mkdir -p "${KERNEL_IMAGES_API_OUTPUT_DIR:-/recordings}" && PORT="${KERNEL_IMAGES_API_PORT:-10001}" FRAME_RATE="${KERNEL_IMAGES_API_FRAME_RATE:-10}" DISPLAY_NUM="${KERNEL_IMAGES_API_DISPLAY_NUM:-${DISPLAY_NUM:-1}}" MAX_SIZE_MB="${KERNEL_IMAGES_API_MAX_SIZE_MB:-500}" OUTPUT_DIR="${KERNEL_IMAGES_API_OUTPUT_DIR:-/recordings}" AUDIO_SOURCE="${KERNEL_IMAGES_API_AUDIO_SOURCE:-${AUDIO_SOURCE:-KernelOutput.monitor}}" PULSE_SERVER="${PULSE_SERVER:-unix:/tmp/pulse/native}" LOG_CDP_MESSAGES="${LOG_CDP_MESSAGES:-false}" S2_BASIN="${S2_BASIN:-}" S2_ACCESS_TOKEN="${S2_ACCESS_TOKEN:-}" S2_STREAM="${S2_STREAM:-}" exec /usr/local/bin/kernel-images-api'
+command=/bin/bash -lc 'mkdir -p "${KERNEL_IMAGES_API_OUTPUT_DIR:-/recordings}" && PORT="${KERNEL_IMAGES_API_PORT:-10001}" FRAME_RATE="${KERNEL_IMAGES_API_FRAME_RATE:-10}" DISPLAY_NUM="${KERNEL_IMAGES_API_DISPLAY_NUM:-${DISPLAY_NUM:-1}}" MAX_SIZE_MB="${KERNEL_IMAGES_API_MAX_SIZE_MB:-500}" OUTPUT_DIR="${KERNEL_IMAGES_API_OUTPUT_DIR:-/recordings}" AUDIO_SOURCE="${KERNEL_IMAGES_API_AUDIO_SOURCE:-${AUDIO_SOURCE:-KernelOutput.monitor}}" PULSE_SERVER="${PULSE_SERVER:-unix:/tmp/pulse/native}" LOG_CDP_MESSAGES="${LOG_CDP_MESSAGES:-false}" CHROMIUM_LOG_PATH="${KERNEL_IMAGES_API_CHROMIUM_LOG_PATH:-/var/log/supervisord/chromium}" S2_BASIN="${S2_BASIN:-}" S2_ACCESS_TOKEN="${S2_ACCESS_TOKEN:-}" S2_STREAM="${S2_STREAM:-}" exec /usr/local/bin/kernel-images-api'
 autostart=false
 autorestart=true
 startsecs=0

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -27,6 +27,7 @@ go.work
 # End of https://www.toptal.com/developers/gitignore/api/go
 
 .tmp/
+.dev/
 bin/
 chromium-launcher
 recordings/

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-.PHONY: oapi-generate build dev test test-unit test-e2e clean
+.PHONY: oapi-generate build dev dev-browser dev-local test test-unit test-e2e clean
 
 BIN_DIR ?= $(CURDIR)/bin
 RECORDING_DIR ?= $(CURDIR)/recordings
@@ -29,6 +29,19 @@ build: | $(BIN_DIR)
 
 dev: build $(RECORDING_DIR)
 	OUTPUT_DIR=$(RECORDING_DIR) DISPLAY_NUM=$(DISPLAY_NUM) ./bin/api
+
+# One-time setup for dev-local: fetch Chrome for Testing (same distribution
+# the container images use) into .dev/browser. Headful-capable; dev-local
+# runs it with a visible window unless HEADLESS=1.
+dev-browser:
+	npx --yes @puppeteer/browsers install chrome@stable --path "$(CURDIR)/.dev/browser"
+
+# Local dev loop: launch the .dev browser as the CDP upstream, then run the
+# server against it (see scripts/dev-local.sh). API on :10001, CDP proxy on
+# :9222. Requires `make dev-browser` once, or CHROME_BIN pointing at a
+# Chromium-family binary.
+dev-local: build $(RECORDING_DIR)
+	OUTPUT_DIR=$(RECORDING_DIR) DISPLAY_NUM=$(DISPLAY_NUM) ./scripts/dev-local.sh ./bin/api
 
 # `test` runs unit + e2e. The two are split so callers (e.g. the Hypeman CI job)
 # can run just the e2e suite, and so e2e logs stream as they run instead of

--- a/server/README.md
+++ b/server/README.md
@@ -1,17 +1,28 @@
 # Kernel Images Server
 
-A REST API server to start, stop, and download screen recordings.
+The API server that runs inside Kernel browser instances. It fronts a
+Chromium with a **CDP DevTools proxy** (with live upstream hot-swapping across
+browser restarts) and a **ChromeDriver proxy**, and exposes REST endpoints for
+**screen recording**, **file I/O**, **process execution**, **computer input**
+(mouse/keyboard/screenshot), **display control**, and **telemetry/event
+streaming**. See `GET /spec.yaml` for the full API.
+
+In production it is baked into the images in `images/` and orchestrated by
+`cmd/wrapper` + supervisord alongside Chromium, Xorg, and Neko. For local
+development, `make dev-local` stands up the minimum substitute: a real
+Chromium-family browser as the CDP upstream.
 
 ## 🛠️ Prerequisites
 
 ### Required Software
 
 - **Go 1.24.3+** - Programming language runtime
-- **ffmpeg** - Video recording engine
+- **Node.js** - `npx` fetches the dev browser; `pnpm` drives OpenAPI code generation
+  - `npm install -g pnpm`
+- **ffmpeg** - Video recording engine (only needed for the `/recording` endpoints)
   - macOS: `brew install ffmpeg`
   - Linux: `sudo apt install ffmpeg` or `sudo yum install ffmpeg`
-- **pnpm** - For OpenAPI code generation
-  - `npm install -g pnpm`
+- **uv** (optional) - Runs the `scripts/drive.py` smoke test
 
 ### System Requirements
 
@@ -21,13 +32,46 @@ A REST API server to start, stop, and download screen recordings.
 
 ## 🚀 Quick Start
 
-### Running the Server
+### Running the Server Locally
 
 ```bash
-make dev
+make dev-browser   # once: downloads Chrome for Testing into .dev/browser
+make dev-local     # launches the browser + the server against it
 ```
 
-The server will start on port 10001 by default and log its configuration.
+`dev-local` starts the browser with remote debugging (headful, so you can
+watch it), waits for its DevTools endpoint, then runs the server pointed at
+it. Stop everything with `Ctrl-C`.
+
+| Port    | Surface                                                  |
+| ------- | -------------------------------------------------------- |
+| `10001` | REST API                                                  |
+| `9222`  | CDP DevTools proxy (Playwright/Puppeteer `connectOverCDP`) |
+| `9224`  | ChromeDriver proxy                                        |
+
+Variations:
+
+```bash
+HEADLESS=1 make dev-local                                  # no browser window
+CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" make dev-local
+```
+
+Smoke test (drives the browser over CDP and exercises REST endpoints):
+
+```bash
+uv run scripts/drive.py
+```
+
+> **No sandbox locally:** `/process` and `/fs` endpoints operate on your real
+> machine when run outside the container. Endpoints that need the container's
+> X/supervisord stack (`/computer`, `/chromium` lifecycle, display capture)
+> won't work locally.
+
+`make dev` runs the bare server without a browser. It requires
+`CHROMIUM_LOG_PATH` to point at a log containing a Chromium
+`DevTools listening on ws://...` line, and exits if no upstream is found
+within 10 seconds — supplying that browser is exactly what `dev-local` does
+for you (and what the wrapper/supervisord stack does in the images).
 
 #### Example use
 
@@ -44,22 +88,34 @@ curl http://localhost:10001/recording/stop -d {}
 curl http://localhost:10001/recording/download --output recording.mp4
 ```
 
+Note: outside the container, recording captures your machine's display — not
+the dev browser's pages.
+
 ### ⚙️ Configuration
 
 Configure the server using environment variables:
 
-| Variable       | Default   | Description                                 |
-| -------------- | --------- | ------------------------------------------- |
-| `PORT`         | `10001`   | HTTP server port                            |
-| `FRAME_RATE`   | `10`      | Default recording framerate (fps)           |
-| `DISPLAY_NUM`  | `1`       | Display/screen number to capture            |
-| `MAX_SIZE_MB`  | `500`     | Default maximum file size (MB)              |
-| `OUTPUT_DIR`   | `.`       | Directory to save recordings                |
-| `FFMPEG_PATH`  | `ffmpeg`  | Path to the ffmpeg binary                   |
+| Variable            | Default          | Description                                              |
+| ------------------- | ---------------- | -------------------------------------------------------- |
+| `CHROMIUM_LOG_PATH` | *(required)*     | Chromium log tailed for the DevTools `ws://` upstream URL |
+| `PORT`              | `10001`          | HTTP server port                                          |
+| `DEVTOOLS_PROXY_PORT` | `9222`         | CDP DevTools proxy port                                   |
+| `CHROMEDRIVER_PROXY_PORT` | `9224`     | ChromeDriver proxy port                                   |
+| `LOG_CDP_MESSAGES`  | `false`          | Log CDP messages passing through the proxy                |
+| `FRAME_RATE`        | `10`             | Default recording framerate (fps)                         |
+| `DISPLAY_NUM`       | `1`              | Display/screen number to capture                          |
+| `MAX_SIZE_MB`       | `500`            | Default maximum file size (MB)                            |
+| `OUTPUT_DIR`        | `.`              | Directory to save recordings                              |
+| `FFMPEG_PATH`       | `ffmpeg`         | Path to the ffmpeg binary                                 |
+
+In the images, `CHROMIUM_LOG_PATH` is set by the supervisord service config
+(`kernel-images-api.conf`) to supervisord's chromium log; `dev-local` points
+it at `.dev/chromium.log`.
 
 #### Example Configuration
 
 ```bash
+export CHROMIUM_LOG_PATH=/var/log/supervisord/chromium
 export PORT=8080
 export FRAME_RATE=30
 export MAX_SIZE_MB=1000

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -85,9 +85,9 @@ func main() {
 	// ws conn tracker
 	wsRegistry := wsdrain.New()
 
-	// DevTools WebSocket upstream manager: tail Chromium supervisord log
-	const chromiumLogPath = "/var/log/supervisord/chromium"
-	upstreamMgr := devtoolsproxy.NewUpstreamManager(chromiumLogPath, slogger)
+	// DevTools WebSocket upstream manager: tail the Chromium log for the
+	// DevTools URL (in the image, supervisord's chromium stdout_logfile)
+	upstreamMgr := devtoolsproxy.NewUpstreamManager(config.ChromiumLogPath, slogger)
 	upstreamMgr.Start(ctx)
 
 	// Initialize Neko authenticated client

--- a/server/cmd/config/config.go
+++ b/server/cmd/config/config.go
@@ -31,6 +31,11 @@ type Config struct {
 	// DevTools proxy configuration
 	DevToolsProxyPort int  `envconfig:"DEVTOOLS_PROXY_PORT" default:"9222"`
 	LogCDPMessages    bool `envconfig:"LOG_CDP_MESSAGES" default:"false"`
+	// Log file the DevTools upstream manager tails for Chromium's
+	// "DevTools listening on ws://" line. Deployment-specific (the container's
+	// supervisord conf and local dev point it at different files), so it has
+	// no default: the deployment must supply it.
+	ChromiumLogPath string `envconfig:"CHROMIUM_LOG_PATH"`
 
 	// How long to wait after the last active request before re-enabling scale-to-zero.
 	ScaleToZeroCooldown time.Duration `envconfig:"SCALE_TO_ZERO_COOLDOWN" default:"1s"`
@@ -66,6 +71,7 @@ func (c *Config) LogValue() slog.Value {
 		slog.String("ffmpeg_path", c.PathToFFmpeg),
 		slog.Int("devtools_proxy_port", c.DevToolsProxyPort),
 		slog.Bool("log_cdp_messages", c.LogCDPMessages),
+		slog.String("chromium_log_path", c.ChromiumLogPath),
 		slog.Duration("scale_to_zero_cooldown", c.ScaleToZeroCooldown),
 		slog.Int("chromedriver_proxy_port", c.ChromeDriverProxyPort),
 		slog.String("chromedriver_upstream_addr", c.ChromeDriverUpstreamAddr),
@@ -113,6 +119,9 @@ func validate(config *Config) error {
 	}
 	if config.DevToolsProxyAddr == "" {
 		return fmt.Errorf("DEVTOOLS_PROXY_ADDR is required")
+	}
+	if config.ChromiumLogPath == "" {
+		return fmt.Errorf("CHROMIUM_LOG_PATH is required")
 	}
 
 	return nil

--- a/server/cmd/config/config_test.go
+++ b/server/cmd/config/config_test.go
@@ -15,8 +15,10 @@ func TestLoad(t *testing.T) {
 		wantCfg *Config
 	}{
 		{
-			name: "defaults (no env set)",
-			env:  map[string]string{},
+			name: "defaults (only chromium log path set)",
+			env: map[string]string{
+				"CHROMIUM_LOG_PATH": "/var/log/supervisord/chromium",
+			},
 			wantCfg: &Config{
 				Port:                     10001,
 				FrameRate:                10,
@@ -31,6 +33,7 @@ func TestLoad(t *testing.T) {
 				ChromeDriverProxyPort:    9224,
 				ChromeDriverUpstreamAddr: "127.0.0.1:9225",
 				DevToolsProxyAddr:        "127.0.0.1:9222",
+				ChromiumLogPath:          "/var/log/supervisord/chromium",
 			},
 		},
 		{
@@ -48,6 +51,7 @@ func TestLoad(t *testing.T) {
 				"SCALE_TO_ZERO_COOLDOWN":     "5s",
 				"CHROMEDRIVER_PROXY_PORT":    "5432",
 				"CHROMEDRIVER_UPSTREAM_ADDR": "127.0.0.1:9999",
+				"CHROMIUM_LOG_PATH":          "/var/log/custom/chromium",
 			},
 			wantCfg: &Config{
 				Port:                     12345,
@@ -63,6 +67,7 @@ func TestLoad(t *testing.T) {
 				ChromeDriverProxyPort:    5432,
 				ChromeDriverUpstreamAddr: "127.0.0.1:9999",
 				DevToolsProxyAddr:        "127.0.0.1:9876",
+				ChromiumLogPath:          "/var/log/custom/chromium",
 			},
 		},
 		{
@@ -70,6 +75,7 @@ func TestLoad(t *testing.T) {
 			env: map[string]string{
 				"DEVTOOLS_PROXY_PORT": "7777",
 				"DEVTOOLS_PROXY_ADDR": "10.0.0.1:1234",
+				"CHROMIUM_LOG_PATH":   "/var/log/supervisord/chromium",
 			},
 			wantCfg: &Config{
 				Port:                     10001,
@@ -85,40 +91,46 @@ func TestLoad(t *testing.T) {
 				ChromeDriverProxyPort:    9224,
 				ChromeDriverUpstreamAddr: "127.0.0.1:9225",
 				DevToolsProxyAddr:        "10.0.0.1:1234",
+				ChromiumLogPath:          "/var/log/supervisord/chromium",
 			},
 		},
 		{
 			name: "negative display num",
 			env: map[string]string{
-				"DISPLAY_NUM": "-1",
+				"DISPLAY_NUM":       "-1",
+				"CHROMIUM_LOG_PATH": "/var/log/supervisord/chromium",
 			},
 			wantErr: true,
 		},
 		{
 			name: "frame rate too high",
 			env: map[string]string{
-				"FRAME_RATE": "1201",
+				"FRAME_RATE":        "1201",
+				"CHROMIUM_LOG_PATH": "/var/log/supervisord/chromium",
 			},
 			wantErr: true,
 		},
 		{
 			name: "max size too big",
 			env: map[string]string{
-				"MAX_SIZE_MB": "10001",
+				"MAX_SIZE_MB":       "10001",
+				"CHROMIUM_LOG_PATH": "/var/log/supervisord/chromium",
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing ffmpeg path (set to empty)",
 			env: map[string]string{
-				"FFMPEG_PATH": "",
+				"FFMPEG_PATH":       "",
+				"CHROMIUM_LOG_PATH": "/var/log/supervisord/chromium",
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing output dir (set to empty)",
 			env: map[string]string{
-				"OUTPUT_DIR": "",
+				"OUTPUT_DIR":        "",
+				"CHROMIUM_LOG_PATH": "/var/log/supervisord/chromium",
 			},
 			wantErr: true,
 		},
@@ -126,7 +138,13 @@ func TestLoad(t *testing.T) {
 			name: "missing chromedriver upstream addr (set to empty)",
 			env: map[string]string{
 				"CHROMEDRIVER_UPSTREAM_ADDR": "",
+				"CHROMIUM_LOG_PATH":          "/var/log/supervisord/chromium",
 			},
+			wantErr: true,
+		},
+		{
+			name:    "missing chromium log path (unset)",
+			env:     map[string]string{},
 			wantErr: true,
 		},
 	}

--- a/server/scripts/dev-local.sh
+++ b/server/scripts/dev-local.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Runs the given command (normally ./bin/api) against a locally launched
+# CDP browser, standing in for the wrapper/supervisord stack the container
+# provides: it starts the browser with remote debugging, captures its output
+# to a log file, waits for the "DevTools listening on ws://" line the
+# server's upstream manager tails for, then runs the server pointed at that
+# log. The browser is killed when the server exits.
+set -euo pipefail
+
+SERVER_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DEV_DIR="$SERVER_DIR/.dev"
+LOG_FILE="$DEV_DIR/chromium.log"
+USER_DATA_DIR="$DEV_DIR/chrome-user-data"
+# 9223: the server's own DevTools proxy listens on 9222.
+DEBUG_PORT="${CHROME_DEBUG_PORT:-9223}"
+READY_TIMEOUT="${READY_TIMEOUT:-30}"
+
+# CHROME_BIN overrides (e.g. your installed Google Chrome); default is the
+# Chrome for Testing installed by `make dev-browser`, falling back to a
+# previously installed chrome-headless-shell.
+BROWSER="${CHROME_BIN:-}"
+if [[ -z "$BROWSER" ]]; then
+  BROWSER="$(find "$DEV_DIR/browser" -type f -name 'Google Chrome for Testing' 2>/dev/null | head -1)"
+fi
+if [[ -z "$BROWSER" ]]; then
+  BROWSER="$(find "$DEV_DIR/browser" -type f -name 'chrome-headless-shell' 2>/dev/null | head -1)"
+fi
+if [[ -z "$BROWSER" || ! -x "$BROWSER" ]]; then
+  echo "dev-local: no browser found — run 'make dev-browser' (or set CHROME_BIN)" >&2
+  exit 1
+fi
+
+mkdir -p "$DEV_DIR" "$USER_DATA_DIR"
+# Truncate so the upstream manager can't scrape a stale ws:// URL from a
+# previous run.
+: > "$LOG_FILE"
+
+# Headful by default so you can watch the browser. HEADLESS=1 opts out
+# (chrome-headless-shell is headless by construction and needs no flag).
+HEADLESS_FLAG=""
+if [[ "$BROWSER" != *chrome-headless-shell* && -n "${HEADLESS:-}" ]]; then
+  HEADLESS_FLAG="--headless=new"
+fi
+
+"$BROWSER" $HEADLESS_FLAG \
+  --remote-debugging-port="$DEBUG_PORT" \
+  --user-data-dir="$USER_DATA_DIR" \
+  --no-first-run --no-default-browser-check \
+  about:blank >"$LOG_FILE" 2>&1 &
+BROWSER_PID=$!
+trap 'kill "$BROWSER_PID" 2>/dev/null; wait "$BROWSER_PID" 2>/dev/null' EXIT
+
+# Gate on the DevTools line so a slow browser cold start can't eat into the
+# server's own 10s upstream deadline.
+for _ in $(seq 1 $((READY_TIMEOUT * 5))); do
+  grep -q 'DevTools listening on ws://' "$LOG_FILE" && break
+  if ! kill -0 "$BROWSER_PID" 2>/dev/null; then
+    echo "dev-local: browser exited during startup; its output:" >&2
+    cat "$LOG_FILE" >&2
+    exit 1
+  fi
+  sleep 0.2
+done
+if ! grep -q 'DevTools listening on ws://' "$LOG_FILE"; then
+  echo "dev-local: browser produced no DevTools URL within ${READY_TIMEOUT}s; its output:" >&2
+  cat "$LOG_FILE" >&2
+  exit 1
+fi
+echo "dev-local: browser ready ($(grep -o 'DevTools listening on ws://[^ ]*' "$LOG_FILE" | head -1))"
+
+export CHROMIUM_LOG_PATH="$LOG_FILE"
+# Not exec: the EXIT trap must survive to reap the browser on Ctrl-C.
+"$@"

--- a/server/scripts/drive.py
+++ b/server/scripts/drive.py
@@ -1,0 +1,54 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["playwright", "httpx"]
+# ///
+"""Smoke-drive a dev-local instance: the browser over CDP (:9222) and the
+kernel-images REST API (:10001), including a CDP→API handoff.
+
+Usage: uv run scripts/drive.py  (with `make dev-local` running)
+
+NOTE: locally there is no sandbox — /process and /fs endpoints operate on
+YOUR machine. In the container they are contained.
+"""
+import base64
+
+import httpx
+from playwright.sync_api import sync_playwright
+
+API = "http://localhost:10001"
+CDP = "http://localhost:9222"
+DEMO_FILE = "/tmp/kernel-dev-demo.png"
+
+api = httpx.Client(base_url=API, timeout=10)
+
+print("== REST: run a command via /process/exec ==")
+r = api.post("/process/exec", json={"command": "uname", "args": ["-a"]})
+r.raise_for_status()
+result = r.json()
+print(f"exit={result['exit_code']} stdout={base64.b64decode(result['stdout_b64']).decode().strip()}")
+
+print("\n== CDP: drive the browser ==")
+with sync_playwright() as p:
+    browser = p.chromium.connect_over_cdp(CDP)
+    ctx = browser.contexts[0]
+    page = ctx.pages[0] if ctx.pages else ctx.new_page()
+    page.goto("https://example.com")
+    print("title:", page.title())
+    shot = page.screenshot()
+    print(f"screenshot: {len(shot)} bytes")
+    browser.close()  # disconnects; the browser itself stays up
+
+print("\n== CDP→API handoff: store the screenshot via /fs/write_file ==")
+r = api.put("/fs/write_file", params={"path": DEMO_FILE}, content=shot)
+r.raise_for_status()
+
+r = api.get("/fs/file_info", params={"path": DEMO_FILE})
+r.raise_for_status()
+info = r.json()
+print(f"file_info: {info['path']} {info['size_bytes']}B mode={info['mode']}")
+
+r = api.get("/fs/read_file", params={"path": DEMO_FILE})
+r.raise_for_status()
+assert r.content == shot, "read-back bytes differ from screenshot!"
+print(f"read_file: {len(r.content)} bytes, matches screenshot ✓")
+print(f"\nopen {DEMO_FILE} to see what the browser saw")


### PR DESCRIPTION
# Checklist

- [ ] A link to a related issue in our repository
- [ ] A description of the changes proposed in the pull request.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Requiring `CHROMIUM_LOG_PATH` at startup can break deployments that launch the API without the updated supervisord env; image configs are updated but any custom runners must set it explicitly.
> 
> **Overview**
> Adds a **local development loop** for the kernel-images API: `make dev-browser` installs Chrome for Testing into `server/.dev/`, and `make dev-local` runs `scripts/dev-local.sh` to start Chromium with remote debugging, tail its log for the DevTools `ws://` line, then launch the server with CDP proxy on `:9222` and REST on `:10001`. A `scripts/drive.py` smoke test exercises CDP and REST together.
> 
> **Breaking/config change:** the DevTools upstream manager no longer hardcodes `/var/log/supervisord/chromium`; it uses required env **`CHROMIUM_LOG_PATH`**. Headful/headless image supervisord configs now export it (defaulting to the chromium supervisord log). Config load and tests require this variable.
> 
> **Docs:** root README clarifies the `:9222` DevTools proxy and restart-safe reconnect; recording examples use host port **444** and drop `WITH_KERNEL_IMAGES_API=true`. `server/README.md` documents the full server surface and the new local workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 848f4de89667ce5a53741401db9e0c1ce5c0dcd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->