### PR TITLE
Await the start_url navigation and surface its failures

### DIFF
--- a/server/cmd/api/api/chromium_configure.go
+++ b/server/cmd/api/api/chromium_configure.go
@@ -24,7 +24,13 @@ import (
 
 const userDataProfileDir = "/home/kernel/user-data"
 const maxStartURLLen = 2048
-const startURLDispatchTimeout = 3 * time.Second
+
+// startURLNavigateTimeout bounds the start_url navigation. Page.navigate only
+// resolves once the navigation commits, so this budget has to cover the origin's
+// DNS, connect and first byte; the previous 3s budget expired against slow
+// origins and handed the session over still showing the pre-navigation page. It
+// does not have to cover subresource loading, which continues after commit.
+const startURLNavigateTimeout = 15 * time.Second
 
 type chromiumConfigureState struct {
 	displayJSON        *string
@@ -181,8 +187,19 @@ func (s *ApiService) ChromiumConfigure(ctx context.Context, request oapi.Chromiu
 	}
 
 	if spec.needsNav {
-		if err := chromiumDoNavigate(ctx, s, spec); err != nil {
-			logger.FromContext(ctx).Warn("start_url dispatch failed", "error", err)
+		// A failed navigation leaves the session on whatever the browser was
+		// showing, so log it and keep going rather than discarding a browser over
+		// a start_url the caller may not control.
+		navStart := time.Now()
+		navErrorText, navErr := chromiumDoNavigate(ctx, s, spec)
+		if navErr == nil && navErrorText != "" {
+			navErr = errors.New(navErrorText)
+		}
+		if navErr != nil {
+			logger.FromContext(ctx).Warn("start_url dispatch failed",
+				"error", navErr,
+				"elapsed", time.Since(navStart).String(),
+				"timeout", startURLNavigateTimeout.String())
 		}
 	}
 
@@ -234,12 +251,14 @@ func normalizeStartURL(rawURL string) string {
 	return rawURL
 }
 
-func chromiumDoNavigate(ctx context.Context, s *ApiService, spec startURLParsed) error {
+// chromiumDoNavigate navigates to spec.url and returns Chrome's navigation
+// errorText, which is non-empty when an error page committed instead.
+func chromiumDoNavigate(ctx context.Context, s *ApiService, spec startURLParsed) (string, error) {
 	upstream := s.upstreamMgr.Current()
 	if upstream == "" {
-		return fmt.Errorf("devtools upstream not available")
+		return "", fmt.Errorf("devtools upstream not available")
 	}
-	navCtx, cancel := context.WithTimeout(ctx, startURLDispatchTimeout)
+	navCtx, cancel := context.WithTimeout(ctx, startURLNavigateTimeout)
 	defer cancel()
 	return cdpclient.DispatchStartURL(navCtx, upstream, spec.url)
 }

--- a/server/cmd/wrapper/snapshot_start_page.go
+++ b/server/cmd/wrapper/snapshot_start_page.go
@@ -62,7 +62,7 @@ func prepareSnapshotStartPage(ctx context.Context, internalPort string) (retErr 
 	logf("WARNING: snapshot start page unavailable, using about:blank: %v", navErr)
 	blankCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	if err := cdpclient.DispatchStartURL(blankCtx, devtoolsURL, "about:blank"); err != nil {
+	if _, err := cdpclient.DispatchStartURL(blankCtx, devtoolsURL, "about:blank"); err != nil {
 		return fmt.Errorf("reset snapshot start page: %w", err)
 	}
 	return nil

--- a/server/lib/cdpclient/cdpclient.go
+++ b/server/lib/cdpclient/cdpclient.go
@@ -220,19 +220,26 @@ func (c *Client) CountPageTargets(ctx context.Context) (int, error) {
 	return n, nil
 }
 
-// DispatchStartURL closes extra page targets and dispatches a navigation on the
-// first page target. It does not wait for lifecycle events; Chrome owns the
-// eventual navigation result.
-func DispatchStartURL(ctx context.Context, devtoolsURL, url string) error {
+// DispatchStartURL closes extra page targets and navigates the first page
+// target. Page.navigate resolves once the navigation commits, so this returns
+// after the new document has replaced the old one but before subresources
+// finish loading.
+//
+// The first return value is Chrome's navigation errorText, non-empty when the
+// navigation committed an error page instead of the requested URL (an
+// unreachable host, for example). Callers that need the requested page to have
+// actually loaded must check it; a nil error alone only means the command was
+// accepted.
+func DispatchStartURL(ctx context.Context, devtoolsURL, url string) (string, error) {
 	c, err := Dial(ctx, devtoolsURL)
 	if err != nil {
-		return fmt.Errorf("dial devtools: %w", err)
+		return "", fmt.Errorf("dial devtools: %w", err)
 	}
 	defer c.Close()
 
 	targetsResult, err := c.send(ctx, "Target.getTargets", nil, "")
 	if err != nil {
-		return fmt.Errorf("Target.getTargets: %w", err)
+		return "", fmt.Errorf("Target.getTargets: %w", err)
 	}
 
 	var targets struct {
@@ -242,7 +249,7 @@ func DispatchStartURL(ctx context.Context, devtoolsURL, url string) error {
 		} `json:"targetInfos"`
 	}
 	if err := json.Unmarshal(targetsResult, &targets); err != nil {
-		return fmt.Errorf("unmarshal targets: %w", err)
+		return "", fmt.Errorf("unmarshal targets: %w", err)
 	}
 
 	var pageTargetID string
@@ -263,13 +270,13 @@ func DispatchStartURL(ctx context.Context, devtoolsURL, url string) error {
 			"url": "about:blank",
 		}, "")
 		if err != nil {
-			return fmt.Errorf("Target.createTarget: %w", err)
+			return "", fmt.Errorf("Target.createTarget: %w", err)
 		}
 		var created struct {
 			TargetID string `json:"targetId"`
 		}
 		if err := json.Unmarshal(createResult, &created); err != nil {
-			return fmt.Errorf("unmarshal create target: %w", err)
+			return "", fmt.Errorf("unmarshal create target: %w", err)
 		}
 		pageTargetID = created.TargetID
 	}
@@ -279,14 +286,14 @@ func DispatchStartURL(ctx context.Context, devtoolsURL, url string) error {
 		"flatten":  true,
 	}, "")
 	if err != nil {
-		return fmt.Errorf("Target.attachToTarget: %w", err)
+		return "", fmt.Errorf("Target.attachToTarget: %w", err)
 	}
 
 	var attach struct {
 		SessionID string `json:"sessionId"`
 	}
 	if err := json.Unmarshal(attachResult, &attach); err != nil {
-		return fmt.Errorf("unmarshal attach: %w", err)
+		return "", fmt.Errorf("unmarshal attach: %w", err)
 	}
 	defer func() {
 		detachCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -296,16 +303,25 @@ func DispatchStartURL(ctx context.Context, devtoolsURL, url string) error {
 		}, "")
 	}()
 
-	if _, err := c.send(ctx, "Page.navigate", map[string]any{"url": url}, attach.SessionID); err != nil {
-		return fmt.Errorf("Page.navigate: %w", err)
+	navResult, err := c.send(ctx, "Page.navigate", map[string]any{"url": url}, attach.SessionID)
+	if err != nil {
+		return "", fmt.Errorf("Page.navigate: %w", err)
 	}
-	return nil
+	var nav struct {
+		ErrorText string `json:"errorText"`
+	}
+	if err := json.Unmarshal(navResult, &nav); err != nil {
+		return "", fmt.Errorf("unmarshal navigate result: %w", err)
+	}
+	return nav.ErrorText, nil
 }
 
 // DispatchStartURLAndWait navigates through navigationURL and waits for
 // destination to load without resolving to Chrome's network error page.
 func DispatchStartURLAndWait(ctx context.Context, devtoolsURL, navigationURL, destination string) error {
-	if err := DispatchStartURL(ctx, devtoolsURL, navigationURL); err != nil {
+	// The polling loop below re-navigates through chrome-error:// pages, so a
+	// reported navigation error is not terminal here.
+	if _, err := DispatchStartURL(ctx, devtoolsURL, navigationURL); err != nil {
 		return err
 	}
 

--- a/server/lib/cdpclient/cdpclient_test.go
+++ b/server/lib/cdpclient/cdpclient_test.go
@@ -34,6 +34,8 @@ type fakeCDP struct {
 	navigateCalled      bool
 	navigateCalls       int
 	navigateURL         string
+	navigateErrorText   string
+	navigateBlock       time.Duration
 	pageStates          []string
 	pageStateIndex      int
 }
@@ -115,7 +117,20 @@ func (f *fakeCDP) handler(w http.ResponseWriter, r *http.Request) {
 			var params map[string]any
 			_ = json.Unmarshal(req.Params, &params)
 			f.navigateURL, _ = params["url"].(string)
-			result = map[string]any{"frameId": "frame-1"}
+			// Page.navigate resolves on commit, so a slow origin holds the
+			// response open rather than replying and navigating later.
+			if f.navigateBlock > 0 {
+				select {
+				case <-time.After(f.navigateBlock):
+				case <-ctx.Done():
+					return
+				}
+			}
+			nav := map[string]any{"frameId": "frame-1"}
+			if f.navigateErrorText != "" {
+				nav["errorText"] = f.navigateErrorText
+			}
+			result = nav
 		case "Runtime.evaluate":
 			state := `{"url":"about:blank","readyState":"loading"}`
 			if len(f.pageStates) > 0 {
@@ -232,6 +247,54 @@ func TestSetDeviceMetricsOverride(t *testing.T) {
 
 		_, err := Dial(ctx, url)
 		require.Error(t, err)
+	})
+}
+
+func TestDispatchStartURL(t *testing.T) {
+	t.Run("reports no error text on a committed navigation", func(t *testing.T) {
+		f := &fakeCDP{pageTargetID: "target-123", sessionID: "session-abc"}
+		url := startFakeCDP(t, f)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		errorText, err := DispatchStartURL(ctx, url, "https://example.com/")
+		require.NoError(t, err)
+		assert.Empty(t, errorText)
+		assert.Equal(t, "https://example.com/", f.navigateURL)
+	})
+
+	// Chrome answers Page.navigate with an errorText and commits an error page
+	// when the requested URL cannot load, which must not read as success.
+	t.Run("surfaces the navigation error text", func(t *testing.T) {
+		f := &fakeCDP{
+			pageTargetID:      "target-123",
+			sessionID:         "session-abc",
+			navigateErrorText: "net::ERR_CONNECTION_REFUSED",
+		}
+		url := startFakeCDP(t, f)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		errorText, err := DispatchStartURL(ctx, url, "https://unreachable.example/")
+		require.NoError(t, err)
+		assert.Equal(t, "net::ERR_CONNECTION_REFUSED", errorText)
+	})
+
+	// When the origin is slower to commit than the caller's budget, the caller
+	// has to see the failure rather than assume the page was replaced.
+	t.Run("errors when the navigation does not commit within the budget", func(t *testing.T) {
+		f := &fakeCDP{
+			pageTargetID:  "target-123",
+			sessionID:     "session-abc",
+			navigateBlock: 2 * time.Second,
+		}
+		url := startFakeCDP(t, f)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		_, err := DispatchStartURL(ctx, url, "https://slow.example/")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Page.navigate")
 	})
 }
 

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -1253,9 +1253,12 @@ paths:
       description: |
         Optional multipart parts apply configuration while Chromium stays stopped once (policy,
         flags, extensions, profile archive, optional display sizing), then Chromium is started exactly
-        once and DevTools readiness is awaited. Optional `start_url` dispatches a best-effort
-        navigation after readiness without waiting for page load. Bare hosts are normalized to
-        `https://`. Omit any part you do not need. At least one actionable part must be present.
+        once and DevTools readiness is awaited. Optional `start_url` is navigated after readiness and
+        awaited until the navigation commits, so the requested document has replaced whatever the
+        browser was showing; subresources may still be loading. A navigation that fails or exceeds
+        the internal budget is logged and still returns 200, leaving the browser on its
+        pre-navigation page. Bare hosts are normalized to `https://`. Omit any part you do not need.
+        At least one actionable part must be present.
         Required configuration steps run in this order: policies, extensions, display, flags,
         then profile archive. Chromium is started only once at the end. The endpoint is not
         transactional: if a later required step fails, earlier successful side effects may remain
@@ -1315,7 +1318,7 @@ paths:
                     required: [zip_file, name]
       responses:
         "200":
-          description: Configuration applied; optional navigate completed successfully.
+          description: Configuration applied; optional navigate committed, failed, or timed out.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

`/configure`'s `start_url` step gave the navigation a 3s budget and treated
anything else as best-effort. Two failure modes fell out of that, both of which
end with the session being handed over on the page it was already showing while
the endpoint reports success:

1. **The budget was too short to reach commit.** `Page.navigate` only resolves
   once the navigation commits, so the budget has to cover the origin's DNS,
   connect and first byte. Against an origin slower than 3s the context expired,
   the handler logged a warning and returned 200, and the navigation committed a
   few seconds later — after the caller already had the browser.
2. **A navigation that could not load read as success.** Chrome answers
   `Page.navigate` with an `errorText` and commits an error page when the URL is
   unreachable. `DispatchStartURL` discarded the result, so an unreachable
   `start_url` returned no error at all.

## What changed

- `startURLDispatchTimeout` (3s) becomes `startURLNavigateTimeout` (15s). Commit
  semantics mean this only has to cover time to first byte, not subresource
  loading, so it does not slow down heavy pages.
- `cdpclient.DispatchStartURL` returns Chrome's navigation `errorText` alongside
  its error, letting callers distinguish a committed navigation from a committed
  error page. `DispatchStartURLAndWait` ignores it deliberately — its polling
  loop already re-navigates through `chrome-error://` — and the wrapper's
  `about:blank` reset is unchanged in behavior.
- Both failure modes log `start_url dispatch failed` with the elapsed time. The
  message is unchanged so existing log queries keep matching.
- A failed navigation still returns 200. Returning non-2xx would make the caller
  treat the instance as tainted and discard an otherwise healthy browser over a
  `start_url` the caller may not control.
- The OpenAPI description now states that the navigation is awaited to commit and
  that a failure is logged and still returns 200. Descriptions do not reach
  generated code, so `lib/oapi/oapi.go` is unchanged; `lib/events/category_gen.go`
  was regenerated and is unchanged.

## Verification

Local reproduction driving Chromium 151 under Xvfb with the headful image's flag
set, calling this package's `DispatchStartURL` behind a replica of
`startChromiumAndWait`'s readiness gate:

| case | before | after |
| --- | --- | --- |
| origin 6s to first byte | errors at 3.00s (`Page.navigate: read: failed to get reader: context deadline exceeded`), handover still renders the previous page, navigation commits at ~6.2s | returns ok at 6.06s, after commit |
| unreachable `start_url` | returns ok, no error reported, browser on an error page | reports `net::ERR_CONNECTION_REFUSED` |
| document commits, subresource stalls 20s | ok at 67ms | ok at 67ms (unchanged — confirms commit, not load, semantics) |

Also measured that restored tab targets all exist before the readiness gate
returns (checked up to 40 tabs), so the single `Target.getTargets` snapshot is
not racing target creation.

New unit tests cover a committed navigation, a reported `errorText`, and a
navigation that does not commit within the budget. `go vet` and the full unit
suite pass (22 packages); the e2e suite needs Docker images and was not run.

## Notes for review

- 15s is a judgement call: long enough for slow-to-commit origins, bounded so a
  hung origin cannot stall a configure indefinitely. It sits well inside the
  calling activity's timeout.
- A caller-visible signal for a failed navigation would need a response schema
  field, which requires the npm down-converter for codegen. Left out here, so the
  failure remains observable only in instance logs.
- The deployed images build from the private fork, so this needs to be synced
  there before it ships.
