### PR TITLE
Upgrade Chromium to 152.0.7977.42

### DIFF
--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -284,7 +284,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-ap
         libxext6 libxfixes3 libxkbcommon0;
 
 # Install Chrome + ChromeDriver as a matched pair from chrome-for-testing so they cannot drift apart.
-ARG CHROME_VERSION=148.0.7778.97
+ARG CHROME_VERSION=152.0.7977.42
 RUN set -eux; \
     curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chrome-linux64.zip" -o /tmp/chrome.zip; \
     curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chromedriver-linux64.zip" -o /tmp/cd.zip; \

--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -112,14 +112,14 @@ RUN --mount=type=cache,target=/tmp/cache/ffmpeg,sharing=locked,id=$CACHEIDPREFIX
     <<-'EOT'
     set -eux
     FFMPEG_CACHE_PATH="/tmp/cache/ffmpeg"
-    FFMPEG_RELEASE="autobuild-2026-08-18-15-03"
-    FFMPEG_VERSION="n8.1.2-44-g7c533d0f86"
+    FFMPEG_RELEASE="autobuild-2026-08-16-13-00"
+    FFMPEG_VERSION="n7.1.5-16-g9a4bb2c579"
     case ${TARGETARCH:-amd64} in
         "amd64") FFMPEG_TARGET_ARCH="64" ;;
         "arm64") FFMPEG_TARGET_ARCH="arm64" ;;
     esac
     FFMPEG_TARGET=linux${FFMPEG_TARGET_ARCH:?}
-    ARCHIVE_NAME="ffmpeg-${FFMPEG_VERSION}-${FFMPEG_TARGET}-gpl-8.1.tar.xz"
+    ARCHIVE_NAME="ffmpeg-${FFMPEG_VERSION}-${FFMPEG_TARGET}-gpl-7.1.tar.xz"
     FFMPEG_CACHED_ARCHIVE_PATH="$FFMPEG_CACHE_PATH/$ARCHIVE_NAME"
     FFMPEG_CACHED_ARCHIVE_CHECKSUM_PATH="$FFMPEG_CACHED_ARCHIVE_PATH.sha256"
     RELEASE_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/$FFMPEG_RELEASE"

--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -107,24 +107,27 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-ap
     apt-get -yqq update; \
     apt-get -yqq --no-install-recommends install ca-certificates curl xz-utils;
 
-# Download FFmpeg (latest static build) for the recording server
+# Download a pinned FFmpeg static build for the recording server
 RUN --mount=type=cache,target=/tmp/cache/ffmpeg,sharing=locked,id=$CACHEIDPREFIX-ffmpeg \
     <<-'EOT'
     set -eux
     FFMPEG_CACHE_PATH="/tmp/cache/ffmpeg"
+    FFMPEG_RELEASE="autobuild-2026-08-18-15-03"
+    FFMPEG_VERSION="n8.1.2-44-g7c533d0f86"
     case ${TARGETARCH:-amd64} in
         "amd64") FFMPEG_TARGET_ARCH="64" ;;
         "arm64") FFMPEG_TARGET_ARCH="arm64" ;;
     esac
     FFMPEG_TARGET=linux${FFMPEG_TARGET_ARCH:?}
-    ARCHIVE_NAME="ffmpeg-n7.1-latest-${FFMPEG_TARGET}-gpl-7.1.tar.xz"
+    ARCHIVE_NAME="ffmpeg-${FFMPEG_VERSION}-${FFMPEG_TARGET}-gpl-8.1.tar.xz"
     FFMPEG_CACHED_ARCHIVE_PATH="$FFMPEG_CACHE_PATH/$ARCHIVE_NAME"
     FFMPEG_CACHED_ARCHIVE_CHECKSUM_PATH="$FFMPEG_CACHED_ARCHIVE_PATH.sha256"
-    URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/$ARCHIVE_NAME"
+    RELEASE_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/$FFMPEG_RELEASE"
+    URL="$RELEASE_URL/$ARCHIVE_NAME"
     TEMPORARY_SHA256_CHECKSUM_PATH=$(mktemp /tmp/tmp_sha256.XXXXXXXXXX)
     CONTINUE="true"
     echo "Downloading FFmpeg checksum"
