### PR TITLE
fix: recover keyboard input when Chromium reports keyCode 229 with no IME active

### DIFF
--- a/images/chromium-headful/client/src/utils/guacamole-keyboard.js
+++ b/images/chromium-headful/client/src/utils/guacamole-keyboard.js
@@ -1318,8 +1318,31 @@ Guacamole.Keyboard = function Keyboard(element) {
 
             // Ignore (but do not prevent) the "composition" keycode sent by some
             // browsers when an IME is in use (see: http://lists.w3.org/Archives/Public/www-dom/2010JulSep/att-0182/keyCode-spec.html)
-            if (keydownEvent.keyCode === 229)
-                return;
+            //
+            // KERNEL: Some Windows + Chromium configurations report keyCode 229 for
+            // *every* keydown on a text field, even when no IME is in use (see:
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=864911).
+            // Returning unconditionally here silently drops all keyboard input on
+            // those machines, while mouse input keeps working, because
+            // interpret_event() only interprets a log that begins with a keydown or
+            // a keyup -- the keypress that follows a dropped keydown is orphaned and
+            // never interpreted.
+            //
+            // Falling through recovers both known shapes of this quirk:
+            //
+            //   - keyCode 229 with a usable "key" ("a", "Enter"): KeydownEvent
+            //     already prefers "key" over "keyCode" when resolving a keysym.
+            //   - keyCode 229 with key "Unidentified": the keydown resolves to a
+            //     null keysym, and interpret_event() then takes the keysym from the
+            //     following keypress, which carries the correct character.
+            //
+            // Only genuine composition is skipped. isComposing is false on the very
+            // first keydown that *starts* composition, so the "Process" sentinel is
+            // still needed to catch that event and avoid a duplicate keystroke.
+            if (keydownEvent.keyCode === 229) {
+                if (e.isComposing || keydownEvent.key === 'Process')
+                    return;
+            }
 
             // Log event
             eventLog.push(keydownEvent);


### PR DESCRIPTION
# Checklist

