### PR TITLE
Cover fork readiness lifecycle invariants

### DIFF
--- a/server/cmd/wrapper/fork_identity.go
+++ b/server/cmd/wrapper/fork_identity.go
@@ -47,7 +47,7 @@ func waitForForkIdentityIfEnabled(ctx context.Context, enabled bool) (forkidenti
 		}
 		fatalf("fork identity payload wait: %v", err)
 	}
-	deadline := time.Now().Add(forkidentity.ApplyTimeout - 5*time.Second)
+	deadline := time.Now().Add(forkidentity.ApplyTimeout - forkidentity.ApplyResponseMargin)
 	if err := applyForkIdentityPayload(payload); err != nil {
 		fatalf("fork identity apply: %v", err)
 	}
@@ -73,6 +73,13 @@ func waitForForkIdentityPayload(ctx context.Context) (forkidentity.Payload, erro
 		case <-time.After(20 * time.Millisecond):
 		}
 	}
+}
+
+func writeForkIdentityAppliedMarker(instanceName string, allReady bool) error {
+	if !allReady {
+		return errors.New("services did not become ready")
+	}
+	return forkidentity.WriteAppliedMarker(instanceName)
 }
 
 func applyForkIdentityPayload(payload forkidentity.Payload) error {

--- a/server/cmd/wrapper/fork_identity_test.go
+++ b/server/cmd/wrapper/fork_identity_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/kernel/kernel-images/server/lib/forkidentity"
 	"github.com/stretchr/testify/assert"
@@ -36,6 +37,55 @@ func TestArmForkIdentityWaitClearsStaleState(t *testing.T) {
 	ready, err := os.ReadFile(forkidentity.ReadyFile)
 	require.NoError(t, err)
 	assert.Equal(t, "waiting\n", string(ready))
+}
+
+func TestForkIdentityAppliedMarkerRequiresEveryReadinessProbe(t *testing.T) {
+	dir := t.TempDir()
+	oldAppliedFile := forkidentity.AppliedFile
+	forkidentity.AppliedFile = filepath.Join(dir, "fork-identity-applied")
+	t.Cleanup(func() { forkidentity.AppliedFile = oldAppliedFile })
+
+	probeNames := []string{"cdp", "chromedriver", "envoy"}
+	for _, failedProbe := range probeNames {
+		t.Run(failedProbe, func(t *testing.T) {
+			probes := make([]probe, 0, len(probeNames))
+			for _, name := range probeNames {
+				ready := name != failedProbe
+				probes = append(probes, probe{name: name, fn: func() bool { return ready }})
+			}
+
+			durations, allReady := waitProbesReady(time.Now(), probes, 50*time.Millisecond)
+			require.False(t, allReady)
+			assert.NotContains(t, durations, failedProbe)
+			for _, name := range probeNames {
+				if name != failedProbe {
+					assert.Contains(t, durations, name)
+				}
+			}
+			require.Error(t, writeForkIdentityAppliedMarker("browser-1", allReady))
+			_, err := os.Stat(forkidentity.AppliedFile)
+			require.ErrorIs(t, err, os.ErrNotExist)
+		})
+	}
+}
+
+func TestForkIdentityAppliedMarkerWrittenAfterReadiness(t *testing.T) {
+	dir := t.TempDir()
+	oldAppliedFile := forkidentity.AppliedFile
+	forkidentity.AppliedFile = filepath.Join(dir, "fork-identity-applied")
+	t.Cleanup(func() { forkidentity.AppliedFile = oldAppliedFile })
+
+	_, allReady := waitProbesReady(time.Now(), []probe{
+		{name: "cdp", fn: func() bool { return true }},
+		{name: "chromedriver", fn: func() bool { return true }},
+		{name: "envoy", fn: func() bool { return true }},
+	}, time.Second)
+	require.True(t, allReady)
+	require.NoError(t, writeForkIdentityAppliedMarker("browser-1", allReady))
+
+	applied, err := os.ReadFile(forkidentity.AppliedFile)
+	require.NoError(t, err)
+	assert.Equal(t, "browser-1\n", string(applied))
 }
 
 func TestApplyForkIdentityPayloadSetsAndClearsEnv(t *testing.T) {

--- a/server/cmd/wrapper/main.go
+++ b/server/cmd/wrapper/main.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
-	"github.com/kernel/kernel-images/server/lib/forkidentity"
 )
 
 const (
@@ -248,11 +246,8 @@ func main() {
 	}
 	probeDurations, allReady := waitAllReady(t0, webrtc, readyTimeout)
 	if forkIdentityWait {
-		if !allReady {
-			fatalf("fork identity services did not become ready")
-		}
-		if err := forkidentity.WriteAppliedMarker(forkIdentity.InstanceName()); err != nil {
-			fatalf("fork identity applied file: %v", err)
+		if err := writeForkIdentityAppliedMarker(forkIdentity.InstanceName(), allReady); err != nil {
+			fatalf("fork identity readiness: %v", err)
 		}
 		logf("fork identity ready instance=%s", forkIdentity.InstanceName())
 	}
@@ -294,6 +289,10 @@ func waitAllReady(t0 time.Time, webrtc bool, timeout time.Duration) (map[string]
 		probes = append(probes, probe{"envoy", func() bool { return tcpOK("127.0.0.1", "3128") }})
 	}
 
+	return waitProbesReady(t0, probes, timeout)
+}
+
+func waitProbesReady(t0 time.Time, probes []probe, timeout time.Duration) (map[string]time.Duration, bool) {
 	type result struct {
 		name string
 		dur  time.Duration

--- a/server/cmd/wrapper/snapshot_start_page.go
+++ b/server/cmd/wrapper/snapshot_start_page.go
@@ -15,8 +15,15 @@ const (
 	envoyBootstrapPath   = "/etc/envoy/bootstrap.yaml"
 )
 
-func prepareSnapshotStartPage(ctx context.Context, internalPort string) error {
+func prepareSnapshotStartPage(ctx context.Context, internalPort string) (retErr error) {
 	seedEnvoyStarted := false
+	seedEnvoyCleaned := false
+	defer func() {
+		if !seedEnvoyCleaned {
+			retErr = errors.Join(retErr, cleanupSeedEnvoyIfStarted(seedEnvoyStarted))
+		}
+	}()
+
 	if envoyEnabled() {
 		if !isExecutable("/usr/local/bin/init-envoy.sh") {
 			return fmt.Errorf("envoy is enabled but init-envoy.sh is unavailable")
@@ -26,21 +33,23 @@ func prepareSnapshotStartPage(ctx context.Context, internalPort string) error {
 		}
 		seedEnvoyStarted = true
 		if err := waitForTCP(ctx, "127.0.0.1", "3128", 25*time.Second); err != nil {
-			return errors.Join(err, cleanupSeedEnvoy())
+			return err
 		}
 	}
 
 	versionURL := "http://127.0.0.1:" + internalPort + "/json/version"
 	devtoolsURL, err := cdpclient.BrowserWebSocketURL(ctx, versionURL)
 	if err != nil {
-		return errors.Join(err, cleanupSeedEnvoyIfStarted(seedEnvoyStarted))
+		return err
 	}
 	navCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	navErr := cdpclient.DispatchStartURLAndWait(navCtx, devtoolsURL, snapshotStartPageURL)
 	cancel()
 
-	if err := cleanupSeedEnvoyIfStarted(seedEnvoyStarted); err != nil {
-		return err
+	cleanupErr := cleanupSeedEnvoyIfStarted(seedEnvoyStarted)
+	seedEnvoyCleaned = true
+	if cleanupErr != nil {
+		return cleanupErr
 	}
 	if navErr == nil {
 		logf("snapshot start page ready url=%s", snapshotStartPageURL)
@@ -67,11 +76,19 @@ func cleanupSeedEnvoyIfStarted(started bool) error {
 }
 
 func cleanupSeedEnvoy() error {
-	stopAll("envoy")
+	return cleanupSeedEnvoyWith(
+		envoyBootstrapPath,
+		func() { stopAll("envoy") },
+		func() bool { return tcpOK("127.0.0.1", "3128") },
+	)
+}
+
+func cleanupSeedEnvoyWith(bootstrapPath string, stop func(), running func() bool) error {
+	stop()
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		if !tcpOK("127.0.0.1", "3128") {
-			if err := os.Remove(envoyBootstrapPath); err != nil && !os.IsNotExist(err) {
+		if !running() {
+			if err := os.Remove(bootstrapPath); err != nil && !os.IsNotExist(err) {
 				return fmt.Errorf("remove seed envoy bootstrap: %w", err)
 			}
 			return nil

--- a/server/cmd/wrapper/snapshot_start_page_test.go
+++ b/server/cmd/wrapper/snapshot_start_page_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupSeedEnvoyStopsProcessAndRemovesBootstrap(t *testing.T) {
+	bootstrapPath := filepath.Join(t.TempDir(), "bootstrap.yaml")
+	require.NoError(t, os.WriteFile(bootstrapPath, []byte("seed"), 0o600))
+
+	var events []string
+	err := cleanupSeedEnvoyWith(
+		bootstrapPath,
+		func() { events = append(events, "stop") },
+		func() bool {
+			events = append(events, "stopped")
+			return false
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = os.Stat(bootstrapPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	assert.Equal(t, []string{"stop", "stopped"}, events)
+}

--- a/server/lib/forkidentity/payload.go
+++ b/server/lib/forkidentity/payload.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	MaxPayloadBytes = 64 * 1024
-	ApplyTimeout    = 30 * time.Second
+	MaxPayloadBytes     = 64 * 1024
+	ApplyTimeout        = 30 * time.Second
+	ApplyResponseMargin = 5 * time.Second
 )
 
 type Payload map[string]string


### PR DESCRIPTION
## Summary

- guarantee seed Envoy cleanup on every snapshot-start-page exit and cover process/bootstrap teardown
- cover the applied-marker gate across each post-fork readiness probe
- name the five-second fork identity response margin alongside the shared apply timeout

## Performance

20 sequential headless Firecracker forks per version (8 vCPU), measuring the fork request through the successful fork-identity response and verifying public CDP returned 200 on every run. The Envoy fixture used a static listener to isolate local process startup/readiness from xDS and network variance.

| version | fork-to-ready p50 | fork-to-ready p95 | identity handoff p50 | identity handoff p95 |
| --- | ---: | ---: | ---: | ---: |
| before `759635d` | 293 ms | 492 ms | 69 ms | 96 ms |
| after #324 (`0503e9f`) | 1,564 ms | 1,708 ms | 1,340 ms | 1,498 ms |

All runs passed (20/20 per version). The after p95 leaves 28.3 seconds of headroom in the 30-second API timeout and 23.3 seconds inside the wrapper's 25-second readiness deadline.

But it's OK that this is slower because we are migrating off of envoy and the hot pools avoid hitting this case. Also we have another tier of idle pool which we can start filling with fanout.

## Testing

- `cd server && go vet ./...`
- `cd server && go test -race $(go list ./... | grep -v /e2e$)`
- `cd server && make build`
- `git diff --check main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fork handoff timing and when the applied marker is written; incorrect gating could stall or falsely signal fork readiness to the API.
> 
> **Overview**
> Tightens **fork-identity readiness** so the applied marker is only written when every post-fork probe succeeds, and documents the **5s response margin** next to `ApplyTimeout` in `forkidentity`.
> 
> `writeForkIdentityAppliedMarker` centralizes that gate; readiness polling is split into **`waitProbesReady`** so tests can assert per-probe behavior (cdp, chromedriver, envoy) without a full boot.
> 
> **Snapshot start page** seed Envoy teardown is guaranteed on all exit paths via a defer, with **`cleanupSeedEnvoyWith`** for unit tests of stop + bootstrap removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 688cd10fda22ec5326fbf5e5a4a4282869fb89ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->