### PR TITLE
display: converge X root on the configure stop/start resize path

### DIFF
--- a/server/cmd/api/api/chromium_configure.go
+++ b/server/cmd/api/api/chromium_configure.go
@@ -688,12 +688,7 @@ func chromiumDisplayApplyWhileStopped(ctx context.Context, s *ApiService, plan *
 		}
 		return nil
 	}
-	var err error
-	if s.isNekoEnabled() {
-		_, _, err = s.applyResolutionAndConverge(ctx, w, h, rr, true)
-	} else {
-		err = s.setResolutionXorgViaXrandr(ctx, w, h, rr)
-	}
+	_, _, err := s.applyResolutionAndConverge(ctx, w, h, rr, s.isNekoEnabled())
 	if err != nil {
 		return cfg500ConfigureStep(chromiumConfigureStepDisplay, err.Error())
 	}

--- a/server/cmd/api/api/chromium_configure.go
+++ b/server/cmd/api/api/chromium_configure.go
@@ -690,7 +690,7 @@ func chromiumDisplayApplyWhileStopped(ctx context.Context, s *ApiService, plan *
 	}
 	var err error
 	if s.isNekoEnabled() {
-		err = s.setResolutionViaNeko(ctx, w, h, rr)
+		_, _, err = s.applyResolutionAndConverge(ctx, w, h, rr, true)
 	} else {
 		err = s.setResolutionXorgViaXrandr(ctx, w, h, rr)
 	}

