### PR TITLE
fix(chromium-headful): sync clipboard to viewers under implicit hosting

### DIFF
--- a/images/chromium-headful/client/src/components/video.vue
+++ b/images/chromium-headful/client/src/components/video.vue
@@ -280,6 +280,10 @@
       return this.$accessor.connecting
     }
 
+    get controlling() {
+      return this.$accessor.remote.controlling
+    }
+
     get hosting() {
       return this.$accessor.remote.hosting
     }
@@ -804,14 +808,18 @@
       first.target.dispatchEvent(simulatedEvent)
     }
 
+    isMouseDown = false
+
     onMouseDown(e: MouseEvent) {
       this.unmuteOnInteraction()
+      this.isMouseDown = true
 
-      if (!this.hosting) {
-        this.$emit('control-attempt', e)
+      if (this.locked) {
+        return
       }
 
-      if (!this.hosting || this.locked) {
+      if (!this.controlling) {
+        this.implicitHostingRequest(e)
         return
       }
 
@@ -820,12 +828,55 @@
     }
 
     onMouseUp(e: MouseEvent) {
-      if (!this.hosting || this.locked) {
+      // only if we are the one who started the mouse down
+      if (!this.isMouseDown) return
+      this.isMouseDown = false
+
+      if (this.locked) {
+        return
+      }
+
+      if (!this.controlling) {
+        this.implicitHostingRequest(e)
         return
       }
 
       this.sendMousePos(e)
       this.$client.sendData('mouseup', { key: e.button + 1 })
+    }
+
+    private reqMouseDown: MouseEvent | null = null
+    private reqMouseUp: MouseEvent | null = null
+
+    @Watch('controlling')
+    onControlChange(controlling: boolean) {
+      if (controlling && this.reqMouseDown) {
+        this.onMouseDown(this.reqMouseDown)
+      }
+
+      if (controlling && this.reqMouseUp) {
+        this.onMouseUp(this.reqMouseUp)
+      }
+
+      this.reqMouseDown = null
+      this.reqMouseUp = null
+    }
+
+    implicitHostingRequest(e: MouseEvent) {
+      if (this.implicitHosting) {
+        if (e.type === 'mousedown') {
+          this.reqMouseDown = e
+          this.reqMouseUp = null
+          this.$accessor.remote.request()
+        } else if (e.type === 'mouseup') {
+          this.reqMouseUp = e
+        }
+        return
+      }
+
+      if (e.type === 'mousedown') {
+        this.$emit('control-attempt', e)
+      }
     }
 
     onMouseMove(e: MouseEvent) {

--- a/images/chromium-headful/client/src/store/remote.ts
+++ b/images/chromium-headful/client/src/store/remote.ts
@@ -18,6 +18,9 @@ export const state = () => ({
 })
 
 export const getters = getterTree(state, {
+  controlling: (state, getters, root) => {
+    return root.user.id === state.id
+  },
   hosting: (state, getters, root) => {
     return root.user.id === state.id || state.implicitHosting
   },
@@ -89,7 +92,7 @@ export const actions = actionTree(
     },
 
     request({ getters }) {
-      if (!accessor.connected || getters.hosting) {
+      if (!accessor.connected || getters.controlling) {
         return
       }
 


### PR DESCRIPTION
## Description

Copying inside a remote browser session never reaches the viewer's local clipboard. The neko server only sends remote-clipboard updates to the registered **host** session, and under implicit hosting the vendored client never sends `control/request` (`remote.ts` `request()` bails because `hosting` is always true), so no host is ever registered and the updates are silently dropped. Full analysis and a live repro in #310.

This is a port of upstream m1k1o/neko#540 (which fixed the same bug, m1k1o/neko#499) onto the client vendored here:

- `remote.ts`: add an explicit-host `controlling` getter; gate `request()` on it instead of `hosting`.
- `video.vue`: on mouse interaction while not controlling, buffer the triggering event, send the control request, and replay the event once `controlling` flips true (`@Watch('controlling')`). Non-implicit behavior (`control-attempt` emit) is preserved.

## Verification

- `npm run build` in `images/chromium-headful/client` passes.
- Protocol change validated against a live production Kernel session: manually issuing the exact `control/request` this patch adds made the server reply `control/locked`, after which a Ctrl+C in the remote browser produced the `control/clipboard` push, `navigator.clipboard.writeText` succeeded, and the local clipboard held the remote selection — end-to-end copy working (details in #310).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote session control and input routing in the headful client; behavior is localized but affects who receives server clipboard and when mouse events reach the remote.
> 
> **Overview**
> Under **implicit hosting**, the client treated every viewer as “hosting” without ever sending **`control/request`**, so the neko server never registered a host and **remote clipboard updates were dropped**.
> 
> This adds a **`controlling`** getter (registered host only) and gates **`remote.request()`** on it instead of **`hosting`**. In **`video.vue`**, the first click while not controlling sends a control request, buffers the mouse down/up, and **replays** them when **`controlling`** becomes true; non-implicit mode still emits **`control-attempt`** on mousedown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 038849301103f3e6b9cedba693118dc48c58fc73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->