-    if curl --connect-timeout 10 -fsSL "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/checksums.sha256" -o $TEMPORARY_SHA256_CHECKSUM_PATH; then
+    if curl --connect-timeout 10 -fsSL "$RELEASE_URL/checksums.sha256" -o $TEMPORARY_SHA256_CHECKSUM_PATH; then
         grep -F "$ARCHIVE_NAME" $TEMPORARY_SHA256_CHECKSUM_PATH > $FFMPEG_CACHED_ARCHIVE_CHECKSUM_PATH
     else
         echo "Failed to connect to ffmpeg static build provider for checksum."

--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -112,8 +112,8 @@ RUN --mount=type=cache,target=/tmp/cache/ffmpeg,sharing=locked,id=$CACHEIDPREFIX
     <<-'EOT'
     set -eux
     FFMPEG_CACHE_PATH="/tmp/cache/ffmpeg"
-    FFMPEG_RELEASE="autobuild-2026-08-16-13-00"
-    FFMPEG_VERSION="n7.1.5-16-g9a4bb2c579"
+    FFMPEG_RELEASE="autobuild-2026-07-31-14-10"
+    FFMPEG_VERSION="n7.1.5-12-g1fdbca85aa"
     case ${TARGETARCH:-amd64} in
         "amd64") FFMPEG_TARGET_ARCH="64" ;;
         "arm64") FFMPEG_TARGET_ARCH="arm64" ;;

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -55,24 +55,27 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-ap
     apt-get -yqq update; \
     apt-get -yqq --no-install-recommends install ca-certificates curl xz-utils;
 
-# Download FFmpeg (latest static build) for the recording server
+# Download a pinned FFmpeg static build for the recording server
 RUN --mount=type=cache,target=/tmp/cache/ffmpeg,sharing=locked,id=$CACHEIDPREFIX-ffmpeg \
     <<-'EOT'
     set -eux
     FFMPEG_CACHE_PATH="/tmp/cache/ffmpeg"
+    FFMPEG_RELEASE="autobuild-2026-08-18-15-03"
+    FFMPEG_VERSION="n8.1.2-44-g7c533d0f86"
     case ${TARGETARCH:-amd64} in
         "amd64") FFMPEG_TARGET_ARCH="64" ;;
         "arm64") FFMPEG_TARGET_ARCH="arm64" ;;
     esac
     FFMPEG_TARGET=linux${FFMPEG_TARGET_ARCH:?}
-    ARCHIVE_NAME="ffmpeg-n7.1-latest-${FFMPEG_TARGET}-gpl-7.1.tar.xz"
+    ARCHIVE_NAME="ffmpeg-${FFMPEG_VERSION}-${FFMPEG_TARGET}-gpl-8.1.tar.xz"
     FFMPEG_CACHED_ARCHIVE_PATH="$FFMPEG_CACHE_PATH/$ARCHIVE_NAME"
     FFMPEG_CACHED_ARCHIVE_CHECKSUM_PATH="$FFMPEG_CACHED_ARCHIVE_PATH.sha256"
-    URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/$ARCHIVE_NAME"
+    RELEASE_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/$FFMPEG_RELEASE"
+    URL="$RELEASE_URL/$ARCHIVE_NAME"
     TEMPORARY_SHA256_CHECKSUM_PATH=$(mktemp /tmp/tmp_sha256.XXXXXXXXXX)
     CONTINUE="true"
     echo "Downloading FFmpeg checksum"
-    if curl --connect-timeout 10 -fsSL "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/checksums.sha256" -o $TEMPORARY_SHA256_CHECKSUM_PATH; then
+    if curl --connect-timeout 10 -fsSL "$RELEASE_URL/checksums.sha256" -o $TEMPORARY_SHA256_CHECKSUM_PATH; then
         grep -F "$ARCHIVE_NAME" $TEMPORARY_SHA256_CHECKSUM_PATH > $FFMPEG_CACHED_ARCHIVE_CHECKSUM_PATH
     else
         echo "Failed to connect to ffmpeg static build provider for checksum."

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -60,8 +60,8 @@ RUN --mount=type=cache,target=/tmp/cache/ffmpeg,sharing=locked,id=$CACHEIDPREFIX
     <<-'EOT'
     set -eux
     FFMPEG_CACHE_PATH="/tmp/cache/ffmpeg"