- [x] A link to a related issue in our repository — #334
- [x] A description of the changes proposed in the pull request — below
- [x] @mentions of the person or team responsible for reviewing proposed changes — @juecd (as author of the live view client in #13); apologies if that is the wrong person, happy to redirect

---

## Problem

On certain end-user machines the live view accepts mouse input but silently drops **all** keyboard input — including in the remote Chromium's own address bar, so it is not page-specific. Full detail in #334.

The keydown handler returns unconditionally on `keyCode === 229`:

```js
if (keydownEvent.keyCode === 229)
    return;
```

That is correct for genuine IME composition, but some Windows + Chromium configurations report `keyCode 229` for *every* keydown on a text field with no IME active ([crbug 864911](https://bugs.chromium.org/p/chromium/issues/detail?id=864911); same symptom downstream in [react#14512](https://github.com/react/react/issues/14512), [select2#2482](https://github.com/select2/select2/issues/2482)). On those machines every keystroke is discarded.

The failure is total rather than partial because `interpret_event()` only interprets a log beginning with a `KeydownEvent` or `KeyupEvent` — there is no branch for a leading `KeypressEvent`, so the keypress after a dropped keydown is orphaned and never interpreted.

## Change

Fall through instead of returning, skipping only genuine composition:

```js
if (keydownEvent.keyCode === 229) {
    if (e.isComposing || keydownEvent.key === 'Process')
        return;
}
```

This recovers both observed shapes of the quirk, using machinery already in the file:

- **`keyCode 229` with a usable `key`** (`"a"`, `"Enter"`) — `KeydownEvent` already prefers `key` over `keyCode` when resolving a keysym (L268-269), so it resolves correctly.
- **`keyCode 229` with `key === "Unidentified"`** (the [react#14512](https://github.com/react/react/issues/14512) shape) — the keydown resolves to a null keysym, and `interpret_event()` then takes the keysym from the following keypress (L1168-1172). This is layout-correct, since keypress `charCode` is the character actually typed rather than a physical key position.

Both checks are needed for composition: `isComposing` is the authoritative signal, but it is still `false` on the very first keydown that *starts* composition, which is where the `"Process"` sentinel applies. Note `e.isComposing` is read from the raw event because `KeyEvent` does not copy that property.

The change is marked `KERNEL:` in-line, matching the existing `NEKO:` convention for local deviations in this vendored file, so it is visible during future upstream syncs.

## Verification

Driving the real module with synthetic events, before and after. The harness reproduces the bug on `main` and confirms the fix, including that genuine IME composition is still suppressed:

```
########## BEFORE (upstream main) ##########
PASS  baseline: normal keydown+keypress (unaffected machine)
FAIL  variant A: false 229, key="a" (+keypress)          expected [97]     got []
FAIL  variant B: false 229, key="Unidentified" (+keypress)  expected [97]  got []
FAIL  variant A: false 229, key="Enter" (no keypress)    expected [65293]  got []
PASS  IME: composition start, key="Process" -> must NOT type
PASS  IME: mid-composition, isComposing=true -> must NOT type

########## AFTER (this PR) ##########
PASS  baseline: normal keydown+keypress (unaffected machine)
PASS  variant A: false 229, key="a" (+keypress)
PASS  variant B: false 229, key="Unidentified" (+keypress)
PASS  variant A: false 229, key="Enter" (no keypress)
PASS  IME: composition start, key="Process" -> must NOT type
PASS  IME: mid-composition, isComposing=true -> must NOT type
```

I did not add this as a test file, since the client has no test runner configured (`package.json` has `serve`/`build`/`lint` only) and the file is vendored. Happy to contribute it under whatever layout you'd prefer if useful.

<details>
<summary>Reproduction harness (<code>node test-229.mjs &lt;path-to-guacamole-keyboard.js&gt;</code>)</summary>

```js
// Node >=21 defines navigator as a getter-only global, so override it.
Object.defineProperty(globalThis, 'navigator', {
  value: { platform: 'Win32', userAgent: 'Chrome/Windows' },
  writable: true, configurable: true,
})
globalThis.window = {
  setTimeout: () => 0, clearTimeout: () => {},
  setInterval: () => 0, clearInterval: () => {},
}
globalThis.document = { createElement: () => ({ style: {} }) }

const Keyboard = (await import(process.argv[2])).default

function mkEvent(type, props) {
  return {
    type, keyCode: props.keyCode, key: props.key, location: 0,
    isComposing: props.isComposing || false,
    shiftKey: false, ctrlKey: false, altKey: false, metaKey: false,
    getModifierState: () => false,
    preventDefault() { this.defaultPrevented = true },
  }
}

function run(events) {
  const handlers = {}
  const el = { addEventListener: (t, fn) => { handlers[t] = fn } }
  const kbd = new Keyboard()
  const pressed = []
  kbd.onkeydown = (keysym) => { pressed.push(keysym); return true }
  kbd.onkeyup = () => {}
  kbd.listenTo(el)
  for (const e of events) handlers[e.type] && handlers[e.type](e)
  return pressed
}

const A = 0x61, ENTER = 0xff0d
const scenarios = [
  { name: 'baseline: normal keydown+keypress (unaffected machine)',
    events: [mkEvent('keydown', { keyCode: 65, key: 'a' }), mkEvent('keypress', { keyCode: 97 })],
    expect: [A] },
  { name: 'variant A: false 229, key="a" (+keypress)',
    events: [mkEvent('keydown', { keyCode: 229, key: 'a' }), mkEvent('keypress', { keyCode: 97 })],
    expect: [A] },
  { name: 'variant B: false 229, key="Unidentified" (+keypress)',
    events: [mkEvent('keydown', { keyCode: 229, key: 'Unidentified' }), mkEvent('keypress', { keyCode: 97 })],
    expect: [A] },
  { name: 'variant A: false 229, key="Enter" (no keypress)',
    events: [mkEvent('keydown', { keyCode: 229, key: 'Enter' }), mkEvent('keyup', { keyCode: 13, key: 'Enter' })],
    expect: [ENTER] },
  { name: 'IME: composition start, key="Process" -> must NOT type',
    events: [mkEvent('keydown', { keyCode: 229, key: 'Process' })], expect: [] },
  { name: 'IME: mid-composition, isComposing=true -> must NOT type',
    events: [mkEvent('keydown', { keyCode: 229, key: 'a', isComposing: true }),
             mkEvent('keypress', { keyCode: 97, isComposing: true })], expect: [] },
]

let failures = 0
for (const s of scenarios) {
  let got; try { got = run(s.events) } catch (err) { got = `THREW: ${err.message}` }
  const ok = JSON.stringify(got) === JSON.stringify(s.expect)
  if (!ok) failures++
  console.log(`${ok ? 'PASS' : 'FAIL'}  ${s.name}\n        expected ${JSON.stringify(s.expect)}  got ${JSON.stringify(got)}`)
}
console.log(`\n${failures === 0 ? 'ALL PASS' : failures + ' FAILED'}`)
```

</details>

## What I could not verify

Stating this plainly so you can weigh it: **we were not able to capture `keydown` events from an affected machine.** The users are at a customer site where we could not get devtools output. So the `keyCode 229` diagnosis is inferred — from the symptom set (mouse works, focus works, the remote address bar is equally unaffected by typing, and the same session and live view URL work fine for other users on other machines) plus reading this file, where the 229 guard is the only silent, keyboard-only, machine-configuration-dependent early return in the keydown path.

If you would like that confirmed before merging, the check on an affected machine is:

```js
addEventListener('keydown', e => console.log(e.key, e.keyCode, e.isComposing), true)
```

`keyCode === 229` on ordinary keys confirms it. I'm glad to carry that back to the customer if you'd rather have the evidence first, and equally happy to adjust the approach if you'd prefer to solve it elsewhere in the stack.

Reported originally as a live view issue by a Kernel customer of ours; the end-user workaround in the meantime is to remove secondary languages under Windows Settings → Time & Language → Language, then restart the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single, localized change to vendored keyboard event filtering with explicit IME safeguards; affects client input path only, not auth or data handling.
> 
> **Overview**
> Fixes **total loss of keyboard input** in the live view Guacamole client on some Windows + Chromium setups where every `keydown` reports `keyCode` 229 even with no IME active.
> 
> The vendored `guacamole-keyboard.js` keydown handler no longer **drops all** `229` events. It still ignores real composition (`isComposing` or `key === 'Process'`) but **logs and interprets** false `229` keydowns, using existing `key` / follow-up `keypress` resolution so remote typing works again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 958fc1fa02286a239cffd37f9c96e0df6dbd3776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->