### PR TITLE
Cancel timed-out Playwright executions

### DIFF
--- a/server/e2e/e2e_playwright_test.go
+++ b/server/e2e/e2e_playwright_test.go
@@ -100,9 +100,21 @@ func TestPlaywrightExecuteTimeoutReturnsPromptlyAndRecovers(t *testing.T) {
 	client, err := c.APIClient()
 	require.NoError(t, err)
 
-	timeoutSec := 2
+	setupReq := instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
+		Code: `return await page.evaluate(() => document.body.dataset.timeoutMutation = "initial");`,
+	}
+	setupRsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, setupReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, setupRsp.StatusCode())
+	require.NotNil(t, setupRsp.JSON200)
+	require.True(t, setupRsp.JSON200.Success)
+
+	timeoutSec := 1
 	timeoutReq := instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
-		Code:       `await new Promise(r => setTimeout(r, 30000));`,
+		Code: `
+await page.waitForTimeout(2500);
+await page.evaluate(() => document.body.dataset.timeoutMutation = "late");
+`,
 		TimeoutSec: &timeoutSec,
 	}
 
@@ -112,7 +124,7 @@ func TestPlaywrightExecuteTimeoutReturnsPromptlyAndRecovers(t *testing.T) {
 	elapsed := time.Since(start)
 
 	require.NoError(t, err, "playwright timeout request should return an API response")
-	require.Less(t, elapsed, 5*time.Second, "timeout response should arrive before the API socket read deadline")
+	require.Less(t, elapsed, 4*time.Second, "timeout response should arrive before the API socket read deadline")
 	require.Equal(t, http.StatusOK, timeoutRsp.StatusCode(), "unexpected status for timed-out playwright execute: %s body=%s", timeoutRsp.Status(), string(timeoutRsp.Body))
 	require.NotNil(t, timeoutRsp.JSON200, "expected JSON200 timeout response, got nil")
 	require.False(t, timeoutRsp.JSON200.Success, "expected success=false for timed-out playwright execution")
@@ -123,7 +135,7 @@ func TestPlaywrightExecuteTimeoutReturnsPromptlyAndRecovers(t *testing.T) {
 	require.NotContains(t, errorMsg, "i/o timeout", "daemon should return a timeout response before the API socket read deadline")
 
 	recoveryReq := instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
-		Code: `return await page.evaluate(() => navigator.userAgent);`,
+		Code: `return await page.evaluate(() => document.body.dataset.timeoutMutation);`,
 	}
 
 	t.Log("executing normal playwright code after timed-out request")
@@ -138,6 +150,18 @@ func TestPlaywrightExecuteTimeoutReturnsPromptlyAndRecovers(t *testing.T) {
 		return "nil"
 	}())
 	require.NotNil(t, recoveryRsp.JSON200.Result, "expected recovery result to be non-nil")
+	require.Equal(t, "initial", recoveryRsp.JSON200.Result)
+
+	// Wait past the abandoned script's delay. A response-only timeout lets that
+	// script wake up and mutate the page after the caller has moved on.
+	time.Sleep(2 * time.Second)
+	lateRsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, recoveryReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, lateRsp.StatusCode())
+	require.NotNil(t, lateRsp.JSON200)
+	require.True(t, lateRsp.JSON200.Success)
+	require.NotNil(t, lateRsp.JSON200.Result)
+	require.Equal(t, "initial", lateRsp.JSON200.Result, "timed-out execution mutated the page after returning")
 
 	t.Log("playwright timeout regression test passed")
 }

--- a/server/runtime/playwright-daemon.ts
+++ b/server/runtime/playwright-daemon.ts
@@ -73,6 +73,18 @@ async function transformCode(code: string): Promise<string> {
   return transformed.slice(bodyStart, bodyEnd).trim();
 }
 
+async function disconnectBrowser(): Promise<void> {
+  const connectedBrowser = browser;
+  browser = null;
+  if (!connectedBrowser) return;
+
+  try {
+    await connectedBrowser.close();
+  } catch {
+    // The timeout may have already torn down the transport.
+  }
+}
+
 async function ensureBrowserConnection(): Promise<Browser> {
   if (browser && browser.isConnected()) {
     return browser;
@@ -214,6 +226,9 @@ function handleConnection(socket: Socket): void {
       try {
         response = await withTimeout(executeCode(request, signal), signal);
       } catch (error: any) {
+        if (signal.aborted) {
+          await disconnectBrowser();
+        }
         response = {
           id: request.id,
           success: false,


### PR DESCRIPTION
## summary

- disconnect the persistent Playwright CDP client when an execution reaches its request timeout
- prevent abandoned scripts from continuing to mutate browser state after the timeout response
- reconnect transparently for the next execution
- extend the timeout regression test to detect delayed page mutations

## proof

The reproduction starts a script that alternates `scrollIntoViewIfNeeded()` between top and bottom targets every 500ms. After ten iterations it sets a marker to `late-finished`. The request timeout is shorter than the script, so any marker or scroll changes after the timeout response are escaped execution.

### before: `main`

The API returned the timeout after approximately one second, but the script remained live:

```json
{
  "timeout": { "success": false, "elapsed_ms": 1004 },
  "immediate": { "marker": "initial" },
  "after_2_seconds": { "marker": "late" }
}
```

The post-timeout mutation reproduces consistently with both the production endpoint and a local Chromium daemon built from `main`.

### after: this branch

Built the complete headless image from this branch (`sha256:b02c5efcc8a1e06933f38b163326b1f65f6dc144267c2706cee787ea48c01101`) and ran the same alternating-scroll request through the image's `/playwright/execute` endpoint:

```json
{
  "timeout": { "success": false, "elapsed_ms": 2015 },
  "immediate": { "marker": "step-3", "scroll_y": 0 },
  "after_4_seconds": { "marker": "step-3", "scroll_y": 0 }
}
```

The marker and scroll position remain unchanged after the timeout. The abandoned script does not reach `late-finished` or perform another scroll. A subsequent Playwright request reconnects and succeeds against the same browser page.

The image-level regression also passes:

```text
=== RUN   TestPlaywrightExecuteTimeoutReturnsPromptlyAndRecovers
playwright timeout regression test passed
--- PASS: TestPlaywrightExecuteTimeoutReturnsPromptlyAndRecovers (8.16s)
```

## validation

- verified the standalone daemon fix with both Playwright and Patchright against local Chromium
- built the full headless image from this branch
- ran `TestPlaywrightExecuteTimeoutReturnsPromptlyAndRecovers` against the built image
- reran the alternating-scroll reproduction through the built image's real API endpoint
- `bun build server/runtime/playwright-daemon.ts --outfile=/tmp/playwright-daemon.js --target=node --external playwright-core --external patchright --external esbuild`
- `go vet ./...`
- `go test -v -race $(go list ./... | grep -v /e2e$)`
