### PR TITLE
Bypass private networks by default

### DIFF
--- a/server/cmd/chromium-launcher/main.go
+++ b/server/cmd/chromium-launcher/main.go
@@ -80,7 +80,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed reading runtime flags: %v\n", err)
 		os.Exit(1)
 	}
-	final := mergeChromiumFlags(baseFlags, runtimeTokens)
+	final := chromiumflags.MergeFlagsWithRuntimeTokens(baseFlags, runtimeTokens)
+	final = withDefaultPrivateNetworkBypass(final)
 
 	// Diagnostics for parity with previous scripts
 	fmt.Printf("BASE_FLAGS: %s\n", baseFlags)
@@ -160,17 +161,13 @@ func main() {
 	}
 }
 
-func mergeChromiumFlags(baseFlags string, runtimeTokens []string) []string {
-	configured := chromiumflags.MergeFlagsWithRuntimeTokens(baseFlags, runtimeTokens)
-	// Chromium applies only the last --proxy-bypass-list flag. Keep the image
-	// default first so a runtime list, including an empty one, replaces it.
-	flags := []string{defaultPrivateNetworkBypassFlag}
-	for _, flag := range configured {
-		if flag != defaultPrivateNetworkBypassFlag {
-			flags = append(flags, flag)
+func withDefaultPrivateNetworkBypass(flags []string) []string {
+	for _, flag := range flags {
+		if flag == "--proxy-bypass-list" || strings.HasPrefix(flag, "--proxy-bypass-list=") {
+			return flags
 		}
 	}
-	return flags
+	return append(flags, defaultPrivateNetworkBypassFlag)
 }
 
 // execLookPath helps satisfy syscall.Exec's requirement to pass an absolute path.

--- a/server/cmd/chromium-launcher/main.go
+++ b/server/cmd/chromium-launcher/main.go
@@ -25,6 +25,8 @@ const (
 	// pulseSink is the null sink chromium plays into; the recorder captures
 	// its .monitor source.
 	pulseSink = "KernelOutput"
+
+	defaultPrivateNetworkBypassFlag = "--proxy-bypass-list=10.0.0.0/8;172.16.0.0/12;192.168.0.0/16;100.64.0.0/10;fc00::/7"
 )
 
 func main() {
@@ -78,7 +80,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed reading runtime flags: %v\n", err)
 		os.Exit(1)
 	}
-	final := chromiumflags.MergeFlagsWithRuntimeTokens(baseFlags, runtimeTokens)
+	final := mergeChromiumFlags(baseFlags, runtimeTokens)
 
 	// Diagnostics for parity with previous scripts
 	fmt.Printf("BASE_FLAGS: %s\n", baseFlags)
@@ -156,6 +158,19 @@ func main() {
 		fmt.Fprintf(os.Stderr, "exec runuser failed: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func mergeChromiumFlags(baseFlags string, runtimeTokens []string) []string {
+	configured := chromiumflags.MergeFlagsWithRuntimeTokens(baseFlags, runtimeTokens)
+	// Chromium applies only the last --proxy-bypass-list flag. Keep the image
+	// default first so a runtime list, including an empty one, replaces it.
+	flags := []string{defaultPrivateNetworkBypassFlag}
+	for _, flag := range configured {
+		if flag != defaultPrivateNetworkBypassFlag {
+			flags = append(flags, flag)
+		}
+	}
+	return flags
 }
 
 // execLookPath helps satisfy syscall.Exec's requirement to pass an absolute path.

--- a/server/cmd/chromium-launcher/main_test.go
+++ b/server/cmd/chromium-launcher/main_test.go
@@ -6,60 +6,64 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/kernel/kernel-images/server/lib/chromiumflags"
 )
 
-func TestMergeChromiumFlags(t *testing.T) {
+func TestWithDefaultPrivateNetworkBypass(t *testing.T) {
 	tests := []struct {
-		name          string
-		baseFlags     string
-		runtimeTokens []string
-		want          []string
+		name  string
+		flags []string
+		want  []string
 	}{
 		{
 			name: "image default",
 			want: []string{defaultPrivateNetworkBypassFlag},
 		},
 		{
-			name:      "base list replaces image default",
-			baseFlags: "--proxy-bypass-list=preview.internal",
-			want: []string{
-				defaultPrivateNetworkBypassFlag,
-				"--proxy-bypass-list=preview.internal",
-			},
+			name:  "default follows unrelated flags",
+			flags: []string{"--kiosk"},
+			want:  []string{"--kiosk", defaultPrivateNetworkBypassFlag},
 		},
 		{
-			name:          "runtime list replaces image and base lists",
-			baseFlags:     "--proxy-bypass-list=base.internal --kiosk",
-			runtimeTokens: []string{"--proxy-bypass-list=runtime.internal"},
-			want: []string{
-				defaultPrivateNetworkBypassFlag,
-				"--proxy-bypass-list=base.internal",
-				"--kiosk",
-				"--proxy-bypass-list=runtime.internal",
-			},
+			name:  "custom list replaces image default",
+			flags: []string{"--proxy-bypass-list=preview.internal"},
+			want:  []string{"--proxy-bypass-list=preview.internal"},
 		},
 		{
-			name:          "explicit empty runtime list clears image default",
-			runtimeTokens: []string{"--proxy-bypass-list="},
-			want: []string{
-				defaultPrivateNetworkBypassFlag,
-				"--proxy-bypass-list=",
-			},
+			name:  "explicit empty list clears image default",
+			flags: []string{"--proxy-bypass-list="},
+			want:  []string{"--proxy-bypass-list="},
 		},
 		{
-			name:      "duplicate image default is removed",
-			baseFlags: defaultPrivateNetworkBypassFlag,
-			want:      []string{defaultPrivateNetworkBypassFlag},
+			name:  "bare empty list clears image default",
+			flags: []string{"--proxy-bypass-list"},
+			want:  []string{"--proxy-bypass-list"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mergeChromiumFlags(tt.baseFlags, tt.runtimeTokens)
+			got := withDefaultPrivateNetworkBypass(tt.flags)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("mergeChromiumFlags() mismatch:\n got: %#v\nwant: %#v", got, tt.want)
+				t.Fatalf("withDefaultPrivateNetworkBypass() mismatch:\n got: %#v\nwant: %#v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDefaultPrivateNetworkBypassPreservesRuntimePrecedence(t *testing.T) {
+	configured := chromiumflags.MergeFlagsWithRuntimeTokens(
+		"--proxy-bypass-list=preview.internal",
+		[]string{defaultPrivateNetworkBypassFlag},
+	)
+	got := withDefaultPrivateNetworkBypass(configured)
+	want := []string{
+		"--proxy-bypass-list=preview.internal",
+		defaultPrivateNetworkBypassFlag,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("runtime precedence changed:\n got: %#v\nwant: %#v", got, want)
 	}
 }
 

--- a/server/cmd/chromium-launcher/main_test.go
+++ b/server/cmd/chromium-launcher/main_test.go
@@ -4,8 +4,64 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
+
+func TestMergeChromiumFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		baseFlags     string
+		runtimeTokens []string
+		want          []string
+	}{
+		{
+			name: "image default",
+			want: []string{defaultPrivateNetworkBypassFlag},
+		},
+		{
+			name:      "base list replaces image default",
+			baseFlags: "--proxy-bypass-list=preview.internal",
+			want: []string{
+				defaultPrivateNetworkBypassFlag,
+				"--proxy-bypass-list=preview.internal",
+			},
+		},
+		{
+			name:          "runtime list replaces image and base lists",
+			baseFlags:     "--proxy-bypass-list=base.internal --kiosk",
+			runtimeTokens: []string{"--proxy-bypass-list=runtime.internal"},
+			want: []string{
+				defaultPrivateNetworkBypassFlag,
+				"--proxy-bypass-list=base.internal",
+				"--kiosk",
+				"--proxy-bypass-list=runtime.internal",
+			},
+		},
+		{
+			name:          "explicit empty runtime list clears image default",
+			runtimeTokens: []string{"--proxy-bypass-list="},
+			want: []string{
+				defaultPrivateNetworkBypassFlag,
+				"--proxy-bypass-list=",
+			},
+		},
+		{
+			name:      "duplicate image default is removed",
+			baseFlags: defaultPrivateNetworkBypassFlag,
+			want:      []string{defaultPrivateNetworkBypassFlag},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeChromiumFlags(tt.baseFlags, tt.runtimeTokens)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("mergeChromiumFlags() mismatch:\n got: %#v\nwant: %#v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestExecLookPath(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- launch Chromium with a default proxy bypass list for RFC1918, CGNAT, and IPv6 ULA ranges when no bypass list is configured
- preserve existing base and runtime flag ordering so custom and explicitly empty bypass lists remain authoritative
- cover default, replacement, clearing, and base/runtime precedence

## Why

Browsers using an egress proxy should retain direct access to standard private network destinations without requiring a runtime Chromium restart. Runtime configuration remains authoritative when callers need a custom list or no bypasses.

## Testing

- `go test -race $(go list ./... | grep -v /e2e$)`
- `go vet ./...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Launcher-only Chromium flag wiring with explicit opt-out via existing bypass-list flags; no auth or data-path changes.
> 
> **Overview**
> Chromium in the kernel image now gets a **default `--proxy-bypass-list`** for RFC1918, CGNAT (`100.64.0.0/10`), and IPv6 ULA (`fc00::/7`) so traffic to private networks can go direct when an egress proxy is in use, without a runtime restart.
> 
> `chromium-launcher` applies this via `withDefaultPrivateNetworkBypass` **after** `CHROMIUM_FLAGS` and runtime overlay are merged. If the merged flags already include `--proxy-bypass-list` (including `=` empty or bare flag), the image default is **not** added—callers keep full control. Unit tests cover default injection, custom/empty override, and that an existing configured bypass is not duplicated when the default token also appears in the merged slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e874dd8d7f35ad6e60e70bdea61c5d4808199c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->