### PR TITLE
Preload fanout snapshot start pages safely

### DIFF
--- a/server/cmd/api/fork_identity.go
+++ b/server/cmd/api/fork_identity.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/kernel/kernel-images/server/lib/forkidentity"
 )
@@ -58,7 +57,7 @@ func forkIdentityHandler(log *slog.Logger, onApplied func(forkidentity.Payload))
 			http.Error(w, "failed to write fork identity", http.StatusInternalServerError)
 			return
 		}
-		if err := forkidentity.WaitAppliedMarker(payload.InstanceName(), 30*time.Second); err != nil {
+		if err := forkidentity.WaitAppliedMarker(payload.InstanceName(), forkidentity.ApplyTimeout); err != nil {
 			log.Error("fork identity apply wait failed", "err", err)
 			http.Error(w, "fork identity not applied", http.StatusInternalServerError)
 			return

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -497,11 +497,10 @@ func mustFFmpeg() {
 func appliedS2Stream(cfg *config.Config) (string, bool) {
 	stream := cfg.S2Stream
 
-	// This process starts before the wrapper enters the wait, and entering it
-	// clears the applied marker and then writes the ready file. So a marker
-	// without a ready file predates this boot's wait: the wrapper is about to
-	// drop it and hold for a new handoff, and binding to it would pin the sinks
-	// to an identity nothing is going to use.
+	// The wrapper clears stale identity state and writes the ready file before
+	// starting this process. Its presence distinguishes a fork-wait boot; once
+	// the fork is applied, the marker and payload survive API restarts and must
+	// take precedence over the seed identity in the boot environment.
 	if _, err := os.Stat(forkidentity.ReadyFile); err != nil {
 		return stream, false
 	}

--- a/server/cmd/wrapper/fork_identity.go
+++ b/server/cmd/wrapper/fork_identity.go
@@ -14,9 +14,9 @@ func forkIdentityWaitEnabled() (bool, error) {
 	return forkidentity.WaitEnabled()
 }
 
-func waitForForkIdentityIfEnabled(ctx context.Context, enabled bool) bool {
+func waitForForkIdentityIfEnabled(ctx context.Context, enabled bool) (forkidentity.Payload, bool) {
 	if !enabled {
-		return true
+		return nil, true
 	}
 	stopAll("envoy")
 
@@ -37,18 +37,15 @@ func waitForForkIdentityIfEnabled(ctx context.Context, enabled bool) bool {
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			logf("fork identity wait canceled")
-			return false
+			return nil, false
 		}
 		fatalf("fork identity payload wait: %v", err)
 	}
 	if err := applyForkIdentityPayload(payload); err != nil {
 		fatalf("fork identity apply: %v", err)
 	}
-	if err := forkidentity.WriteAppliedMarker(payload.InstanceName()); err != nil {
-		fatalf("fork identity applied file: %v", err)
-	}
-	logf("fork identity applied instance=%s", payload.InstanceName())
-	return true
+	logf("fork identity environment applied instance=%s", payload.InstanceName())
+	return payload, true
 }
 
 func waitForForkIdentityPayload(ctx context.Context) (forkidentity.Payload, error) {

--- a/server/cmd/wrapper/fork_identity.go
+++ b/server/cmd/wrapper/fork_identity.go
@@ -14,9 +14,9 @@ func forkIdentityWaitEnabled() (bool, error) {
 	return forkidentity.WaitEnabled()
 }
 
-func waitForForkIdentityIfEnabled(ctx context.Context, enabled bool) (forkidentity.Payload, bool) {
+func armForkIdentityWait(enabled bool) {
 	if !enabled {
-		return nil, true
+		return
 	}
 	stopAll("envoy")
 
@@ -31,21 +31,28 @@ func waitForForkIdentityIfEnabled(ctx context.Context, enabled bool) (forkidenti
 	if err := os.WriteFile(forkidentity.ReadyFile, []byte("waiting\n"), 0o644); err != nil {
 		fatalf("fork identity ready file: %v", err)
 	}
+}
+
+func waitForForkIdentityIfEnabled(ctx context.Context, enabled bool) (forkidentity.Payload, time.Time, bool) {
+	if !enabled {
+		return nil, time.Time{}, true
+	}
 
 	logf("fork identity waiting payload=%s", forkidentity.PayloadFile)
 	payload, err := waitForForkIdentityPayload(ctx)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			logf("fork identity wait canceled")
-			return nil, false
+			return nil, time.Time{}, false
 		}
 		fatalf("fork identity payload wait: %v", err)
 	}
+	deadline := time.Now().Add(forkidentity.ApplyTimeout - 5*time.Second)
 	if err := applyForkIdentityPayload(payload); err != nil {
 		fatalf("fork identity apply: %v", err)
 	}
 	logf("fork identity environment applied instance=%s", payload.InstanceName())
-	return payload, true
+	return payload, deadline, true
 }
 
 func waitForForkIdentityPayload(ctx context.Context) (forkidentity.Payload, error) {

--- a/server/cmd/wrapper/fork_identity_test.go
+++ b/server/cmd/wrapper/fork_identity_test.go
@@ -2,12 +2,41 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kernel/kernel-images/server/lib/forkidentity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestArmForkIdentityWaitClearsStaleState(t *testing.T) {
+	dir := t.TempDir()
+	oldPayloadFile := forkidentity.PayloadFile
+	oldAppliedFile := forkidentity.AppliedFile
+	oldReadyFile := forkidentity.ReadyFile
+	forkidentity.PayloadFile = filepath.Join(dir, "fork-identity.json")
+	forkidentity.AppliedFile = filepath.Join(dir, "fork-identity-applied")
+	forkidentity.ReadyFile = filepath.Join(dir, "fork-identity-ready")
+	t.Cleanup(func() {
+		forkidentity.PayloadFile = oldPayloadFile
+		forkidentity.AppliedFile = oldAppliedFile
+		forkidentity.ReadyFile = oldReadyFile
+	})
+
+	require.NoError(t, os.WriteFile(forkidentity.PayloadFile, []byte("stale"), 0o600))
+	require.NoError(t, os.WriteFile(forkidentity.AppliedFile, []byte("stale"), 0o644))
+
+	armForkIdentityWait(true)
+
+	_, err := os.Stat(forkidentity.PayloadFile)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(forkidentity.AppliedFile)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	ready, err := os.ReadFile(forkidentity.ReadyFile)
+	require.NoError(t, err)
+	assert.Equal(t, "waiting\n", string(ready))
+}
 
 func TestApplyForkIdentityPayloadSetsAndClearsEnv(t *testing.T) {
 	t.Setenv("METRO_NAME", "old-metro")

--- a/server/cmd/wrapper/main.go
+++ b/server/cmd/wrapper/main.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -22,6 +23,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/kernel/kernel-images/server/lib/forkidentity"
 )
 
 const (
@@ -192,6 +195,16 @@ func main() {
 	startAll("chromium")
 	if forkIdentityWait {
 		waitForHTTPProbe("chromium devtools", "http://127.0.0.1:"+os.Getenv("INTERNAL_PORT")+"/json/version", 30*time.Second)
+		if err := prepareSnapshotStartPage(startupCtx, os.Getenv("INTERNAL_PORT")); err != nil {
+			if errors.Is(err, context.Canceled) {
+				logf("snapshot start page preparation canceled")
+				if err := supCmd.Wait(); err != nil {
+					logf("supervisord exited: %v", err)
+				}
+				return
+			}
+			fatalf("prepare snapshot start page: %v", err)
+		}
 		startAll("kernel-images-api")
 	}
 	waitForSocket(dbusSocket, 10*time.Second)
@@ -203,7 +216,8 @@ func main() {
 	}
 	browserDone := time.Now()
 
-	if !waitForForkIdentityIfEnabled(startupCtx, forkIdentityWait) {
+	forkIdentity, ok := waitForForkIdentityIfEnabled(startupCtx, forkIdentityWait)
+	if !ok {
 		if err := supCmd.Wait(); err != nil {
 			logf("supervisord exited: %v", err)
 		}
@@ -224,7 +238,20 @@ func main() {
 
 	// Wait for the union of caller-visible ready signals. Each probe runs
 	// concurrently and logs as soon as its target is reachable.
-	probeDurations := waitAllReady(t0, webrtc)
+	readyTimeout := 60 * time.Second
+	if forkIdentityWait {
+		readyTimeout = forkidentity.ApplyTimeout - 5*time.Second
+	}
+	probeDurations, allReady := waitAllReady(t0, webrtc, readyTimeout)
+	if forkIdentityWait {
+		if !allReady {
+			fatalf("fork identity services did not become ready")
+		}
+		if err := forkidentity.WriteAppliedMarker(forkIdentity.InstanceName()); err != nil {
+			fatalf("fork identity applied file: %v", err)
+		}
+		logf("fork identity ready instance=%s", forkIdentity.InstanceName())
+	}
 	logf("ready in %s (browser=%s identity=%s; %s)",
 		since(t0),
 		browserDone.Sub(browserStart).Truncate(time.Millisecond),
@@ -250,7 +277,7 @@ func main() {
 //     when api itself is up, which CDP readiness already implies)
 //   - neko         : TCP on neko's HTTP port (8080), only when ENABLE_WEBRTC=true
 //   - envoy        : TCP on envoy's listener (3128), only when envoy is enabled
-func waitAllReady(t0 time.Time, webrtc bool) map[string]time.Duration {
+func waitAllReady(t0 time.Time, webrtc bool, timeout time.Duration) (map[string]time.Duration, bool) {
 	chromePort := os.Getenv("CHROME_PORT")
 	probes := []probe{
 		{"cdp", func() bool { return httpProbeOK("http://127.0.0.1:" + chromePort + "/json/version") }},
@@ -272,7 +299,7 @@ func waitAllReady(t0 time.Time, webrtc bool) map[string]time.Duration {
 	for _, p := range probes {
 		go func(name string, fn func() bool) {
 			start := time.Now()
-			deadline := start.Add(60 * time.Second)
+			deadline := start.Add(timeout)
 			for time.Now().Before(deadline) {
 				if fn() {
 					d := since(t0)
@@ -282,18 +309,21 @@ func waitAllReady(t0 time.Time, webrtc bool) map[string]time.Duration {
 				}
 				time.Sleep(20 * time.Millisecond)
 			}
-			logf("[ready] WARNING: %s never became ready", name)
+			logf("[ready] WARNING: %s never became ready after %s", name, timeout)
 			done <- result{name, since(t0), false}
 		}(p.name, p.fn)
 	}
 	durations := make(map[string]time.Duration, len(probes))
+	allReady := true
 	for range probes {
 		r := <-done
 		if r.ok {
 			durations[r.name] = r.dur
+		} else {
+			allReady = false
 		}
 	}
-	return durations
+	return durations, allReady
 }
 
 func waitForHTTPProbe(name, url string, timeout time.Duration) {

--- a/server/cmd/wrapper/main.go
+++ b/server/cmd/wrapper/main.go
@@ -205,6 +205,7 @@ func main() {
 			}
 			fatalf("prepare snapshot start page: %v", err)
 		}
+		armForkIdentityWait(true)
 		startAll("kernel-images-api")
 	}
 	waitForSocket(dbusSocket, 10*time.Second)
@@ -216,7 +217,7 @@ func main() {
 	}
 	browserDone := time.Now()
 
-	forkIdentity, ok := waitForForkIdentityIfEnabled(startupCtx, forkIdentityWait)
+	forkIdentity, identityDeadline, ok := waitForForkIdentityIfEnabled(startupCtx, forkIdentityWait)
 	if !ok {
 		if err := supCmd.Wait(); err != nil {
 			logf("supervisord exited: %v", err)
@@ -240,7 +241,10 @@ func main() {
 	// concurrently and logs as soon as its target is reachable.
 	readyTimeout := 60 * time.Second
 	if forkIdentityWait {
-		readyTimeout = forkidentity.ApplyTimeout - 5*time.Second
+		readyTimeout = time.Until(identityDeadline)
+		if readyTimeout <= 0 {
+			fatalf("fork identity readiness deadline exceeded during identity startup")
+		}
 	}
 	probeDurations, allReady := waitAllReady(t0, webrtc, readyTimeout)
 	if forkIdentityWait {

--- a/server/cmd/wrapper/snapshot_start_page.go
+++ b/server/cmd/wrapper/snapshot_start_page.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/kernel/kernel-images/server/lib/cdpclient"
+)
+
+const (
+	snapshotStartPageURL = "https://start.duckduckgo.com/"
+	envoyBootstrapPath   = "/etc/envoy/bootstrap.yaml"
+)
+
+func prepareSnapshotStartPage(ctx context.Context, internalPort string) error {
+	seedEnvoyStarted := false
+	if envoyEnabled() {
+		if !isExecutable("/usr/local/bin/init-envoy.sh") {
+			return fmt.Errorf("envoy is enabled but init-envoy.sh is unavailable")
+		}
+		if err := runStream("envoy-init", "/usr/local/bin/init-envoy.sh"); err != nil {
+			return fmt.Errorf("start seed envoy: %w", err)
+		}
+		seedEnvoyStarted = true
+		if err := waitForTCP(ctx, "127.0.0.1", "3128", 25*time.Second); err != nil {
+			return errors.Join(err, cleanupSeedEnvoy())
+		}
+	}
+
+	versionURL := "http://127.0.0.1:" + internalPort + "/json/version"
+	devtoolsURL, err := cdpclient.BrowserWebSocketURL(ctx, versionURL)
+	if err != nil {
+		return errors.Join(err, cleanupSeedEnvoyIfStarted(seedEnvoyStarted))
+	}
+	navCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	navErr := cdpclient.DispatchStartURLAndWait(navCtx, devtoolsURL, snapshotStartPageURL)
+	cancel()
+
+	if err := cleanupSeedEnvoyIfStarted(seedEnvoyStarted); err != nil {
+		return err
+	}
+	if navErr == nil {
+		logf("snapshot start page ready url=%s", snapshotStartPageURL)
+		return nil
+	}
+	if errors.Is(navErr, context.Canceled) {
+		return navErr
+	}
+
+	logf("WARNING: snapshot start page unavailable, using about:blank: %v", navErr)
+	blankCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := cdpclient.DispatchStartURL(blankCtx, devtoolsURL, "about:blank"); err != nil {
+		return fmt.Errorf("reset snapshot start page: %w", err)
+	}
+	return nil
+}
+
+func cleanupSeedEnvoyIfStarted(started bool) error {
+	if !started {
+		return nil
+	}
+	return cleanupSeedEnvoy()
+}
+
+func cleanupSeedEnvoy() error {
+	stopAll("envoy")
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !tcpOK("127.0.0.1", "3128") {
+			if err := os.Remove(envoyBootstrapPath); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove seed envoy bootstrap: %w", err)
+			}
+			return nil
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return fmt.Errorf("seed envoy did not stop")
+}
+
+func waitForTCP(ctx context.Context, host, port string, timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if tcpOK(host, port) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return fmt.Errorf("%s:%s did not become ready after %s", host, port, timeout)
+		case <-ticker.C:
+		}
+	}
+}

--- a/server/lib/cdpclient/cdpclient.go
+++ b/server/lib/cdpclient/cdpclient.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -37,6 +40,32 @@ func (e *cdpError) Error() string {
 type Client struct {
 	conn   *websocket.Conn
 	nextID atomic.Int64
+}
+
+// BrowserWebSocketURL reads Chrome's browser-level DevTools WebSocket URL.
+func BrowserWebSocketURL(ctx context.Context, versionURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, versionURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("get DevTools version: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("get DevTools version: %s", resp.Status)
+	}
+	var version struct {
+		WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&version); err != nil {
+		return "", fmt.Errorf("decode DevTools version: %w", err)
+	}
+	if version.WebSocketDebuggerURL == "" {
+		return "", fmt.Errorf("DevTools version response has no browser WebSocket URL")
+	}
+	return version.WebSocketDebuggerURL, nil
 }
 
 // Dial opens a WebSocket connection to the given DevTools URL.
@@ -271,6 +300,93 @@ func DispatchStartURL(ctx context.Context, devtoolsURL, url string) error {
 		return fmt.Errorf("Page.navigate: %w", err)
 	}
 	return nil
+}
+
+// DispatchStartURLAndWait navigates the user-facing page and waits until the
+// destination has loaded without resolving to Chrome's network error page.
+func DispatchStartURLAndWait(ctx context.Context, devtoolsURL, destination string) error {
+	if err := DispatchStartURL(ctx, devtoolsURL, destination); err != nil {
+		return err
+	}
+
+	want, err := url.Parse(destination)
+	if err != nil {
+		return fmt.Errorf("parse destination: %w", err)
+	}
+	c, err := Dial(ctx, devtoolsURL)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	targetID, err := c.firstPageTargetID(ctx)
+	if err != nil {
+		return err
+	}
+	attachResult, err := c.send(ctx, "Target.attachToTarget", map[string]any{
+		"targetId": targetID,
+		"flatten":  true,
+	}, "")
+	if err != nil {
+		return fmt.Errorf("Target.attachToTarget: %w", err)
+	}
+	var attach struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(attachResult, &attach); err != nil {
+		return fmt.Errorf("unmarshal attach: %w", err)
+	}
+	defer func() {
+		detachCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, _ = c.send(detachCtx, "Target.detachFromTarget", map[string]any{
+			"sessionId": attach.SessionID,
+		}, "")
+	}()
+
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	var lastState struct {
+		URL        string `json:"url"`
+		ReadyState string `json:"readyState"`
+	}
+	lastNavigate := time.Now()
+	for {
+		raw, evalErr := c.send(ctx, "Runtime.evaluate", map[string]any{
+			"expression":    `JSON.stringify({url: location.href, readyState: document.readyState})`,
+			"returnByValue": true,
+		}, attach.SessionID)
+		if evalErr == nil {
+			var evaluated struct {
+				Result struct {
+					Value string `json:"value"`
+				} `json:"result"`
+			}
+			if err := json.Unmarshal(raw, &evaluated); err == nil {
+				_ = json.Unmarshal([]byte(evaluated.Result.Value), &lastState)
+				current, parseErr := url.Parse(lastState.URL)
+				if parseErr == nil && relatedHosts(current.Hostname(), want.Hostname()) && lastState.ReadyState == "complete" {
+					return nil
+				}
+				if strings.HasPrefix(lastState.URL, "chrome-error://") && time.Since(lastNavigate) >= 250*time.Millisecond {
+					_, _ = c.send(ctx, "Page.navigate", map[string]any{"url": destination}, attach.SessionID)
+					lastNavigate = time.Now()
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for %s to load (last URL %q, state %q): %w", destination, lastState.URL, lastState.ReadyState, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func relatedHosts(a, b string) bool {
+	a = strings.ToLower(strings.TrimSuffix(a, "."))
+	b = strings.ToLower(strings.TrimSuffix(b, "."))
+	return a == b || strings.HasSuffix(a, "."+b) || strings.HasSuffix(b, "."+a)
 }
 
 // firstPageTargetID returns the targetId of the first page target reported

--- a/server/lib/cdpclient/cdpclient_test.go
+++ b/server/lib/cdpclient/cdpclient_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coder/websocket"
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,11 @@ type fakeCDP struct {
 	getVersionCalled    bool
 	failGetVersion      bool
 	productResponse     string
+	navigateCalled      bool
+	navigateCalls       int
+	navigateURL         string
+	pageStates          []string
+	pageStateIndex      int
 }
 
 func (f *fakeCDP) handler(w http.ResponseWriter, r *http.Request) {
@@ -103,6 +109,22 @@ func (f *fakeCDP) handler(w http.ResponseWriter, r *http.Request) {
 					"jsVersion":       "1.2.3",
 				}
 			}
+		case "Page.navigate":
+			f.navigateCalled = true
+			f.navigateCalls++
+			var params map[string]any
+			_ = json.Unmarshal(req.Params, &params)
+			f.navigateURL, _ = params["url"].(string)
+			result = map[string]any{"frameId": "frame-1"}
+		case "Runtime.evaluate":
+			state := `{"url":"about:blank","readyState":"loading"}`
+			if len(f.pageStates) > 0 {
+				state = f.pageStates[f.pageStateIndex]
+				if f.pageStateIndex < len(f.pageStates)-1 {
+					f.pageStateIndex++
+				}
+			}
+			result = map[string]any{"result": map[string]any{"type": "string", "value": state}}
 		}
 
 		resp := map[string]any{"id": req.ID}
@@ -211,6 +233,77 @@ func TestSetDeviceMetricsOverride(t *testing.T) {
 		_, err := Dial(ctx, url)
 		require.Error(t, err)
 	})
+}
+
+func TestDispatchStartURLAndWait(t *testing.T) {
+	t.Run("waits for loaded destination", func(t *testing.T) {
+		f := &fakeCDP{
+			pageTargetID: "target-123",
+			sessionID:    "session-abc",
+			pageStates: []string{
+				`{"url":"chrome-error://chromewebdata/","readyState":"complete"}`,
+				`{"url":"https://start.duckduckgo.com/","readyState":"loading"}`,
+				`{"url":"https://duckduckgo.com/","readyState":"complete"}`,
+			},
+		}
+		url := startFakeCDP(t, f)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		err := DispatchStartURLAndWait(ctx, url, "https://start.duckduckgo.com/")
+		require.NoError(t, err)
+		assert.True(t, f.navigateCalled)
+		assert.Equal(t, "https://start.duckduckgo.com/", f.navigateURL)
+	})
+
+	t.Run("retries a failed initial navigation", func(t *testing.T) {
+		f := &fakeCDP{
+			pageTargetID: "target-123",
+			sessionID:    "session-abc",
+			pageStates: []string{
+				`{"url":"chrome-error://chromewebdata/","readyState":"complete"}`,
+				`{"url":"chrome-error://chromewebdata/","readyState":"complete"}`,
+				`{"url":"chrome-error://chromewebdata/","readyState":"complete"}`,
+				`{"url":"chrome-error://chromewebdata/","readyState":"complete"}`,
+				`{"url":"chrome-error://chromewebdata/","readyState":"complete"}`,
+				`{"url":"chrome-error://chromewebdata/","readyState":"complete"}`,
+				`{"url":"https://start.duckduckgo.com/","readyState":"complete"}`,
+			},
+		}
+		url := startFakeCDP(t, f)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		err := DispatchStartURLAndWait(ctx, url, "https://start.duckduckgo.com/")
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, f.navigateCalls, 2)
+	})
+
+	t.Run("times out on Chrome error page", func(t *testing.T) {
+		f := &fakeCDP{
+			pageTargetID: "target-123",
+			sessionID:    "session-abc",
+			pageStates:   []string{`{"url":"chrome-error://chromewebdata/","readyState":"complete"}`},
+		}
+		url := startFakeCDP(t, f)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		err := DispatchStartURLAndWait(ctx, url, "https://start.duckduckgo.com/")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "chrome-error://chromewebdata/")
+	})
+}
+
+func TestBrowserWebSocketURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"webSocketDebuggerUrl":"ws://127.0.0.1/devtools/browser/test"}`))
+	}))
+	defer srv.Close()
+
+	got, err := BrowserWebSocketURL(context.Background(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "ws://127.0.0.1/devtools/browser/test", got)
 }
 
 func TestDial(t *testing.T) {

--- a/server/lib/forkidentity/payload.go
+++ b/server/lib/forkidentity/payload.go
@@ -9,7 +9,10 @@ import (
 	"time"
 )
 
-const MaxPayloadBytes = 64 * 1024
+const (
+	MaxPayloadBytes = 64 * 1024
+	ApplyTimeout    = 30 * time.Second
+)
 
 type Payload map[string]string
 


### PR DESCRIPTION
## Summary

- preload DuckDuckGo before a reusable browser template becomes fork-ready, with an `about:blank` fallback
- stop seed Envoy and remove its rendered bootstrap before snapshotting
- arm fork identity intake before the API and public CDP are exposed
- write the applied marker only after required local services are ready within the shared identity deadline

## Why

Snapshot forks inherit Chromium's rendered tab state. Preparing that state while the template is built avoids external navigation and stale network error pages on the synchronous fork path.

## Testing

- `cd server && go vet ./...`
- `cd server && go test -race $(go list ./... | grep -v /e2e$)`
- `cd server && make build`
- `git diff --check main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM boot ordering, fork identity control plane, and Envoy/CDP startup paths where mis-timed handoffs could block forks or leave wrong S2 identity; changes are localized but operationally sensitive.
> 
> **Overview**
> Preloads **DuckDuckGo** into Chromium while building a fork-wait template so snapshot forks inherit a loaded tab instead of doing external navigation on the hot path. The wrapper may briefly run **seed Envoy**, navigates via new CDP helpers (`BrowserWebSocketURL`, `DispatchStartURLAndWait`), then tears down seed Envoy and its bootstrap before continuing.
> 
> **Fork identity** sequencing changes: stale payload/applied state is cleared and the ready file is written in **`armForkIdentityWait`** only after snapshot prep and **before** `kernel-images-api` and public CDP are exposed. The **applied marker** is written **after** identity env apply, post-identity Envoy init, and concurrent readiness probes succeed within a deadline derived from shared **`forkidentity.ApplyTimeout`** (also used by the API handoff wait). Readiness probing now fails the boot if required services do not come up in that window.
> 
> Docs/comments for **`appliedS2Stream`** are updated to match the new ready-file semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f53443da60c24273d46da278c6adc6761e13343e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->