-    FFMPEG_RELEASE="autobuild-2026-08-16-13-00"
-    FFMPEG_VERSION="n7.1.5-16-g9a4bb2c579"
+    FFMPEG_RELEASE="autobuild-2026-07-31-14-10"
+    FFMPEG_VERSION="n7.1.5-12-g1fdbca85aa"
     case ${TARGETARCH:-amd64} in
         "amd64") FFMPEG_TARGET_ARCH="64" ;;
         "arm64") FFMPEG_TARGET_ARCH="arm64" ;;

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -60,14 +60,14 @@ RUN --mount=type=cache,target=/tmp/cache/ffmpeg,sharing=locked,id=$CACHEIDPREFIX
     <<-'EOT'
     set -eux
     FFMPEG_CACHE_PATH="/tmp/cache/ffmpeg"
-    FFMPEG_RELEASE="autobuild-2026-08-18-15-03"
-    FFMPEG_VERSION="n8.1.2-44-g7c533d0f86"
+    FFMPEG_RELEASE="autobuild-2026-08-16-13-00"
+    FFMPEG_VERSION="n7.1.5-16-g9a4bb2c579"
     case ${TARGETARCH:-amd64} in
         "amd64") FFMPEG_TARGET_ARCH="64" ;;
         "arm64") FFMPEG_TARGET_ARCH="arm64" ;;
     esac
     FFMPEG_TARGET=linux${FFMPEG_TARGET_ARCH:?}
-    ARCHIVE_NAME="ffmpeg-${FFMPEG_VERSION}-${FFMPEG_TARGET}-gpl-8.1.tar.xz"
+    ARCHIVE_NAME="ffmpeg-${FFMPEG_VERSION}-${FFMPEG_TARGET}-gpl-7.1.tar.xz"
     FFMPEG_CACHED_ARCHIVE_PATH="$FFMPEG_CACHE_PATH/$ARCHIVE_NAME"
     FFMPEG_CACHED_ARCHIVE_CHECKSUM_PATH="$FFMPEG_CACHED_ARCHIVE_PATH.sha256"
     RELEASE_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/$FFMPEG_RELEASE"

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -166,7 +166,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-ap
     apt-get --no-install-recommends -y install sqlite3 unzip;
 
 # Install Chrome + ChromeDriver as a matched pair from chrome-for-testing so they cannot drift apart.
-ARG CHROME_VERSION=148.0.7778.97
+ARG CHROME_VERSION=152.0.7977.42
 RUN set -eux; \
     curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chrome-linux64.zip" -o /tmp/chrome.zip; \
     curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chromedriver-linux64.zip" -o /tmp/cd.zip; \


### PR DESCRIPTION
## Summary

Upgrade the Chrome for Testing release used by the headful and headless browser images from `148.0.7778.97` to the latest stable release, `152.0.7977.42`.

The existing install path continues to fetch Chrome and ChromeDriver from the same release so their versions remain matched.

The image builds also depended on a removed floating FFmpeg `n7.1-latest` asset. Keep FFmpeg on 7.1 by pinning both images to the immutable `n7.1.5-12-g1fdbca85aa` archives from retained month-end release `autobuild-2026-07-31-14-10`.

## Testing

- `GOCACHE=/tmp/kernel-images-go-cache GOMODCACHE=/tmp/kernel-images-go-mod make test-unit`
- Confirmed the published Linux Chrome and ChromeDriver archives both report `152.0.7977.42`
- Started Chromium directly and verified `Chrome/152.0.7977.42` over `/json/version`
- Attached ChromeDriver to the existing Chromium process, created a WebDriver session, and verified the returned BiDi WebSocket URL
- Verified the pinned FFmpeg 7.1 checksum and archive URLs for amd64 and arm64
- Full headful/headless image builds and e2e coverage are left to CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core browser automation binaries (Chrome 148→152) and recording FFmpeg sourcing; pinned artifacts reduce build drift but runtime WebDriver/BiDi behavior may change until CI e2e completes.
> 
> **Overview**
> Bumps **Chrome for Testing** and **ChromeDriver** from `148.0.7778.97` to **`152.0.7977.42`** in both `chromium-headful` and `chromium-headless` image Dockerfiles, keeping the existing matched-pair install from `chrome-for-testing-public`.
> 
> Replaces the removed floating **FFmpeg** `n7.1-latest` download with a **pinned** BtbN build: release `autobuild-2026-07-31-14-10`, version `n7.1.5-12-g1fdbca85aa`, including checksum URLs tied to that release instead of `latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8084bc06ca74e78eee1137c0495342f1a9c29990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->