--- a/server/cmd/api/api/display.go
+++ b/server/cmd/api/api/display.go
@@ -115,92 +115,26 @@ func (s *ApiService) PatchDisplay(ctx context.Context, req oapi.PatchDisplayRequ
 
 	// Route to appropriate resolution change handler
 	if displayMode == "xorg" {
-		useNeko := s.isNekoEnabled()
-		if useNeko {
-			log.Info("using Neko API for Xorg resolution change")
-			err = s.setResolutionViaNeko(ctx, width, height, refreshRate)
-		} else {
-			log.Info("using xrandr for Xorg resolution change (Neko disabled)")
-			err = s.setResolutionXorgViaXrandr(ctx, width, height, refreshRate)
-		}
-		// Re-assert the maximized window state via CDP, then verify the
-		// X root has reached the requested size. Mutter reflows a
-		// maximized (or fullscreen) window onto the new root
-		// automatically, so the CDP call's only job is to make sure the
-		// window is in the state that triggers the reflow. The X root
-		// poll is the authoritative post-condition: it's the value the
-		// server actually set and stays panel-robust if mutter ever
-		// gains a taskbar (a maximized window would then be smaller
-		// than the root by the panel's reserved space).
-		//
-		// Both are fatal on failure — returning 200 with the X root
-		// still at the old size, or the window stuck in normal state,
-		// would leave the caller with no signal of the mismatch. The
-		// previous approach of restarting chromium so it could re-apply
-		// --start-maximized had the same effective contract (the
-		// restart blocked the response) but cost ~9s per resize and
-		// wiped browser-side state (Emulation.* overrides, devtools
-		// sessions). The restart_chromium request field is still
-		// accepted for API compatibility but no longer triggers a
-		// restart on this path.
+		var realizedW, realizedH int
+		realizedW, realizedH, err = s.applyResolutionAndConverge(ctx, width, height, refreshRate, s.isNekoEnabled())
 		if err == nil {
-			// Wait for the X root to settle, then use it as the
-			// realized size in the response. The wait returns early
-			// when either (a) xrandr reports the requested size — the
-			// common case — or (b) consecutive reads are stable for a
-			// short window, capturing libxcvt's rounded size on
-			// requests it can't honour exactly (CVT 8-pixel grid +
-			// FWXGA bump for 1360×768 → 1366×768).
-			//
-			// The poll absorbs transient X root states — chromium
-			// running in --kiosk briefly pushes the root to the dummy
-			// DDX's max mode (3840×2160) while mutter settles on the
-			// new screen, and a single immediate read would catch that
-			// transient instead of the steady-state size.
-			//
-			// On the Neko path, retry the reconfig RPC when X never
-			// converges. Neko applies screen configuration asynchronously
-			// and can drop/clobber a PATCH that lands while a previous
-			// reconfig (e.g. its boot 1920x1080) is still in flight —
-			// the new request is silently lost and X stays at the dummy
-			// DDX default (3840x2160). Polling X harder won't recover;
-			// only re-issuing the reconfig will.
-			const maxAttempts = 3
-			var realizedW, realizedH int
-			var converged bool
-			for attempt := 0; attempt < maxAttempts; attempt++ {
-				realizedW, realizedH, converged = s.waitForXRootRealized(ctx, width, height, 10*time.Second)
-				if converged {
-					break
-				}
-				if !useNeko || attempt == maxAttempts-1 {
-					break
-				}
-				log.Warn("X root did not converge after resize, retrying neko reconfig",
-					"attempt", attempt+1,
+			if realizedW != width || realizedH != height {
+				log.Info("X root differs from request after resize",
 					"requested", fmt.Sprintf("%dx%d", width, height),
 					"realized", fmt.Sprintf("%dx%d", realizedW, realizedH))
-				if retryErr := s.setResolutionViaNeko(ctx, width, height, refreshRate); retryErr != nil {
-					err = retryErr
-					break
-				}
 			}
-			if err == nil {
-				if !converged {
-					log.Error("display did not converge to requested mode after retries",
-						"requested", fmt.Sprintf("%dx%d", width, height),
-						"realized", fmt.Sprintf("%dx%d", realizedW, realizedH))
-					err = fmt.Errorf("display did not converge to %dx%d (X root reports %dx%d)", width, height, realizedW, realizedH)
-				} else {
-					if realizedW != width || realizedH != height {
-						log.Info("X root differs from request after resize",
-							"requested", fmt.Sprintf("%dx%d", width, height),
-							"realized", fmt.Sprintf("%dx%d", realizedW, realizedH))
-					}
-					width, height = realizedW, realizedH
-				}
-			}
+			width, height = realizedW, realizedH
 		}
+		// Re-assert the maximized window state via CDP so mutter reflows the
+		// window onto the new root; applyResolutionAndConverge already verified
+		// the root size, which is the authoritative post-condition. Fatal on
+		// failure — returning 200 with the window stuck in its old state would
+		// leave the caller with no signal of the mismatch. The previous approach
+		// of restarting chromium so it could re-apply --start-maximized had the
+		// same effective contract but cost ~9s per resize and wiped browser-side
+		// state (Emulation.* overrides, devtools sessions); restart_chromium is
+		// still accepted for API compatibility but no longer triggers a restart
+		// on this path.
 		if err == nil {
 			if cdpErr := s.setWindowMaximizedViaCDP(ctx); cdpErr != nil {
 				log.Error("CDP maximize re-assert failed after Xorg resolution change", "error", cdpErr)
@@ -588,6 +522,67 @@ func abs(x int) int {
 		return -x
 	}
 	return x
+}
+
+// applyResolutionAndConverge sets the Xorg resolution — via Neko when enabled,
+// otherwise xrandr — and waits for the X root to actually reach the requested
+// size, returning the realized dimensions.
+//
+// The poll absorbs transient X root states: chromium running in --kiosk briefly
+// pushes the root to the dummy DDX's max mode (3840x2160) while mutter settles
+// on the new screen, and a single immediate read would catch that transient. It
+// also captures libxcvt's rounded size on requests the driver can't honour
+// exactly (CVT 8-pixel grid + FWXGA bump for 1360x768 -> 1366x768).
+//
+// On the Neko path it re-issues the reconfig when the root never converges.
+// Neko applies screen configuration asynchronously and can drop/clobber a
+// request that lands while a previous reconfig (e.g. its boot 1920x1080) is
+// still in flight — the request is silently lost and X stays at the dummy DDX
+// default (3840x2160). Polling X harder won't recover it, only re-issuing will.
+// setResolutionViaNeko returns as soon as the request is accepted, so every
+// caller that needs the resolution to have taken effect — the live-resize path
+// before re-asserting the window, and the configure stop/start path before
+// relaunching Chromium in --kiosk — must go through here rather than call
+// setResolutionViaNeko directly.
+func (s *ApiService) applyResolutionAndConverge(ctx context.Context, width, height, refreshRate int, useNeko bool) (int, int, error) {
+	log := logger.FromContext(ctx)
+	var err error
+	if useNeko {
+		log.Info("using Neko API for Xorg resolution change")
+		err = s.setResolutionViaNeko(ctx, width, height, refreshRate)
+	} else {
+		log.Info("using xrandr for Xorg resolution change (Neko disabled)")
+		err = s.setResolutionXorgViaXrandr(ctx, width, height, refreshRate)
+	}
+	if err != nil {
+		return 0, 0, err
+	}
+	const maxAttempts = 3
+	var realizedW, realizedH int
+	var converged bool
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		realizedW, realizedH, converged = s.waitForXRootRealized(ctx, width, height, 10*time.Second)
+		if converged {
+			break
+		}
+		if !useNeko || attempt == maxAttempts-1 {
+			break
+		}
+		log.Warn("X root did not converge after resize, retrying neko reconfig",
+			"attempt", attempt+1,
+			"requested", fmt.Sprintf("%dx%d", width, height),
+			"realized", fmt.Sprintf("%dx%d", realizedW, realizedH))
+		if retryErr := s.setResolutionViaNeko(ctx, width, height, refreshRate); retryErr != nil {
+			return realizedW, realizedH, retryErr
+		}
+	}
+	if !converged {
+		log.Error("display did not converge to requested mode after retries",
+			"requested", fmt.Sprintf("%dx%d", width, height),
+			"realized", fmt.Sprintf("%dx%d", realizedW, realizedH))
+		return realizedW, realizedH, fmt.Errorf("display did not converge to %dx%d (X root reports %dx%d)", width, height, realizedW, realizedH)
+	}
+	return realizedW, realizedH, nil
 }
 
 // setViewportViaCDP resizes the browser viewport using the CDP


### PR DESCRIPTION
## Problem

On the batched chromium-configure **stop/start path** (`chromiumDisplayApplyWhileStopped`), the Neko screen resize was fire-and-forget: it called `setResolutionViaNeko` and returned as soon as Neko ACKed, without waiting for the X root to actually reach the requested size. Neko applies screen config asynchronously and can silently drop a reconfig that lands while a previous one is in flight, leaving the root at the dummy DDX default (3840x2160). Chromium then relaunches in `--kiosk` and maximizes onto the stale root, so the live view shows the browser in a small corner of the frame. Intermittent, and the call returns 200 despite the wrong size.

This branch runs whenever a profile/extension/policy/flags change is bundled with a viewport change in the same configure call. The live-resize path (`PatchDisplay`) already guards against this (poll + retry, #280); the stop/start branch never got that guard.

## Fix

Extract the apply-poll-retry loop into `applyResolutionAndConverge` and route **both** paths through it, so the convergence guarantee can't drift between them again. `PatchDisplay` behavior is unchanged; the stop/start path now waits for the resize to take effect before Chromium relaunches.

## Testing

### Static

`go build`, `go vet`, `go test ./cmd/api/api/`, `gofmt` all clean. No unit test (helper needs live X/Neko; matches the untested #280 loop).

### Manual live (headful docker container, `ENABLE_WEBRTC=true` so the Neko path is exercised)

Approach: drive the real HTTP API against a running `chromium-headful` container. To hit the fixed stop/start branch, every `POST /configure` bundled a restart-triggering part (`chromium_flags`) with a `display` viewport change, so the resize runs through `applyResolutionAndConverge` while Chromium is stopped. After each call: read the X root via `xrandr` and assert it reached the request (within the ±32 libxcvt-rounding delta), and capture a full-screen screenshot to confirm the browser fills the root rather than sitting in a corner of a stale 3840×2160 frame.

| Suite | Coverage | Result |
| --- | --- | --- |
| Stop/start convergence | 40 `POST /configure` (flags + display), cycling 1280×720 / 1600×900 / 1024×768 | 40/40 X root == request, ~4.6s each |
| Live `PATCH /display` regression | 1440×900, 1920×1080 | 2/2 converged, CDP maximize re-assert fired |
| No-op skip | re-send current size | 200, resize skipped |
| Non-standard sizes | 1360×768, 1366×768, 1365×769, 1111×777, 999×666, 800×600, 1920×1200, 1234×567, 1023×767, 1728×1117 | 10/10 within ±32 |

Log evidence (52 successful resizes across all suites): `using Neko API for Xorg resolution change` and `successfully changed resolution via Neko API` fired on every resize (Neko path, not the xrandr fallback); `retrying neko reconfig` = 0 and `did not converge to requested mode` = 0.

Non-standard sizes confirmed libxcvt behaves as the code comments document: widths snap down to the CVT 8-pixel grid (≤7px observed) with heights untouched, and the `1360→1366` FWXGA bump fired exactly. Real rounding topped out at 7px — comfortably inside the ±32 `acceptableDelta` and far from the ~1000px+ dummy-DDX transient that delta is meant to reject.

Not covered: the intermittent dropped-reconfig race never reproduced live (timing-sensitive, low-probability — consistent with the original repro difficulty), so the neko-retry and fail-loud 500 branches were not observed firing. The tests prove the convergence guarantee holds on the happy path; the mechanism for the failure path remains confirmed only in code and prod logs (frequent `realized=3840x2160` drops, recovered on the guarded path).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches headful display resize timing on two API paths; live-path behavior is largely preserved but the stop/start path now fails configure when X never converges instead of silently relaunching Chromium on a wrong root.
> 
> **Overview**
> **Xorg resize now shares one convergence path** for live `PatchDisplay` and batched chromium configure while Chromium is stopped. The apply → poll X root → Neko retry loop moves into `applyResolutionAndConverge` in `display.go`.
> 
> The **configure stop/start** path (`chromiumDisplayApplyWhileStopped`) no longer calls Neko/xrandr and returns on ACK alone. It waits until the X root reaches the requested size (with the same Neko reconfig retries as the live path) **before** Chromium relaunches in `--kiosk`, avoiding intermittent wrong live view when Neko drops an in-flight reconfig and X stays at 3840×2160.
> 
> `PatchDisplay` on Xorg is refactored to call the helper; realized dimensions and CDP maximize re-assert stay on the caller. Non-convergence still fails the request instead of returning 200 with a stale root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 189d12dadf03eff4220f215ecd020854f9f8f9e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
