### PR TITLE
Strip profile session restore when configure batch carries a start_url

### DIFF
--- a/server/cmd/api/api/chromium_configure.go
+++ b/server/cmd/api/api/chromium_configure.go
@@ -569,14 +569,9 @@ func chromiumPrepareProfileArchive(profilePath string, strip int) (preparedDir s
 	return preparedDir, cleanup, nil
 }
 
-// stripProfileSessionRestore deletes the prepared profile's Default/Sessions
-// directory so Chrome does not restore the profile's saved tabs on the restart
-// that follows. Only called when the same configure batch carries a start_url:
-// Chrome restores tabs asynchronously after DevTools comes up, so a restored
-// tab can appear after the start_url dispatch has enumerated (and closed) page
-// targets, leaving the browser on a profile tab instead of the requested page.
-// Without a start_url the directory is kept and tabs restore as usual. Only
-// the live copy is touched; the stored profile archive is unchanged.
+// stripProfileSessionRestore deletes the prepared profile's Default/Sessions so
+// Chrome cannot restore its saved tabs after the restart and race the start_url
+// navigation. Only the live copy is touched; the stored archive is unchanged.
 func stripProfileSessionRestore(preparedDir string) error {
 	if err := os.RemoveAll(filepath.Join(preparedDir, "Default", "Sessions")); err != nil {
 		return fmt.Errorf("strip profile session restore: %w", err)

--- a/server/cmd/api/api/chromium_configure.go
+++ b/server/cmd/api/api/chromium_configure.go
@@ -158,6 +158,11 @@ func (s *ApiService) ChromiumConfigure(ctx context.Context, request oapi.Chromiu
 			if err != nil {
 				return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), nil
 			}
+			if spec.needsNav {
+				if err := stripProfileSessionRestore(preparedProfile); err != nil {
+					return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), nil
+				}
+			}
 			if err := chromiumInstallPreparedProfile(preparedProfile); err != nil {
 				return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), nil
 			}
@@ -562,6 +567,21 @@ func chromiumPrepareProfileArchive(profilePath string, strip int) (preparedDir s
 		return "", nil, fmt.Errorf("chown user-data: %w (%s)", err, string(out))
 	}
 	return preparedDir, cleanup, nil
+}
+
+// stripProfileSessionRestore deletes the prepared profile's Default/Sessions
+// directory so Chrome does not restore the profile's saved tabs on the restart
+// that follows. Only called when the same configure batch carries a start_url:
+// Chrome restores tabs asynchronously after DevTools comes up, so a restored
+// tab can appear after the start_url dispatch has enumerated (and closed) page
+// targets, leaving the browser on a profile tab instead of the requested page.
+// Without a start_url the directory is kept and tabs restore as usual. Only
+// the live copy is touched; the stored profile archive is unchanged.
+func stripProfileSessionRestore(preparedDir string) error {
+	if err := os.RemoveAll(filepath.Join(preparedDir, "Default", "Sessions")); err != nil {
+		return fmt.Errorf("strip profile session restore: %w", err)
+	}
+	return nil
 }
 
 func chromiumInstallPreparedProfile(preparedDir string) error {

--- a/server/cmd/api/api/chromium_configure_test.go
+++ b/server/cmd/api/api/chromium_configure_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"mime/multipart"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -74,6 +76,24 @@ func TestChromiumStartURLSpec(t *testing.T) {
 	longURL := strings.Repeat("a", maxStartURLLen+1)
 	_, errs = chromiumStartURLSpec(&longURL)
 	require.NotEmpty(t, errs)
+}
+
+func TestStripProfileSessionRestore(t *testing.T) {
+	prepared := t.TempDir()
+	sessions := filepath.Join(prepared, "Default", "Sessions")
+	require.NoError(t, os.MkdirAll(sessions, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sessions, "Session_123"), []byte("tabs"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(prepared, "Default", "Preferences"), []byte("{}"), 0o644))
+
+	require.NoError(t, stripProfileSessionRestore(prepared))
+
+	_, err := os.Stat(sessions)
+	require.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(prepared, "Default", "Preferences"))
+	require.NoError(t, err)
+
+	// Absent Sessions directory is a no-op, not an error.
+	require.NoError(t, stripProfileSessionRestore(prepared))
 }
 
 func TestChromiumValidateFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

When `/chromium/configure` receives both a profile archive and a `start_url`, the documented behavior is that `start_url` wins: the browser should come up on that page with the profile's saved tabs discarded. Today that override is racy. The profile archive keeps `Default/Sessions` (intentionally, so tab restore works when no `start_url` is given), and Chrome restores those tabs asynchronously after DevTools comes up. `DispatchStartURL` enumerates page targets right after DevTools readiness, closes the extras it sees, and navigates the first — so any restored tab that materializes after that enumeration survives and can leave the browser sitting on a profile tab instead of the requested page.

Fix: when the configure batch carries a `start_url`, delete `Default/Sessions` from the extracted profile before installing it. With no session-restore data on disk, Chrome never reopens the old tabs and there is nothing to race. This mirrors what the legacy-profile migration path in the API already does for the same reason.

Scope notes:
- Only the live copy in the VM is touched; the stored profile archive is unchanged, and cookies/local storage are preserved.
- When no `start_url` is present, `Default/Sessions` is kept and tab restore behaves exactly as before.

## Testing

- `go test ./cmd/api/api/ -count=1` passes (includes new `TestStripProfileSessionRestore`).
- `go vet ./cmd/api/api/` clean.
- e2e suite not run locally (needs docker); the existing `/chromium/configure` powerset e2e covers the profile+start_url combination path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change on the profile install path, gated on `start_url`; behavior without `start_url` is unchanged.
> 
> **Overview**
> When `/chromium/configure` installs a profile archive **and** a `start_url`, the handler now removes `Default/Sessions` from the extracted profile **before** install so Chrome cannot asynchronously restore saved tabs and race `DispatchStartURL`.
> 
> Profile-only configures are unchanged: session data stays on disk and tab restore still works. Only the live VM copy is modified; the uploaded archive is untouched.
> 
> Adds `stripProfileSessionRestore` and `TestStripProfileSessionRestore` (removes Sessions, leaves other profile files, no error if Sessions is missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa17d7b858f62a101901bf64c475ba019807c065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->