### PR TITLE
Sync upstream - v52/v56 (20260724)

### DIFF
--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -265,7 +265,7 @@ func main() {
 	rMetrics := chi.NewRouter()
 	rMetrics.Use(chiMiddleware.Recoverer)
 	rMetrics.Method(http.MethodGet, "/metrics", metrics.Handler(slogger,
-		metrics.NewChromeCollector(upstreamMgr),
+		metrics.NewChromeCollector(upstreamMgr, slogger),
 		metrics.NewGPUCollector(),
 		metrics.NewSystemCollector(),
 	))

--- a/server/lib/metrics/chrome.go
+++ b/server/lib/metrics/chrome.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"math"
 	"strconv"
 	"strings"
@@ -78,10 +79,11 @@ type DevToolsUpstream interface {
 type ChromeCollector struct {
 	upstream   DevToolsUpstream
 	histograms []UMAHistogram
+	log        *slog.Logger
 }
 
-func NewChromeCollector(upstream DevToolsUpstream) *ChromeCollector {
-	return &ChromeCollector{upstream: upstream, histograms: DefaultUMAHistograms}
+func NewChromeCollector(upstream DevToolsUpstream, log *slog.Logger) *ChromeCollector {
+	return &ChromeCollector{upstream: upstream, histograms: DefaultUMAHistograms, log: log}
 }
 
 func (c *ChromeCollector) Name() string { return "chrome" }
@@ -109,9 +111,13 @@ func (c *ChromeCollector) Collect(ctx context.Context, w *Writer) error {
 		w.Sample("kernel_chromium_pages", nil, float64(pages))
 	}
 
+	// A histogram fetch failure must not discard the up/info/pages
+	// samples already gathered: log it, skip the UMA family for this
+	// scrape, and report success for the rest.
 	fetched, err := c.fetchHistograms(ctx, client)
 	if err != nil {
-		return err
+		c.log.Error("chrome histogram fetch failed", "err", err)
+		return nil
 	}
 	w.Metric("kernel_chromium_uma",
 		"Chrome UMA histogram, cumulative since browser start, re-bucketed onto fixed bounds. Units follow the UMA definition: PageLoad timings are milliseconds, NumInteractions is a count, CLS is a unitless score, Memory.GPU.* is MB.",

--- a/server/lib/metrics/chrome_test.go
+++ b/server/lib/metrics/chrome_test.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -91,7 +92,7 @@ func TestChromeCollector(t *testing.T) {
 	srv := fakeCDP(t)
 	defer srv.Close()
 
-	c := NewChromeCollector(staticUpstream("ws" + strings.TrimPrefix(srv.URL, "http")))
+	c := NewChromeCollector(staticUpstream("ws"+strings.TrimPrefix(srv.URL, "http")), slog.New(slog.DiscardHandler))
 	w := &Writer{}
 	require.NoError(t, c.Collect(context.Background(), w))
 	out := string(w.Bytes())
@@ -119,18 +120,24 @@ func TestChromeCollector(t *testing.T) {
 func TestChromeCollectorDown(t *testing.T) {
 	// An unreachable browser is not a collector error: the up sample must
 	// survive the handler's discard-on-error policy.
-	c := NewChromeCollector(staticUpstream(""))
+	c := NewChromeCollector(staticUpstream(""), slog.New(slog.DiscardHandler))
 	w := &Writer{}
 	require.NoError(t, c.Collect(context.Background(), w))
 	assert.Contains(t, string(w.Bytes()), "kernel_chromium_up 0\n")
 }
 
 func TestChromeCollectorHistogramFailure(t *testing.T) {
+	// A histogram fetch failure must not take down the whole chrome
+	// scrape: up/info/pages survive and only the UMA family is skipped.
 	srv := fakeCDP(t)
 	defer srv.Close()
 
-	c := NewChromeCollector(staticUpstream("ws" + strings.TrimPrefix(srv.URL, "http")))
+	c := NewChromeCollector(staticUpstream("ws"+strings.TrimPrefix(srv.URL, "http")), slog.New(slog.DiscardHandler))
 	c.histograms = []UMAHistogram{{Name: "Fail.Me", Bounds: boundsPageLoadMs}}
 	w := &Writer{}
-	require.Error(t, c.Collect(context.Background(), w))
+	require.NoError(t, c.Collect(context.Background(), w))
+	out := string(w.Bytes())
+	assert.Contains(t, out, "kernel_chromium_up 1\n")
+	assert.Contains(t, out, "kernel_chromium_pages 2\n")
+	assert.NotContains(t, out, "kernel_chromium_uma")
 }

--- a/server/lib/metrics/system.go
+++ b/server/lib/metrics/system.go
@@ -104,6 +104,11 @@ func (c *SystemCollector) Collect(ctx context.Context, w *Writer) error {
 		w.Sample("kernel_vm_disk_free_bytes", []Label{{"mount", c.rootPath}}, float64(fs.Bavail)*bsize)
 	}
 
+	// The /proc reads above are microseconds; the PID walk is the only
+	// part worth gating on an expired scrape deadline.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	procs, rssBytes := c.chromiumProcesses()
 	w.Metric("kernel_chromium_processes", "Number of running Chromium processes (browser, renderers, utilities).", "gauge")
 	w.Sample("kernel_chromium_processes", nil, float64(procs))


### PR DESCRIPTION
## Summary

This evergreen sync PR updates the `sync/upstream-release` branch with new commits from the private `main` branch. Upstream (`kernel/kernel-images`) was already fully synced, and kernel-browser is already at the latest release, so this run only performed the **private main sync (Part 0)**.

- **Date of sync:** 2026-07-24
- **Private sync:** Yes — 10 new commits from `origin/main` were merged into `sync/upstream-release`.
- **Upstream merge:** Not needed — `upstream/main` is already an ancestor of the sync branch.
- **kernel-browser update:** Not needed — already at latest `v150.0.7871.114-r1` on both image types.

## Private commits merged from `origin/main`

Feature: **BYO proxy CA trust** (PR #306) — install a customer-provided CA bundle at claim time via `/chromium/configure` and enforce cert validation for BYO MITM proxies.

- Support multi-cert CA bundles and optional cert validation for BYO proxies
- Install BYO CA bundle at claim time via `/chromium/configure`
- Harden customer CA bundle handling
- Merge `chromiumcerts` into `chromiumflags`; log instead of exit on stat error
- Add e2e coverage for BYO CA configure install and enforce
- Add tests for `init-browser-trust.sh` branchy logic and fail-closed enforcement

## Merge conflicts resolved

- `server/lib/oapi/oapi.go`: **regenerated** with `(cd server && make oapi-generate)` after confirming the auto-merged `server/openapi.yaml` cleanly contained both sides' changes. This generated file conflicted because both branches changed the OpenAPI spec:
  - `origin/main` side added the `ca_bundle` field to `/chromium/configure`.
  - `sync/upstream-release` side (from a prior upstream sync) added telemetry export config (`BrowserTelemetryExportConfig`, OTLP) and `BrowserPageCrashedEvent`.

  Taking either side's `oapi.go` verbatim would have dropped the other side's schema, so it was regenerated from the merged `server/openapi.yaml` (source of truth). The regenerated output contains `CaBundle`, `PageCrashed`, and the OTLP/telemetry-export types. `server/go.mod`/`server/go.sum` were already conflict-free and unchanged by `go mod tidy`.
- `server/openapi.yaml`: auto-merged cleanly by git (union of the `ca_bundle` addition and the telemetry/page-crashed additions); no manual resolution required.

All other files (`server/cmd/api/api/chromium_configure*.go`, `server/cmd/chromium-launcher/main*.go`, `server/lib/chromiumflags/chromiumflags.go`, `server/e2e/e2e_chromium_configure_ca_bundle_test.go`, `shared/certs/init-browser-trust.sh`) were auto-merged cleanly by git.

## Verification

- `go build ./...` — passes
- `go vet ./...` — passes

## New image versions

- headless: **v52**
- headful: **v56**

(Already exactly one ahead of `main` (headless v51 / headful v55); no additional bump was required since no upstream merge occurred this run.)
