### PR TITLE
Preserve new tab semantics for snapshot preload

### DIFF
--- a/server/cmd/wrapper/snapshot_start_page.go
+++ b/server/cmd/wrapper/snapshot_start_page.go
@@ -43,7 +43,7 @@ func prepareSnapshotStartPage(ctx context.Context, internalPort string) (retErr 
 		return err
 	}
 	navCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
-	navErr := cdpclient.DispatchStartURLAndWait(navCtx, devtoolsURL, snapshotStartPageURL)
+	navErr := cdpclient.DispatchStartURLAndWait(navCtx, devtoolsURL, "chrome://newtab/", snapshotStartPageURL)
 	cancel()
 
 	cleanupErr := cleanupSeedEnvoyIfStarted(seedEnvoyStarted)

--- a/server/lib/cdpclient/cdpclient.go
+++ b/server/lib/cdpclient/cdpclient.go
@@ -302,10 +302,10 @@ func DispatchStartURL(ctx context.Context, devtoolsURL, url string) error {
 	return nil
 }
 
-// DispatchStartURLAndWait navigates the user-facing page and waits until the
-// destination has loaded without resolving to Chrome's network error page.
-func DispatchStartURLAndWait(ctx context.Context, devtoolsURL, destination string) error {
-	if err := DispatchStartURL(ctx, devtoolsURL, destination); err != nil {
+// DispatchStartURLAndWait navigates through navigationURL and waits for
+// destination to load without resolving to Chrome's network error page.
+func DispatchStartURLAndWait(ctx context.Context, devtoolsURL, navigationURL, destination string) error {
+	if err := DispatchStartURL(ctx, devtoolsURL, navigationURL); err != nil {
 		return err
 	}
 
@@ -369,7 +369,7 @@ func DispatchStartURLAndWait(ctx context.Context, devtoolsURL, destination strin
 					return nil
 				}
 				if strings.HasPrefix(lastState.URL, "chrome-error://") && time.Since(lastNavigate) >= 250*time.Millisecond {
-					_, _ = c.send(ctx, "Page.navigate", map[string]any{"url": destination}, attach.SessionID)
+					_, _ = c.send(ctx, "Page.navigate", map[string]any{"url": navigationURL}, attach.SessionID)
 					lastNavigate = time.Now()
 				}
 			}

--- a/server/lib/cdpclient/cdpclient_test.go
+++ b/server/lib/cdpclient/cdpclient_test.go
@@ -250,10 +250,10 @@ func TestDispatchStartURLAndWait(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
-		err := DispatchStartURLAndWait(ctx, url, "https://start.duckduckgo.com/")
+		err := DispatchStartURLAndWait(ctx, url, "chrome://newtab/", "https://start.duckduckgo.com/")
 		require.NoError(t, err)
 		assert.True(t, f.navigateCalled)
-		assert.Equal(t, "https://start.duckduckgo.com/", f.navigateURL)
+		assert.Equal(t, "chrome://newtab/", f.navigateURL)
 	})
 
 	t.Run("retries a failed initial navigation", func(t *testing.T) {
@@ -274,9 +274,10 @@ func TestDispatchStartURLAndWait(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
-		err := DispatchStartURLAndWait(ctx, url, "https://start.duckduckgo.com/")
+		err := DispatchStartURLAndWait(ctx, url, "chrome://newtab/", "https://start.duckduckgo.com/")
 		require.NoError(t, err)
 		assert.GreaterOrEqual(t, f.navigateCalls, 2)
+		assert.Equal(t, "chrome://newtab/", f.navigateURL)
 	})
 
 	t.Run("times out on Chrome error page", func(t *testing.T) {
@@ -289,7 +290,7 @@ func TestDispatchStartURLAndWait(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
-		err := DispatchStartURLAndWait(ctx, url, "https://start.duckduckgo.com/")
+		err := DispatchStartURLAndWait(ctx, url, "chrome://newtab/", "https://start.duckduckgo.com/")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "chrome-error://chromewebdata/")
 	})


### PR DESCRIPTION
## Summary

- initiate the snapshot preload through `chrome://newtab/` so Chromium applies the managed external new-tab policy
- continue waiting for DuckDuckGo to finish loading, including navigation retries
- preserve the empty new-tab omnibox instead of showing the destination URL as a normal navigation

## Testing

- `cd server && go vet ./...`
- `cd server && go test -race $(go list ./... | grep -v /e2e$)`
- `cd server && make build`
- manually verified Chromium loads an external managed new-tab page when launched through `chrome://newtab/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to snapshot preload CDP navigation and its helper; no auth or data-path changes, with behavior covered by updated unit tests.
> 
> **Overview**
> Snapshot preload no longer CDP-navigates straight to the DuckDuckGo start URL. **`DispatchStartURLAndWait`** now takes a separate **`navigationURL`** and **`destination`**: CDP issues **`Page.navigate`** to the navigation URL, while readiness still waits for the destination host to reach **`complete`**.
> 
> **`prepareSnapshotStartPage`** uses **`chrome://newtab/`** as the navigation URL and the existing start page as the destination so Chromium applies the managed external new-tab flow instead of treating the load as a normal navigation (preserving an empty omnibox). Chrome error-page retries re-issue navigation to **`navigationURL`**, not the destination.
> 
> Tests assert the initial and retry navigations target **`chrome://newtab/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4be9d2e268e16c2551abe73584706d8c34201aa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->