### PR TITLE
Fix Live View clipboard sync under implicit hosting (#310)

### DIFF
--- a/images/chromium-headful/client/src/components/video.vue
+++ b/images/chromium-headful/client/src/components/video.vue
@@ -280,6 +280,10 @@
       return this.$accessor.connecting
     }
 
+    get controlling() {
+      return this.$accessor.remote.controlling
+    }
+
     get hosting() {
       return this.$accessor.remote.hosting
     }
@@ -806,6 +810,10 @@
 
     onMouseDown(e: MouseEvent) {
       this.unmuteOnInteraction()
+
+      if (!this.controlling && this.implicitHosting && !this.locked) {
+        this.$accessor.remote.request()
+      }
 
       if (!this.hosting) {
         this.$emit('control-attempt', e)

--- a/images/chromium-headful/client/src/neko/index.ts
+++ b/images/chromium-headful/client/src/neko/index.ts
@@ -240,12 +240,15 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
       return
     }
 
-    // KERNEL: don't surface a "you took the controls" toast to the viewer.
-    // With implicit hosting, control is now registered automatically on the
-    // first interaction (see remote.request() in video.vue), so this would
-    // fire on essentially every session's first click — pure noise for a
-    // single-viewer embedded live view. Notifications for other members
-    // taking/stealing control are left intact.
+    // KERNEL: drop the self-only "you took the controls" toast (was gated on
+    // this.id === id). With implicit hosting, control is now registered
+    // automatically on the first interaction (see remote.request() in
+    // video.vue), so it would fire on essentially every session's first click
+    // — pure noise for a single-viewer embedded live view. The chat event
+    // below (and other members' take/steal toasts elsewhere) is unaffected.
+    // Note: this is a shared component, so explicit control-takes in the full
+    // neko UI also lose this confirmation; acceptable since Kernel only ships
+    // the embedded live view.
 
     this.$accessor.chat.newMessage({
       id: member.id,

--- a/images/chromium-headful/client/src/neko/index.ts
+++ b/images/chromium-headful/client/src/neko/index.ts
@@ -240,17 +240,12 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
       return
     }
 
-    if (this.id === id) {
-      this.$vue.$notify({
-        group: 'neko',
-        type: 'info',
-        title: this.$vue.$t('notifications.controls_taken', {
-          name: member.id == this.id && this.$vue.$te('you') ? this.$vue.$t('you') : member.displayname,
-        }) as string,
-        duration: 5000,
-        speed: 1000,
-      })
-    }
+    // KERNEL: don't surface a "you took the controls" toast to the viewer.
+    // With implicit hosting, control is now registered automatically on the
+    // first interaction (see remote.request() in video.vue), so this would
+    // fire on essentially every session's first click — pure noise for a
+    // single-viewer embedded live view. Notifications for other members
+    // taking/stealing control are left intact.
 
     this.$accessor.chat.newMessage({
       id: member.id,

--- a/images/chromium-headful/client/src/store/remote.ts
+++ b/images/chromium-headful/client/src/store/remote.ts
@@ -18,6 +18,9 @@ export const state = () => ({
 })
 
 export const getters = getterTree(state, {
+  controlling: (state, getters, root) => {
+    return root.user.id !== '' && root.user.id === state.id
+  },
   hosting: (state, getters, root) => {
     return root.user.id === state.id || state.implicitHosting
   },
@@ -89,7 +92,7 @@ export const actions = actionTree(
     },
 
     request({ getters }) {
-      if (!accessor.connected || getters.hosting) {
+      if (!accessor.connected || getters.controlling) {
         return
       }
 

--- a/images/chromium-headful/client/src/store/remote.ts
+++ b/images/chromium-headful/client/src/store/remote.ts
@@ -15,6 +15,10 @@ export const state = () => ({
   implicitHosting: true,
   fileTransfer: true,
   keyboardModifierState: -1,
+  // true once a control/request has been sent and we're waiting for the
+  // server's control/locked response. Prevents rapid clicks from emitting
+  // multiple requests before `controlling` flips.
+  requesting: false,
 })
 
 export const getters = getterTree(state, {
@@ -39,6 +43,8 @@ export const mutations = mutationTree(state, {
     } else {
       state.id = host.id
     }
+    // host resolved (for us or someone else) — clear any pending request
+    state.requesting = false
   },
 
   setClipboard(state, clipboard: string) {
@@ -61,10 +67,15 @@ export const mutations = mutationTree(state, {
     state.fileTransfer = val
   },
 
+  setRequesting(state, val: boolean) {
+    state.requesting = val
+  },
+
   reset(state) {
     state.id = ''
     state.clipboard = ''
     state.locked = false
+    state.requesting = false
   },
 })
 
@@ -91,11 +102,12 @@ export const actions = actionTree(
       }
     },
 
-    request({ getters }) {
-      if (!accessor.connected || getters.controlling) {
+    request({ state, getters }) {
+      if (!accessor.connected || getters.controlling || state.requesting) {
         return
       }
 
+      accessor.remote.setRequesting(true)
       $client.sendMessage(EVENT.CONTROL.REQUEST)
     },
 


### PR DESCRIPTION
## Problem

Fixes #310. In an embedded Live View, copying text inside the remote browser never updates the viewer's local clipboard.

Root cause is client-side control registration, not browser clipboard permissions:

- Kernel runs neko with `session.implicit_hosting: true`.
- The client's `remote.hosting` getter is `true` whenever implicit hosting is on, even though the viewer was never registered as a host server-side.
- `remote.request()` short-circuits when `hosting` is true, so the client never sends `control/request`.
- neko delivers remote clipboard updates only to the registered host (`sessions.GetHost()`); with no host registered, `control/clipboard` is never sent, so `navigator.clipboard.writeText()` never runs.

Sending a manual `control/request` in a live session produces `control/locked`, after which the very next copy delivers `control/clipboard` and the paste works — isolating the defect to the missing client request. This matches upstream `m1k1o/neko#540`.

## Change

- **`store/remote.ts`** — add a `controlling` getter (true only when the viewer is the actual registered host) and guard `request()` on it instead of the broad `hosting`. The `id !== ''` check prevents the pre-connection empty-id state from reading as controlling.
- **`components/video.vue`** — on the first interaction under implicit hosting, call `remote.request()` so the session registers as host, while still forwarding the original click immediately. The pinned neko server accepts input via `LegacyIsHost()` under implicit hosting, so no mousedown/mouseup buffering + replay is required.
- **`neko/index.ts`** — stop surfacing the "you took the controls" toast to the viewer. Control now registers automatically on the first click, so the toast would otherwise fire on essentially every session's first interaction. Notifications for *other* members taking/stealing control are left intact.

## Relationship to #311

Same diagnosis and the same store-level fix as #311 (both port upstream `m1k1o/neko#540`). This PR intentionally diverges in `video.vue`: instead of buffering the first mouse down/up and replaying them via a `@Watch('controlling')`, it forwards the first click immediately and relies on the pinned server accepting pre-registration input. This avoids the stuck-remote-button edge cases raised in #311's review (replaying a `mousedown` with no matching `mouseup`; a single `isMouseDown` boolean mishandling multi-button chords). It also adds the "you took the controls" toast suppression, which #311 does not.

## Verification

Built the patched `chromium-headful` image and embedded its Live View in a cross-origin iframe (`allow="clipboard-read; clipboard-write"`), driven with Playwright while capturing `/ws` control frames:

- **Baseline (main):** first click sends no `control/request`; remote Ctrl+C yields no `control/clipboard`; paste stays stale.
- **Fixed:** first click → exactly one `control/request` → `control/locked` → remote Ctrl+C → `control/clipboard` with the exact text → paste matches. Second click sends no duplicate request; the first click is still delivered once (no dropped/stuck button); no "you took the controls" toast appears.

macOS Cmd+C remains a separate, pre-existing gap noted in #310 (the client special-cases paste, not copy) and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebSocket control registration and clipboard delivery for embedded sessions; behavior is localized to the neko client but affects first-interaction control state.
> 
> **Overview**
> Fixes embedded Live View clipboard sync when **implicit hosting** is enabled: the client treated the viewer as “hosting” without ever sending `control/request`, so the server never delivered `control/clipboard` to the viewer.
> 
> **`store/remote.ts`** adds a **`controlling`** getter (viewer is the registered host) and a **`requesting`** flag so **`request()`** is no longer blocked by broad **`hosting`** and rapid clicks cannot spam duplicate requests before **`control/locked`**.
> 
> **`video.vue`** calls **`remote.request()`** on the first mouse down when implicit hosting is on and the viewer is not yet controlling, while still forwarding that click to the remote (no buffered replay).
> 
> **`neko/index.ts`** removes the self-only “you took the controls” toast on **`control/locked`**, since auto-registration on first click would show it on every session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c15d5d59aeb6b2b577a5fb0d2bf9c1fa08ba49f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->